### PR TITLE
Fix mobile nav

### DIFF
--- a/scss/components/Header.scss
+++ b/scss/components/Header.scss
@@ -5,4 +5,13 @@
         left: 0;
         z-index: 10;
     }
+
+    .MainHeader {
+        overflow: hidden;
+    }
+
+    .navbar-toggler {
+        position: fixed;
+        top: 0;
+    }
 }


### PR DESCRIPTION
Fix for the hamburger-menu-button getting hidden by the new title when the width is mobile device sized.

Before:
![screen shot 2017-12-21 at 5 23 34 pm](https://user-images.githubusercontent.com/2046750/34277442-b6b7105c-e673-11e7-8231-af3179671490.png)

After:
![screen shot 2017-12-21 at 5 22 23 pm](https://user-images.githubusercontent.com/2046750/34277414-940687b8-e673-11e7-93a7-ecc2f643db0e.png)
