### PR TITLE
Updated warning note of self-service migration workflow

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4997,7 +4997,8 @@ paths:
 
         **Note:** Next Generation Network (NGN) data centers do not support IPv6 `/116` pools or IP Failover.
         If you have these features enabled on your Linode and attempt to migrate to an NGN data center,
-        the migration will not initiate. NGN data centers include Toronto and Mumbai.
+        the migration will not initiate. NGN data centers include Toronto and Mumbai. If a Linode cannot be
+        migrated because of an incompatibility, the user will be prompted to contact support.
       tags:
        - Linode Instances
       operationId: migrateLinodeInstance

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4998,7 +4998,8 @@ paths:
         **Note:** Next Generation Network (NGN) data centers do not support IPv6 `/116` pools or IP Failover.
         If you have these features enabled on your Linode and attempt to migrate to an NGN data center,
         the migration will not initiate. NGN data centers include Toronto and Mumbai. If a Linode cannot be
-        migrated because of an incompatibility, the user will be prompted to contact support.
+        migrated because of an incompatibility, the user will be prompted to select a different data center
+        or contact support.
       tags:
        - Linode Instances
       operationId: migrateLinodeInstance


### PR DESCRIPTION
Added mention of the prompt to open a support ticket when trying to migrate Linodes with /116 pools.