### PR TITLE
[Update] LKENodePool to use multi-item example

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15660,6 +15660,13 @@ components:
             its ID will be returned as null.
           items:
             $ref: '#/components/schemas/LKELinodeStatus'
+          example:
+            - id: 123456
+              status: ready
+            - id : 123457
+              status: ready
+            - id: 123458
+              status: not_ready
     LKELinodeStatus:
       type: object
       description: >


### PR DESCRIPTION
This example better represents the `linodes` property which returns an array of objects.