### PR TITLE
[Update] PAT section with link to POST /profile/tokens

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -36,7 +36,8 @@ info:
 
     The easiest way to access the API is with a Personal Access Token (PAT)
     generated from the
-    <a target="_top" href="https://cloud.linode.com/profile/tokens">Linode Cloud Manager</a>.
+    <a target="_top" href="https://cloud.linode.com/profile/tokens">Linode Cloud Manager</a> or
+    the [Create Personal Access Token](/api/v4/profile-tokens#post) endpoint.
 
     All scopes for the OAuth security model ([defined below](#o-auth)) apply to this
     security model as well.


### PR DESCRIPTION
* Previously, PAT section of API ref did not mention `POST /profile/tokens` as a method for creating a PAT. This PR adds a mention and link to the `POST /profile/tokens` section of the ref.