### PR TITLE
[Update] Profile collection

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -17466,6 +17466,10 @@ components:
             - Has never used Third-Party Authentication, their authentication type will be `password`.
             - Is using Third-Party Authentication, their authentication type will be the name of their Identity Provider (eg. `github`).
             - Has used Third-Party Authentication and has since revoked it, their authentication type will be `password`.
+
+
+            **Note:** Note this functionality is not yet available in Cloud Manager.
+            See the [Cloud Manager Changelog](/changelog/cloud-manager/) for the latest updates.
           example: password
           readOnly: true
     Region:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -17456,9 +17456,16 @@ components:
           type: string
           enum:
           - password
+          - github
           description: |
-            This account's Cloud Manager authentication type. Currently, a user's password
-            (in conjunction with their username) is the only available authentication type.
+            This account's Cloud Manager authentication type. Authentication types are chosen through
+            Cloud Manager and authorized when logging into your account. These authentication types are either
+            the user's password (in conjunction with their username), or the name of their
+            indentity provider such as GitHub. For example, if a user:
+
+            - Has never used Third-Party Authentication, their authentication type will be `password`.
+            - Is using Third-Party Authentication, their authentication type will be the name of their Identity Provider (eg. `github`).
+            - Has used Third-Party Authentication and has since revoked it, their authentication type will be `password`.
           example: password
           readOnly: true
     Region:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -17468,7 +17468,7 @@ components:
             - Has used Third-Party Authentication and has since revoked it, their authentication type will be `password`.
 
 
-            **Note:** Note this functionality is not yet available in Cloud Manager.
+            **Note:** This functionality is not yet available in Cloud Manager.
             See the [Cloud Manager Changelog](/changelog/cloud-manager/) for the latest updates.
           example: password
           readOnly: true


### PR DESCRIPTION
* Add info about GitHub `authentication_type`
* This feature will be going live soon in Cloud Manager, so users will be able to receive `github` as a possible value in their Profile collection responses.