### PR TITLE
Update: components/schemas/PaymentRequest

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15235,7 +15235,8 @@ components:
         usd:
           type: string
           description: >
-            The amount in US Dollars of the Payment.
+            The amount in US Dollars of the Payment. The maximum credit card
+            payment that can be made is $50,000 dollars.
           example: '120.50'
     PayPal:
       type: object


### PR DESCRIPTION
Affects: POST /account/payments
Insert disclaimer for $50,000 credit card payment limit in
description of usd property.

Documents:
- [ARB-1389](https://jira.linode.com/browse/ARB-1389)
- [LinodeAPI/apinext#1792](https://bits.linode.com/LinodeAPI/apinext/pull/1792)