### PR TITLE
Added new CLI-specific parameters to backups endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,5 @@ Attribute | Location | Type | Supported By | Explanation
 `x-linode-cli-skip` | method | boolean | linode-cli | If true, the CLI will not expose this action.
 `x-linode-redoc-load-ids`| operation | boolean | If true, ReDoc will load this path and print a bulleted list of IDs.  This only works on public collections.
 `x-linode-ref-name`| keyword | string | [Linode Developer's Site](https://github.com/linode/developers) | Provides a mechanism by which the Developer's site can generate a dropdown menu with an Object's name when using the `oneOf` keyword with a `discriminator`. **Note**: This front end functionality is currently being developed.
+`x-linode-cli-rows`| media type | array | A list of JSON paths where the CLI can find the value it should treat as table rows.  Only needed for irregular endpoints.
+`x-linode-cli-use-schema` | media type | schema or $ref | The schema the CLI should use when showing a row for this response.  Use with `x-linode-cli-rows`.

--- a/README.md
+++ b/README.md
@@ -49,3 +49,4 @@ Attribute | Location | Type | Supported By | Explanation
 `x-linode-ref-name`| keyword | string | [Linode Developer's Site](https://github.com/linode/developers) | Provides a mechanism by which the Developer's site can generate a dropdown menu with an Object's name when using the `oneOf` keyword with a `discriminator`. **Note**: This front end functionality is currently being developed.
 `x-linode-cli-rows`| media type | array | A list of JSON paths where the CLI can find the value it should treat as table rows.  Only needed for irregular endpoints.
 `x-linode-cli-use-schema` | media type | schema or $ref | The schema the CLI should use when showing a row for this response.  Use with `x-linode-cli-rows`.
+`x-linode-cli-nested-list` | media type | string | The name of the property defined by this response body's schema that is a nested list.  Items in the list will be broken out into rows in the CLI's output.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3326,6 +3326,12 @@ paths:
           description: A collection of the specified Linode's available backups.
           content:
             application/json:
+              x-linode-cli-rows:
+              - automatic
+              - snapshot.current
+              - snapshot.in_progress
+              x-linode-cli-use-schema:
+                $ref: '#/components/schemas/Backup'
               schema:
                 type: object
                 properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6268,6 +6268,18 @@ paths:
           description: Returns an array of all Pools in this Kubernetes cluster.
           content:
             application/json:
+              x-linode-cli-nested-list: linodes
+              x-linode-cli-use-schema:
+                type: object
+                properties:
+                  id:
+                    x-linode-cli-display: 1
+                  type:
+                    x-linode-cli-display: 2
+                  linodes.id:
+                    x-linode-cli-display: 3
+                  linodes.status:
+                    x-linode-cli-display: 4
               schema:
                 type: object
                 properties:


### PR DESCRIPTION
This goes with https://github.com/linode/linode-cli/pull/156

The CLI had a hard time parsing the output of this endpoint well, so I
made the above CLI PR to use these two new spec extensions to give it a
hint as to how to parse these responses.  They shouldn't change anything
in the docs at all.