### PR TITLE
Changed ttl_sec documentation to reflect the correct default value

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11952,7 +11952,7 @@ components:
 
             * ttl_sec will default to 0 if no value is provided.
 
-            * A value of 0 is equivalent to a value of 300.
+            * A value of 0 is equivalent to a value of 86400.
           example: 300
         tags:
           x-linode-filterable: true


### PR DESCRIPTION
aorlowsky's original comment:

It looks like we added this documentation as a result of [ARB-1143](https://jira.linode.com/browse/ARB-1143). It turns out that the default value of 0 for ttl_sec is equivalent to 86400 instead of 300:

```
orlowsky.work.		21599	IN	SOA	ns1.linode.com. orlowska.go.stockton.edu. 2019013104 14400 14400 1209600 86400
```

Let me know if I missed anything! 👍 