### PR TITLE
[Update] DELETE /linode/instances/{linodeId}/disks/{diskId}

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4359,7 +4359,9 @@ paths:
       - Linode Instances
       summary: Delete Disk
       description: |
-        Deletes a Disk you have permission to `read_write`.
+        Deletes a Disk you have permission to `read_write`. The Disk cannot be
+        deleted if it is currently attached to a Linode with a currently-running
+        configuration profile.
 
         **Deleting a Disk is a destructive action and cannot be undone.**
       operationId: deleteDisk

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4360,8 +4360,7 @@ paths:
       summary: Delete Disk
       description: |
         Deletes a Disk you have permission to `read_write`. The Disk cannot be
-        deleted if it is currently attached to a Linode with a currently-running
-        configuration profile.
+        deleted if it is attached to a Linode's running configuration profile.
 
         **Deleting a Disk is a destructive action and cannot be undone.**
       operationId: deleteDisk


### PR DESCRIPTION
added a note that a disk can only be deleted if not attached to a linode with a currently running config profile

Documents:
-[ARB-1406] https://jira.linode.com/browse/ARB-1406 