### PR TITLE
Allow CLI to accept k8s version when creating clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,4 @@ Attribute | Location | Type | Supported By | Explanation
 `x-linode-cli-rows`| media type | array | A list of JSON paths where the CLI can find the value it should treat as table rows.  Only needed for irregular endpoints.
 `x-linode-cli-use-schema` | media type | schema or $ref | The schema the CLI should use when showing a row for this response.  Use with `x-linode-cli-rows`.
 `x-linode-cli-nested-list` | media type | string | The name of the property defined by this response body's schema that is a nested list.  Items in the list will be broken out into rows in the CLI's output.
+`x-linode-cli-name` | schema | string | The name this attribute should translate to when being included in a CLI call.  Use only when necessary to preserve consistency between API and CLI.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6127,7 +6127,7 @@ paths:
           linode-cli lke cluster-create \
             --label cluster12345 \
             --region us-central \
-            --version 1.16 \
+            --kube-version 1.16 \
             --node_pools.type g6-standard-4 --node_pools.count 6 \
             --node_pools.type g6-standard-8 --node_pools.count 3
   /lke/clusters/{clusterId}:
@@ -15651,6 +15651,7 @@ components:
             The desired Kubernetes version for this Kubernetes cluster in the format of &lt;major&gt;.&lt;minor&gt;,
             and the latest supported patch version will be deployed.
           example: "1.16"
+          x-linode-cli-name: kube-version
         tags:
           type: array
           description: >


### PR DESCRIPTION
This is for https://github.com/linode/linode-cli/pull/177

Right now, the "version" argument accepted when creating an LKE Cluster
translates in the CLI to `--version`, which the CLI interprets to mean
it should print its own version and exit.

For this reason, a new spec extension has been added,
`x-linode-cli-name`, which is allowed in schemas to define a new name
for the CLI argument for any POST/PUT attribute.  To keep things
consistent between the API and CLI, this should be used only in extreme
circumstances (such as noted above).