### PR TITLE
Correct ID prefix for payment routing.

### DIFF
--- a/src/data/endpoints/account.yaml
+++ b/src/data/endpoints/account.yaml
@@ -606,7 +606,7 @@ endpoints:
                     "usd": "120.00",
                 }' \
                 https://$api_root/$version/account/payments
-  /account/payments/:id:
+  /account/payments/$id:
     group: Payments
     type: Resource
     authenticated: true


### PR DESCRIPTION
Closes https://github.com/linode/manager/issues/2800.