### PR TITLE
Release 4.60.1

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.1
 info:
-  version: 4.60.0
+  version: 4.60.1
 
   title: Linode API
   description: |


### PR DESCRIPTION
* Bump version to 4.60.1
* Includes info about List Events limit to events from the last 90 days.