### PR TITLE
Release 4.11.0 (hotfix copy edit)

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -299,9 +299,6 @@ info:
     Endpoints that do not have CLI examples are currently unavailable through the CLI, but
     can be accessed via other methods such as Shell commands and other third-party applications.
 
-    # APIv3
-
-    View the [Linode APIv3 Documentation](https://linode.com/apiv3).
   contact:
     name: Linode
     url: /


### PR DESCRIPTION
Removing link to APIv3