### PR TITLE
[Hotfix] Block Storage Label Clarification

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.1
 info:
-  version: 4.11.0
+  version: 4.11.1
   title: Linode API
   description: |
     # Introduction

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9697,7 +9697,9 @@ paths:
                   type: string
                   description: >
                     The name for this bucket. Must be unique in the cluster you
-                    are creating the bucket in, or an error will be returned.
+                    are creating the bucket in, or an error will be returned. Labels will be
+                    reserved only for the cluster that active buckets are created and stored in.
+
                   pattern: ^[a-z0-09][a-z0-9-]*[a-z0-9]?$
                   example: example-bucket
                 cluster:


### PR DESCRIPTION
Added a sentence to make it clear that block storage labels will not be reserved across clusters