### PR TITLE
Don't describe LKE Cluster label as optional

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15674,7 +15674,6 @@ components:
           type: string
           description: >
             This Kubernetes cluster's unique label for display purposes only.
-            If no label is provided, one will be assigned automatically.
 
             Labels have the following constraints:
               * Must start with an alpha character

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15676,6 +15676,7 @@ components:
             This Kubernetes cluster's unique label for display purposes only.
 
             Labels have the following constraints:
+
               * Must start with an alpha character
               * Must only consist of alphanumeric characters and dashes (`-`)
               * Must not contain two dashes in a row


### PR DESCRIPTION
> If no label is provided, one will be assigned automatically.

This bit is inaccurate. If no `label` is provided, the API throws a Bad Request error.

```
❯ curl --location --request POST 'https://api.linode.com/v4/lke/clusters' \
	--header 'Content-Type: application/json' \
	--header "Authorization: Bearer $LINODE_API_TOKEN" \
	--data-raw '{
	    "k8s_version": "1.17",
	    "region": "us-east",
	    "node_pools": [
	        {
	            "type": "g6-standard-1",
	            "count": 1
	        }
	    ]
	}'
{"errors": [{"reason": "label is required", "field": "label"}]}
```