### PR TITLE
Adding authentication_type to Profile

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -17385,15 +17385,11 @@ components:
           x-linode-cli-display: 3
         authentication_type:
           type: string
+          enum:
+          - password
           description: |
-            The authentication type of the account. Authentication types are chosen through
-            Cloud Manager and authorized when logging into your account. These authentication types are either
-            the user's password (in conjunction with their username), or the name of their
-            indentity provider such as GitHub. For example, if a user:
-
-            - Has never used Third-Party Authentication, their authentication type will be `password`.
-            - Is using Third-Party Authentication, their authentication type will be the name of their Identity Provider (eg. `github`).
-            - Has used Third-Party Authentication and has since revoked it, their authentication type will be `password`.
+            This account's Cloud Manager authentication type. Currently, a user's password
+            (in conjunction with their username) is the only available authentication type.
           example: password
           readOnly: true
     Region:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -17387,13 +17387,13 @@ components:
           type: string
           description: |
             The authentication type of the account. Authentication types are chosen through
-            Cloud Manager and authorized through Login. These authentication types are either
+            Cloud Manager and authorized when logging into your account. These authentication types are either
             the user's password (in conjunction with their username), or the name of their
-            indentity provider such as "github", "google", etc. For example:
+            indentity provider such as "github", "google", etc. For example, if a user:
 
-            - If a user has never used Third-Party Authentication, their authentication type will be "password".
-            - If a user is using Third-Party Authentication, their authentication type will be the name of their Identity Provider (eg. "github").
-            - If a user used Third-Party Authentication and has since revoked it, their authentication type will be "password".
+            - Has never used Third-Party Authentication, their authentication type will be "password".
+            - Is using Third-Party Authentication, their authentication type will be the name of their Identity Provider (eg. "github").
+            - Has used Third-Party Authentication and has since revoked it, their authentication type will be "password".
           example: password
           readOnly: true
     Region:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -17389,11 +17389,11 @@ components:
             The authentication type of the account. Authentication types are chosen through
             Cloud Manager and authorized when logging into your account. These authentication types are either
             the user's password (in conjunction with their username), or the name of their
-            indentity provider such as "github", "google", etc. For example, if a user:
+            indentity provider such as GitHub. For example, if a user:
 
-            - Has never used Third-Party Authentication, their authentication type will be "password".
-            - Is using Third-Party Authentication, their authentication type will be the name of their Identity Provider (eg. "github").
-            - Has used Third-Party Authentication and has since revoked it, their authentication type will be "password".
+            - Has never used Third-Party Authentication, their authentication type will be `password`.
+            - Is using Third-Party Authentication, their authentication type will be the name of their Identity Provider (eg. `github`).
+            - Has used Third-Party Authentication and has since revoked it, their authentication type will be `password`.
           example: password
           readOnly: true
     Region:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -17383,6 +17383,19 @@ components:
             access/perform, see [/profile/grants](/api/v4/profile-grants).
           example: false
           x-linode-cli-display: 3
+        authentication_type:
+          type: string
+          description: |
+            The authentication type of the account. Authentication types are chosen through
+            Cloud Manager and authorized through Login. These authentication types are either
+            the user's password (in conjunction with their username), or the name of their
+            indentity provider such as "github", "google", etc. For example:
+
+            - If a user has never used Third-Party Authentication, their authentication type will be "password".
+            - If a user is using Third-Party Authentication, their authentication type will be the name of their Identity Provider (eg. "github").
+            - If a user used Third-Party Authentication and has since revoked it, their authentication type will be "password".
+          example: password
+          readOnly: true
     Region:
       type: object
       description: An area where Linode services are available.


### PR DESCRIPTION
Added authentication_type to profile schema object

See the endpoints:
GET https://api.linode.com/v4/profile
PUT https://api.linode.com/v4/profile (response only)