### PR TITLE
[Fix] Add response body to Clone Volumes endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12611,7 +12611,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
+                $ref: '#/components/schemas/Volume'
         default:
           $ref: '#/components/responses/ErrorResponse'
       x-code-samples:


### PR DESCRIPTION
* POST /volumes/{volumeId}/clone was missing a response body.