### PR TITLE
Added link to Linode CLI on docs main page

### DIFF
--- a/src/getting_started/intros/Introduction.js
+++ b/src/getting_started/intros/Introduction.js
@@ -33,8 +33,9 @@ export default function Introduction() {
           <Link to={`/${API_VERSION}/guides/curl/testing-with-curl`}>
             Check out the Testing with cURL guide
           </Link> to get started making API calls using a Personal Access Token (PAT).
-          If you don't want to curl the api directly, you might be looking for
-          the <ExternalLink to='https://github.com/linode/linode-cli'>Linode CLI</ExternalLink>.
+          <br /><br />
+          If you want to access our API through a command line, check out the
+          new <ExternalLink to="https://github.com/linode/linode-cli">Linode CLI</ExternalLink>.
         </div>
         <p>
           All APIv4 endpoints are located at:

--- a/src/getting_started/intros/Introduction.js
+++ b/src/getting_started/intros/Introduction.js
@@ -33,6 +33,8 @@ export default function Introduction() {
           <Link to={`/${API_VERSION}/guides/curl/testing-with-curl`}>
             Check out the Testing with cURL guide
           </Link> to get started making API calls using a Personal Access Token (PAT).
+          If you don't want to curl the api directly, you might be looking for
+          the <ExternalLink to='https://github.com/linode/linode-cli'>Linode CLI</ExternalLink>.
         </div>
         <p>
           All APIv4 endpoints are located at:


### PR DESCRIPTION
I added the link in the dialog about the cURL guide, since it's another way to access the api.  If this placement doesn't make sense, please suggest an alternative.

Screenshot: 

![screen shot 2018-02-22 at 1 19 59 pm](https://user-images.githubusercontent.com/7172953/36556451-3bfb652a-17d3-11e8-8a7a-a4b4614b1b7b.png)
