### PR TITLE
[Update] /account/events action field

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -14159,6 +14159,7 @@ components:
             The action that caused this Event. New actions may be added in the future.
           example: ticket_create
           x-linode-cli-display: 3
+          x-linode-filterable: true
         created:
           type: string
           readOnly: true


### PR DESCRIPTION
* `action` field for `/account/events` is now filterable