### PR TITLE
Fix copy and paste-ability of filtering examples

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -182,9 +182,7 @@ info:
 
     ```Shell
     curl "https://api.linode.com/v4/linode/types" \
-      -H 'X-Filter: { \
-        "class": "standard"
-      }'
+    -H 'X-Filter: { "class": "standard" }'
     ```
 
     The filter object's keys are the keys of the object you're filtering,
@@ -193,11 +191,8 @@ info:
     Types that offer one vcpu:
 
     ```Shell
-     curl "https://api.linode.com/v4/linode/types" \
-      -H 'X-Filter: { \
-        "class": "standard",
-        "vcpus": 1
-      }'
+    curl "https://api.linode.com/v4/linode/types" \
+    -H 'X-Filter: { "class": "standard", "vcpus": 1 }'
     ```
 
     In the above example, both filters are combined with an "and" operation.
@@ -206,12 +201,7 @@ info:
 
     ```Shell
     curl "https://api.linode.com/v4/linode/types" \
-      -H 'X-Filter: {
-        "+or": [
-          { "vcpus": 1 },
-          { "class": "standard" }
-        ]
-      }'
+    -H 'X-Filter: { "+or": [ { "vcpus": 1 }, { "class": "standard" } ] }'
     ```
 
     Each filter in the `+or` array is its own filter object, and all conditions
@@ -239,11 +229,7 @@ info:
 
     ```Shell
     curl "https://api.linode.com/v4/linode/types" \
-      -H 'X-Filter: {
-        "memory": {
-          "+gte": 61440
-        }
-      }'
+    -H 'X-Filter: { "memory": { "+gte": 61440 } }'
     ```
 
     You can combine and nest operators to construct arbitrarily-complex queries.
@@ -253,34 +239,7 @@ info:
 
     ```Shell
     curl "https://api.linode.com/v4/linode/types" \
-      -H 'X-Filter: {
-        "+or": [
-          {
-            "+or": [
-              {
-                "class": "standard"
-              },
-              {
-                "class": "highmem"
-              }
-            ]
-          },
-          {
-            "+and": [
-              {
-                "vcpus": {
-                  "+gte": 12
-                }
-              },
-              {
-                "vcpus": {
-                  "+lte": 20
-                }
-              }
-            ]
-          }
-        ]
-      }'
+    -H 'X-Filter: { "+or": [ { "+or": [ { "class": "standard" }, { "class": "highmem" } ] }, { "+and": [ { "vcpus": { "+gte": 12 } }, { "vcpus": { "+lte": 20 } } ] } ] }'
     ```
 
     # CLI (Command Line Interface)


### PR DESCRIPTION
The newlines presented in the previous filtering code examples were breaking them, resulting in errors. I've stripped the newlines from the JSON and the code is now copy and paste-able.