### PR TITLE
[Update] POST /account/credit-card

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12435,7 +12435,6 @@ components:
       properties:
         card_number:
           type: string
-          format: PAN
           description: Your credit card number. No spaces or dashes allowed.
           minLength: 13
           maxLength: 23


### PR DESCRIPTION
Remove format for card_number:

The former `PAN` format does not correspond to any format specified by OpenAPI:
https://swagger.io/specification/#data-types

`PAN` was meant to stand for `primary account number`, but this may not be obvious to an API reader.
https://en.wikipedia.org/wiki/Payment_card_number

The format was meant to hide the number when using the CLI:
https://github.com/linode/linode-api-docs/commit/2bb2cc15423a416f95395dc9cccccdeee9e46997

However, this functionality was never built into the CLI. After discussing with dev team, it's likely not desirable to have this functionality for the card_number property in the CLI. Because the `PAN` label doesn't assist with a reader's understanding of what the field should be used for, or the values it accepts, I'm proposing we remove it.