### PR TITLE
Bucket Label Clarification

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9699,6 +9699,8 @@ paths:
                     The name for this bucket. Must be unique in the cluster you
                     are creating the bucket in, or an error will be returned. Labels will be
                     reserved only for the cluster that active buckets are created and stored in.
+                    If you want to reserve this bucket's label in another cluster,
+                    you must create a new bucket with the same label in the new cluster.
                   pattern: ^[a-z0-09][a-z0-9-]*[a-z0-9]?$
                   example: example-bucket
                 cluster:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9697,7 +9697,8 @@ paths:
                   type: string
                   description: >
                     The name for this bucket. Must be unique in the cluster you
-                    are creating the bucket in, or an error will be returned.
+                    are creating the bucket in, or an error will be returned. Labels will be
+                    reserved only for the cluster that active buckets are created and stored in.
                   pattern: ^[a-z0-09][a-z0-9-]*[a-z0-9]?$
                   example: example-bucket
                 cluster:


### PR DESCRIPTION
Added sentence to clarify that labels can only be reserved for a single cluster per bucket