### PR TITLE
Release 4.66.0

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.1
 info:
-  version: 4.65.0
+  version: 4.66.0
 
   title: Linode API
   description: |


### PR DESCRIPTION
### Changed

- In an effort to fight spam, Linode restricts outbound connections on ports 25, 465, and 587 on all Linodes for new accounts created after November 5th, 2019. This is not a new change; however, this note now appears on the Create Linode ([POST /linode/instances](/api/v4/linode-instances/#post)) endpoint.

- The upper limit for pagination can now be set to 500; the default remains 100. Read more about [pagination](/api/v4/#pagination).

- The CPU alert value defaults to 90% multiplied by the number of cores. This is not a new change; a note has been added to the [Linode Instances](/api/v4/linode-instances) group of endpoints.