### PR TITLE
[Update] GET /account/events and GET /account/events/{eventId}

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12392,7 +12392,7 @@ components:
           format: date-time
           description: When this Event was created.
           example: '2018-01-01T00:01:01'
-          x-linode-cli-display: 5
+          x-linode-cli-display: 6
           x-linode-filterable: true
         entity:
           type: object
@@ -12455,7 +12455,7 @@ components:
               - volume
               readOnly: true
               description: >
-                The type of entity this Event is related to.
+                The type of entity that is being referenced by the Event.
               example: ticket
               x-linode-filterable: true
             url:
@@ -12470,7 +12470,8 @@ components:
           readOnly: true
           description: |
             Detailed information about the Event's secondary entity, which provides additional information
-            for Linode boot, create, and clone jobs
+            for `linode_boot`, `linode_create`, and `linode_clone` Event actions.
+          x-linode-cli-display: 5
           properties:
             id:
               type: integer
@@ -12479,9 +12480,6 @@ components:
 
 
                 Secondary Entities are assigned the ID of the Linode they correspond to.
-                When filtering by ID for these Events, use the corresponding Linode's ID.
-                These Events include:
-                  * `linode`
               example: 1234
             label:
               type: string
@@ -12491,9 +12489,13 @@ components:
               example: linode1234
             type:
               type: string
+              enum:
+              - backup
+              - image
+              - linode
               readOnly: true
               description: >
-                The type of entity this Event is related to.
+                The type of entity that is being referenced by the Event.
               example: linode
             url:
               type: string
@@ -12522,13 +12524,13 @@ components:
           readOnly: true
           description: If this Event has been read.
           example: true
-          x-linode-cli-display: 8
+          x-linode-cli-display: 9
         seen:
           type: boolean
           readOnly: true
           description: If this Event has been seen.
           example: true
-          x-linode-cli-display: 7
+          x-linode-cli-display: 8
         status:
           type: string
           readOnly: true
@@ -12539,7 +12541,7 @@ components:
           - notification
           - scheduled
           - started
-          x-linode-cli-display: 6
+          x-linode-cli-display: 7
           x-linode-cli-color:
             failed: red
             finished: green

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12463,6 +12463,43 @@ components:
                 a relative URL, it is relative to the domain you retrieved the
                 Event from.
               example: /v4/support/tickets/11111
+        secondary_entity:
+          type: object
+          readOnly: true
+          description: |
+            Detailed information about the Event's secondary entity, which provides additional information
+            for Linode boot, create, and clone jobs
+          properties:
+            id:
+              type: integer
+              description: |
+                The unique ID for an Event's secondary entity.
+
+
+                Secondary Entities are assigned the ID of the Linode they correspond to.
+                When filtering by ID for these Events, use the corresponding Linode's ID.
+                These Events include:
+                  * `linode`
+              example: 1234
+            label:
+              type: string
+              description: >
+                The current label of this object. The label may reflect changes
+                that occur with this Event.
+              example: linode1234
+            type:
+              type: string
+              readOnly: true
+              description: >
+                The type of entity this Event is related to.
+              example: linode
+            url:
+              type: string
+              description: >
+                The URL where you can access the object this Event is for. If
+                a relative URL, it is relative to the domain you retrieved the
+                Event from.
+              example: /v4/linode/instances/1234
         percent_complete:
           type: integer
           readOnly: true

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12470,29 +12470,21 @@ components:
           readOnly: true
           description: |
             Detailed information about the Event's secondary entity, which provides additional information
-            for `linode_boot`, `linode_create`, and `linode_clone` Event actions.
+            for events such as, but not limited to, `linode_boot`, `linode_create`, and `linode_clone` Event actions.
           x-linode-cli-display: 5
           properties:
             id:
-              type: integer
-              description: |
-                The unique ID for an Event's secondary entity.
-
-
-                Secondary Entities are assigned the ID of the Linode they correspond to.
-              example: 1234
+              type: string
+              description: >
+                The ID of the object that is the secondary entity.
+              example: linode/debian9
             label:
               type: string
               description: >
-                The current label of this object. The label may reflect changes
-                that occur with this Event.
+                The label of this object.
               example: linode1234
             type:
               type: string
-              enum:
-              - backup
-              - image
-              - linode
               readOnly: true
               description: >
                 The type of entity that is being referenced by the Event.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12276,6 +12276,7 @@ components:
           description: The unique ID of this Event.
           example: 123
           x-linode-cli-display: 1
+          x-linode-filterable: true
         action:
           type: string
           enum:
@@ -12392,6 +12393,7 @@ components:
           description: When this Event was created.
           example: '2018-01-01T00:01:01'
           x-linode-cli-display: 5
+          x-linode-filterable: true
         entity:
           type: object
           readOnly: true


### PR DESCRIPTION
Added secondary_entity object to Event schema object which appears in both 
GET /account/events
and
GET /account/events/{eventId}

Additionally, while researching discovered that "filterable" should have been set on Event properties id and created - added that in second commit.

Documents:
- [ARB-1376] https://jira.linode.com/browse/ARB-1376
https://bits.linode.com/LinodeAPI/apinext/pull/1793
- [CT-753] https://jira.linode.com/browse/CT-753