### PR TITLE
Release 4.70.0

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.1
 info:
-  version: 4.69.0
+  version: 4.70.0
 
   title: Linode API
   description: |


### PR DESCRIPTION
### Added

- Added the `Recycle Node Pool` ([POST /lke/clusters/{clusterId}/pools/{poolId}/recycle](/api/v4/lke-clusters-cluster-id-pools-pool-id-recycle/#post)) endpoint. This new endpoint allows you to recycle the Node Pool of your specified Kubernetes Cluster by `clusterId` and `poolId`.

### Changed

- Password validation is now solely reliant upon complexity (strength) score and no longer requires a set number of characters in special classes. Relevant endpoints:

    - `Create Linode` ([POST /linode/instances](/api/v4/linode-instances/#post))
    - `Rebuild Linode` ([POST /linode/instances/{linodeId}/rebuild](/api/v4/linode-instances-linode-id-rebuild/#post))
    - `Create Managed Credential` ([POST /managed/credentials](/api/v4/managed-credentials/#post))
    - `Update Managed Credential Username and Password` ([POST /managed/credentials/{credentialId}/update](/api/v4/managed-credentials-credential-id-update/#post))
    - `Create Disk` ([POST /linode/instances/{linodeId}/disks](/api/v4/linode-instances-linode-id-disks/#post))
    - `Reset Disk Root Password` ([POST /linode/instances/{linodeId}/disks/{diskId}/password](/api/v4/linode-instances-linode-id-disks-disk-id-password/#post))

- Updated the description for the `Update Node Pool` ([PUT /lke/clusters/{clusterId}/pools/{poolId}](/api/v4/lke-clusters-cluster-id-pools-pool-id/#put)) endpoint. Now the description more accurately explains that nodes are created or deleted to match the updated count and that any local storage on deleted Linodes (such as "hostPath" and "emptyDir" volumes, or "local" PersistentVolumes) will be erased.

### Fixed

- Fixed a bug with domain validation where some multi-level domains were being flagged as invalid.

- Fixed a bug in CNAME record validation. It now checks all incoming CNAME records against all existing records (CNAME and otherwise) in this domain to make sure there are no conflicts. Relevant endpoints:

    - `Create Domain Record` ([POST /domains/{domainId}/records](/api/v4/domains-domain-id-records/#post))
    - `Update Domain Record` ([PUT /domains/{domainId}/records/{recordId}](/api/v4/domains-domain-id-records-record-id/#put))

- Updated the [OAuth Workflow section](/api/v4/#o-auth) to include `grant_type` as a required parameter when using a refresh token.

- Switched the order of the name for the `Initiate Pending Host Migration/DC Migration` endpoint to `Initiate DC Migration/Pending Host Migration` to clear up any confusion about which part the word `Pending` applies. Pending refers only to the host migration and not to the data center migration. The [POST /linode/instances/{linodeId}/migrate](/api/v4/linode-instances-linode-id-migrate/#post) endpoint itself remains unchanged.