### PR TITLE
Add minimum and maximum values for DomainRecord's weight

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -13797,6 +13797,8 @@ components:
           description: >
             The relative weight of this Record. Higher values are preferred.
           example: 50
+          minimum: 0
+          maximum: 65535
           x-linode-cli-display: 7
         port:
           type: integer

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -13805,6 +13805,8 @@ components:
           description: >
             The port this Record points to.
           example: 80
+          minimum: 0
+          maximum: 65535
         service:
           type: string
           nullable: true


### PR DESCRIPTION
One of the last sprint's tasks was to standardize the max weight of a DomainRecord to 65535. The minimum and maximum weight were missing from the spec file, so this PR fixes that too