### PR TITLE
Update StackScript collection

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -17504,6 +17504,7 @@ components:
           - linode/debian8
           x-linode-cli-display: 4
         deployments_total:
+          x-linode-filterable: true
           type: integer
           description: >
             The total number of times this StackScript has been deployed.


### PR DESCRIPTION
`deployments_total` property is now filterable.