### PR TITLE
[Update] lke/clusters PUT and lke/cluster POST to reflect actual behavior

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -16023,9 +16023,6 @@ components:
                 characters.
           minLength: 1
           maxLength: 32
-          # Kubernetes does NOT allow underscores in resource names and we are
-          # passing this name to Kubernetes. Thus the following pattern:
-          pattern: '[a-zA-Z0-9-]{3, 32}'
           x-linode-cli-display: 2
           example: lkecluster12345
         region:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15933,10 +15933,18 @@ components:
 
             Labels have the following constraints:
 
-              * Must start with an alpha character
-              * Must only consist of alphanumeric characters and dashes (`-`)
-              * Must not contain two dashes in a row
-          minLength: 3
+              * UTF-8 characters will be returned by the API using escape
+                sequences of their Unicode code points. As an example, the
+                Japanese character 'か' is 3 bytes in UTF-8 (0xE382AB). Its
+                Unicode code point is 2 bytes (0x30AB). APIv4 supports this
+                character and the API will return it as the escape sequence
+                using six 1 byte characters which represent 2 bytes of Unicode
+                code point ("\u30ab").
+              * 4 byte UTF-8 characters are not supported.
+              * If the label is entirely composed of UTF-8 characters, the API
+                response will return the code points using up to 193 1 byte
+                characters.
+          minLength: 1
           maxLength: 32
           # Kubernetes does NOT allow underscores in resource names and we are
           # passing this name to Kubernetes. Thus the following pattern:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -16011,12 +16011,12 @@ components:
             Labels have the following constraints:
 
               * UTF-8 characters will be returned by the API using escape
-                sequences of their Unicode code points. As an example, the
-                Japanese character 'か' is 3 bytes in UTF-8 (0xE382AB). Its
-                Unicode code point is 2 bytes (0x30AB). APIv4 supports this
+                sequences of their Unicode code points. For example, the
+                Japanese character *か* is 3 bytes in UTF-8 (`0xE382AB`). Its
+                Unicode code point is 2 bytes (`0x30AB`). APIv4 supports this
                 character and the API will return it as the escape sequence
                 using six 1 byte characters which represent 2 bytes of Unicode
-                code point ("\u30ab").
+                code point (`"\u30ab"`).
               * 4 byte UTF-8 characters are not supported.
               * If the label is entirely composed of UTF-8 characters, the API
                 response will return the code points using up to 193 1 byte


### PR DESCRIPTION
LKE does not impose ASCII-only restrictions on the label name. The only restrictions on the label are length and JSON validity.