### PR TITLE
Minor LKE Schema fixes to bring it in line with API

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15812,11 +15812,11 @@ components:
       readOnly: true
       properties:
         id:
-          type: number
+          type: string
           description: >
             The Node's ID.
           x-linode-filterable: true
-          example: 123456
+          example: "123456"
         instance_id:
           type: string
           description: >

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15748,16 +15748,13 @@ components:
         # LKEClusterRequestBody but otherwise inherit all of the original
         # sub-properties.
         label:
-          x-linode-filterable: true
           x-linode-cli-display: 2
           example: lkecluster12345
         region:
           readOnly: true
-          x-linode-filterable: true
           x-linode-cli-display: 3
           example: us-central
         version:
-          x-linode-filterable: true
           example: "1.16"
         tags:
           example:
@@ -15815,7 +15812,6 @@ components:
           type: string
           description: >
             The Node's ID.
-          x-linode-filterable: true
           example: "123456"
         instance_id:
           type: string


### PR DESCRIPTION
There were two main changes in this PR
1. The `LKENodeStatus` had `id` as a number when it is a string. That id is the name of the node object as listed by the Kubernetes API server.
2. Removed the `x-linode-filterable` key from fields which are not filterable.