### PR TITLE
Revert "Fix /domains/import: linode-cli now displays import as an act…

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2290,9 +2290,9 @@ paths:
           source: >
             linode-cli domains delete 1234
   /domains/import:
-    x-linode-cli-command: domains
     post:
       x-linode-grant: read_write
+      x-linode-cli-command: domains
       tags:
       - Domains
       summary: Import Domain


### PR DESCRIPTION
…ion"

This reverts commit b2a63c3f1f2a6d43b15d060ba073c385b4f4479d.