### PR TITLE
Add enum of capabilities for Regions

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -17307,6 +17307,12 @@ components:
           type: array
           items:
             type: string
+            enum:
+            - Linodes
+            - NodeBalancers
+            - Block Storage
+            - Object Storage
+            - Kubernetes
           description: >
               A list of capabilities of this region.
           example:


### PR DESCRIPTION
This PR should display the possible values that could be included in the `capabilities` array of a Region.

However:
- The current developers site does not display these values with the updates in this PR.
- If the enum is moved out of the `items` scope and into the `capabilities` scope (like below), then the enum does display:
    ```
        capabilities:
          type: array
          items:
            type: string
          description: >
              A list of capabilities of this region.
          enum:
          - Linodes
          - NodeBalancers
          - Block Storage
          - Object Storage
          - Kubernetes
          example:
          - Linodes
          - NodeBalancers
          - Block Storage
          - Object Storage
          readOnly: true
          x-linode-cli-display: 3
    ```
    <img width="854" alt="capabilities-enum-displayed" src="https://user-images.githubusercontent.com/255491/75831337-3e8fd780-5d81-11ea-8ad0-5550b7f3c237.png">
- I believe that the above code is incorrect; the [openapi docs from Swagger](https://swagger.io/docs/specification/2-0/enums/) say: `All values in an enum must adhere to the specified type`. In this code, the `type` is `array`, while the elements of the enum are strings.
- It seems like we should not try to update the spec file with technically incorrect content that happens to render like we want it to. Instead, we should update the renderer so that it works with the correct spec syntax.

I'm going to close this PR, so we don't keep it open while waiting on updating the renderer, while still keeping this as a record of the work done so far