### PR TITLE
bug: Add "content" block to lke node pool recycle POST

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6755,6 +6755,10 @@ paths:
       responses:
         '200':
           description: Node Pool has been recycled.
+          content:
+            application/json:
+              schema:
+                type: object
         default:
           $ref: '#/components/responses/ErrorResponse'
       x-code-samples:


### PR DESCRIPTION
The absence of this is breaking CLI builds.  The CLI builds as expected
with this included.  This is probably also more correct, as the API
appears to return a `{}` as the body for a 200 response from this endpoint.