### PR TITLE
Added the "size" property to the Object Storage bucket model.

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -17431,6 +17431,10 @@ components:
             The hostname where this bucket can be accessed. This hostname
             can be accessed through a browser if the bucket is made public.
           example: example-bucket.us-east-1.linodeobjects.com
+        size:
+          type: integer
+          description: The size of the bucket in bytes.
+          example: 188318981
     ObjectStorageObject:
       type: object
       description: >


### PR DESCRIPTION
This is my first PR to the Linode API docs.

Following [a question on the community Q&A](https://www.linode.com/community/questions/20315/when-will-the-object-storage-api-be-able-to-report-total-storage-used) I realised that the new "size" parameter for an Object Storage bucket is not documented, so this PR adds it to the `ObjectStorageBucket` model.