### PR TITLE
brk: renamed reset_secret to reset-secret

### DIFF
--- a/src/data/endpoints/account.yaml
+++ b/src/data/endpoints/account.yaml
@@ -185,7 +185,7 @@ endpoints:
           python: |
             my_client = linode.OAuthClient(client, 123)
             my_client.delete()
-  /account/oauth-clients/$id/reset_secret:
+  /account/oauth-clients/$id/reset-secret:
     group: OAuth Clients
     type: Action
     authenticated: true
@@ -200,7 +200,7 @@ endpoints:
             curl -H "Content-Type: application/json" \
                 -H "Authorization: Bearer $TOKEN" \
                 -X POST \
-                https://$api_root/$version/account/oauth-clients/$client_id/reset_secret
+                https://$api_root/$version/account/oauth-clients/$client_id/reset-secret
           python: |
             my_client = linode.OAuthClient(client, 123)
             new_secret = my_client.reset_secret()


### PR DESCRIPTION
* Endpoint should match convention, so it has been changed to:
  * /account/oauth-clients/$id/reset-secret