### PR TITLE
brk: param changes to POST /networking/ips and /linode/instances/:id/ips

### DIFF
--- a/src/data/endpoints/linodes.yaml
+++ b/src/data/endpoints/linodes.yaml
@@ -869,23 +869,27 @@ endpoints:
         money: true
         oauth: linodes:modify
         description: >
-          Allocates a new IP Address for this Linode.
+          Allocates a new IPv4 Address for this Linode.
         params:
           type:
-            description: >
-                The type of IP Address this is, can be one of "public" or "private".
-                Public IP Addresses, over and above the one included with each Linode,
-                incur an additional monthly charge. If you need an additional Public IP Address
-                you must request one - please open a ticket.
             type: String
-            value: private
+            description: >
+              The type of IP to allocate.  Currently only "ipv4" is supported.
+            value: ipv4
+          public:
+            type: Boolean
+            description: >
+              Whether this is a public or private IP address.
+              Public IP Addresses, over and above the one included with each
+              Linode, incur an additional monthly charge. If you need an
+              additional Public IP Address you must request one - please
+              open a ticket.
+            value: true
         examples:
           curl: |
             curl -H "Content-Type: application/json" \
                 -H "Authorization: Bearer $TOKEN" \
-                -X POST -d '{
-                    "type": "private"
-                }' \
+                -X POST -d '{"type": "ipv4", "public":true}' \
                 https://$api_root/$version/linode/instances/$linode_id/ips
   /linode/instances/$id/ips/$ip_address:
     group: IPs

--- a/src/data/endpoints/networking.yaml
+++ b/src/data/endpoints/networking.yaml
@@ -22,24 +22,36 @@ endpoints:
             curl -H "Authorization: Bearer $TOKEN" \
               https://$api_root/$version/networking/ips
       POST:
+        response: ipaddress
         money: true
         oauth: ips:create
         description: >
-          Create a new Public IPv4 Address.
+          Create a new IPv4 Address.
         params:
           type:
             type: String
             description: >
-              The type of IP to allocate.  Currently only "ipv4" is supported.
+              The type of IP to allocate. Currently only "ipv4" is supported.
+            value: ipv4
+          public:
+            type: Boolean
+            description: >
+              Whether this is a public or private IP address.
+              Public IP Addresses, over and above the one included with each
+              Linode, incur an additional monthly charge. If you need an
+              additional Public IP Address you must request one - please
+              open a ticket.
+            value: true
           linode_id:
+            type: Integer
             description: >
               The Linode ID to assign this IP to.
-            type: Integer
+            value: 123
         examples:
           curl: |
             curl -H "Content-Type: application/json" \
                 -H "Authorization: Bearer $TOKEN" \
-                -X POST -d '{"type":"ipv4","linode":123}' \
+                -X POST -d '{"type":"ipv4", "public":true, "linode":123}' \
                 https://$api_root/$version/networking/ips
   /networking/ips/$address:
     group: IPs

--- a/src/data/objects/ipaddressv6linklocal.yaml
+++ b/src/data/objects/ipaddressv6linklocal.yaml
@@ -1,27 +1,27 @@
 name: IP Address
 description: >
-    An IPv4 Address
+    An IPv6 Address - link_local
 schema:
   address:
     type: String
-    value: 97.107.143.8
+    value: fe80::f03c:91ff:fe24:3a2f
     description: The IP Address.
   gateway:
     type: String
-    value: 97.107.143.1
-    description: The default gateway. Gateways for private IP's are always null.
+    value: fe80::1
+    description: The default gateway.
   linode_id:
     type: Integer
     value: 42
     description: The Linode this IP is associated with.
   prefix:
     type: String
-    value: 24
+    value: 64
     description: The network prefix.
   rdns:
     editable: true
     type: String
-    value: "example.org"
+    value: null
     description: Reverse DNS address for this IP Address. Null to reset.
   region:
     type: String
@@ -29,20 +29,14 @@ schema:
     description: The Region this IP is in.
   subnet_mask:
     type: String
-    value: 255.255.255.0
+    value: ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
     description: The subnet mask.
   public:
     type: Boolean
-    value: true
+    value: false
     description: Whether this is a public or private IP address.
   type:
     type: String
     description: The type of IP Address.
-    value: ipv4
-enums:
-  IPAddressType:
-    public: Public IP Address.
-    private: Internal IP Addresses (192.168 range).
-    slaac: A Linode's slaac address.  These may not be transferred between Linodes.
-    link-local: A Linode's link local address.  These may not be transferred
-                between linodes.
+    value: ipv6
+

--- a/src/data/objects/ipaddressv6slaac.yaml
+++ b/src/data/objects/ipaddressv6slaac.yaml
@@ -1,22 +1,22 @@
 name: IP Address
 description: >
-    An IPv4 Address
+    An IPv6 Address - slaac
 schema:
   address:
     type: String
-    value: 97.107.143.8
+    value: 2600:3c03::f03c:91ff:fe24:3a2f
     description: The IP Address.
   gateway:
     type: String
-    value: 97.107.143.1
-    description: The default gateway. Gateways for private IP's are always null.
+    value: fe80::1
+    description: The default gateway.
   linode_id:
     type: Integer
     value: 42
     description: The Linode this IP is associated with.
   prefix:
     type: String
-    value: 24
+    value: 64
     description: The network prefix.
   rdns:
     editable: true
@@ -29,7 +29,7 @@ schema:
     description: The Region this IP is in.
   subnet_mask:
     type: String
-    value: 255.255.255.0
+    value: ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
     description: The subnet mask.
   public:
     type: Boolean
@@ -38,11 +38,5 @@ schema:
   type:
     type: String
     description: The type of IP Address.
-    value: ipv4
-enums:
-  IPAddressType:
-    public: Public IP Address.
-    private: Internal IP Addresses (192.168 range).
-    slaac: A Linode's slaac address.  These may not be transferred between Linodes.
-    link-local: A Linode's link local address.  These may not be transferred
-                between linodes.
+    value: ipv6
+

--- a/src/data/objects/linodenetworking.yaml
+++ b/src/data/objects/linodenetworking.yaml
@@ -19,12 +19,11 @@ schema:
   ipv6:
     description: The Linode's IPv6 networking data.
     slaac:
-      type: ipaddress
+      type: ipaddressv6slaac
       description: >
         This Linode's SLAAC range.
     link_local:
-      type: String
-      value: f300::f03c:91ff:fe96:46da
+      type: ipaddressv6linklocal
       description: >
         This Linode's link-local range.
     global:


### PR DESCRIPTION
- POST /networking/ips - now accepts "type":"ipv4" and "public":bool
- POST /networking/ips - can do private ipv4 addresses
- POST /linode/instances/:id/ips - now accepts "type":"ipv4" and "public":bool