### PR TITLE
Release 4.72.0

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1634,6 +1634,9 @@ paths:
       summary: Update Account Settings
       description: >
         Updates your Account settings.
+
+
+        To update your Longview subscription plan, send a request to [Update Longview Plan](/api/v4/longview-plan/#put).
       operationId: updateAccountSettings
       x-linode-cli-action: settings-update
       security:
@@ -1663,13 +1666,11 @@ paths:
                 -H "Authorization: Bearer $TOKEN" \
                 -X PUT -d '{
                     "network_helper": true,
-                    "longview_subscription": "longview-10"
                 }' \
                 https://api.linode.com/v4/account/settings
         - lang: CLI
           source: >
             linode-cli account settings-update \
-              --longview_subscription longview-30 \
               --network_helper false
   /account/settings/managed-enable:
     x-linode-cli-command: account
@@ -7184,8 +7185,20 @@ paths:
       - Longview
       summary: View Longview Plan
       description: >
-        Returns the Longview subscription plan for this account. You can send a request to the
-        [View Longview Subscription](/api/v4/longview-subscriptions-subscription-id) endpoint for details on each particular subscription plan.
+        Get the details of your current Longview plan. This returns a `LongviewSubscription` object
+        for your current Longview Pro plan, or an empty set `{}` if your current plan is Longview Free.
+
+
+        You must have at least one of the following `global` [User Grants](/api/v4/account-users-username-grants/)
+        in order to access this endpoint:
+
+          - `"account_access": read_write`
+          - `"account_access": read_only`
+          - `"longview_subscription": true`
+          - `"add_longview": true`
+
+
+        To update your subscription plan, send a request to [Update Longview Plan](/api/v4/longview-plan/#put).
       operationId: getLongviewPlan
       x-linode-cli-action: plan-view
       security:
@@ -7194,11 +7207,11 @@ paths:
         - longview:read_only
       responses:
         '200':
-          description: The Longview Subscription plan for this account.
+          description: The Longview plan details for this account.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LongviewPlan'
+                $ref: '#/components/schemas/LongviewSubscription'
         default:
           $ref: '#/components/responses/ErrorResponse'
       x-code-samples:
@@ -7214,14 +7227,22 @@ paths:
       - Longview
       summary: Update Longview Plan
       description: >
-        Updates the Longview subscription plan for this account. You can send a request to the
-        [View Longview Subscription](/api/v4/longview-subscriptions-subscription-id) endpoint for details on each particular subscription plan.
+        Update your Longview plan to that of the given subcription ID. This returns a `LongviewSubscription` object for
+        the updated Longview Pro plan, or an empty set `{}` if the updated plan is Longview Free.
+
+
+        You must have `"longview_subscription": true` configured as a `global`
+        [User Grant](/api/v4/account-users-username-grants/) in order to access this endpoint.
+
+
+        You can send a request to the [List Longview Subscriptions](/api/v4/longview-subscriptions/)
+        endpoint to receive the details, including `id`'s, of each plan.
       operationId: updateLongviewPlan
       x-linode-cli-action: plan-update
       security:
       - personalAccessToken: []
       - oauth:
-        - account:read_write
+        - longview:read_write
       requestBody:
         description: Update your Longview subscription plan.
         required: true
@@ -7231,22 +7252,11 @@ paths:
               $ref: '#/components/schemas/LongviewPlan'
       responses:
         '200':
-          description: The requested Longview Subscription.
+          description: The updated Longview plan details for this account.
           content:
             application/json:
               schema:
-                properties:
-                  longview_subscription:
-                    type: string
-                    description: >
-                      The Longview subscription plan you are currently subscribed to.
-
-
-
-                      To update your subscription plan send a request to [Update Longview Plan](/api/v4/longview-plan/#put).
-                      The value must be a [Longview Subscription ID](/api/v4/longview-subscriptions) or `null`. Note that a value of `null` will cancel the longview subscription.
-                    example: longview-10
-                    x-linode-cli-display: 1
+                $ref: '#/components/schemas/LongviewSubscription'
         default:
           $ref: '#/components/responses/ErrorResponse'
       x-code-samples:
@@ -7317,13 +7327,13 @@ paths:
       - Longview
       summary: View Longview Subscription
       description: >
-        Returns a single LongviewSubscription object.  This is a public
-        endpoint and requires no authentication.
+        Get the Longview plan details as a single `LongviewSubscription` object for the provided subscription ID. This is a public endpoint
+        and requires no authentication.
       operationId: getLongviewSubscription
       x-linode-cli-action: subscription-view
       responses:
         '200':
-          description: The requested Longview Subscription.
+          description: The requested Longview Subscription details.
           content:
             application/json:
               schema:
@@ -13426,11 +13436,12 @@ components:
           x-linode-cli-display: 3
         longview_subscription:
           type: string
+          readOnly: true
           description: >
-            The Longview Pro tier you are currently subscribed to. The value must
+            The Longview Pro tier you are currently subscribed to. The value must be
             a [Longview Subscription](/api/v4/longview-subscriptions)
-            ID or `null`.
-          example: longview-30
+            ID or `null` for Longview Free.
+          example: longview-3
           x-linode-cli-display: 2
         network_helper:
           type: boolean
@@ -16319,11 +16330,12 @@ components:
     LongviewSubscription:
       type: object
       description: >
-        A Longview Subscriptions represents a tier of Longview service you
+        A Longview Subscription represents a tier of Longview service you
         can subscribe to.
       properties:
         id:
           type: string
+          enum: ['longview-3', 'longview-10', 'longview-40', 'longview-100']
           description: >
             The unique ID of this Subscription tier.
           example: longview-10
@@ -16354,7 +16366,7 @@ components:
           type: string
           description: >
             A display name for this Subscription tier.
-          example: Longivew Pro 10 pack
+          example: Longview Pro 10 pack
           readOnly: true
           x-linode-cli-display: 2
         clients_included:
@@ -16371,14 +16383,15 @@ components:
       properties:
         longview_subscription:
           type: string
+          enum: ['longview-3', 'longview-10', 'longview-40', 'longview-100']
+          nullable: True
           description: >
-            The Longview subscription plan you are currently subscribed to.
+            The subscription ID for a particular Longview plan. A value of `null` corresponds to Longview Free.
 
 
-
-            To update your subscription plan send a request to [Update Longview Plan](/api/v4/longview-plan/#put).
-            The value must be a [Longview Subscription ID](/api/v4/longview-subscriptions) or `null`. Note that a value of `null` will cancel the Longview subscription.
-          example: longview-30
+            You can send a request to the [List Longview Subscriptions](/api/v4/longview-subscriptions/)
+            endpoint to receive the details of each plan.
+          example: longview-10
           x-linode-cli-display: 1
     ManagedContact:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -17910,6 +17910,23 @@ components:
           - outage
           readOnly: true
           x-linode-cli-display: 4
+        resolvers:
+          type: object
+          readOnly: true
+          x-linode-cli-display: 5
+          properties:
+            ipv4:
+              type: string
+              description: >
+                The IPv4 addresses for this region's DNS resolvers, separated by commas.
+              example: "192.0.2.0,192.0.2.1"
+              readOnly: true
+            ipv6:
+              type: string
+              description: >
+                The IPv6 addresses for this region's DNS resolvers, separated by commas.
+              example: "2001:0db8::,2001:0db8::1"
+              readOnly: true
     RescueDevices:
       type: object
       properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.1
 info:
-  version: 4.70.0
+  version: 4.72.0
 
   title: Linode API
   description: |

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -17431,6 +17431,10 @@ components:
             The hostname where this bucket can be accessed. This hostname
             can be accessed through a browser if the bucket is made public.
           example: example-bucket.us-east-1.linodeobjects.com
+        size:
+          type: integer
+          description: The size of the bucket in bytes.
+          example: 188318981
     ObjectStorageObject:
       type: object
       description: >


### PR DESCRIPTION
### Added

- The IPv4 and IPv6 addresses of the DNS resolvers for a region are now accessible at the View Region ([GET /regions/{regionId}](/api/v4/regions-region-id)) endpoint.

### Changed

- Changing your Longview subscription is no longer available at the Update Account Settings ([PUT /account/settings](/api/v4/account-settings/#put)) endpoint. Accordingly, the `longview_subscription` property has been removed from the Update Account Settings request body. To update your Longview plan, please use the Update Longview Plan ([PUT /longview/plan](/api/v4/longview-plan/#put)) endpoint.

- Updated the description and response for the View Longview Plan ([GET /longview/plan](/api/v4/longview-plan)) endpoint:
  - The previous description stated that this endpoint returns a `longview_subscription` ID. This has been corrected to state that the response consists of a LongviewSubscription object for your current Longview Pro plan, or an empty set `{}` if your current plan is Longview Free.
  - The response body and sample have been updated to include the details of the returned LongviewSubscription object for your current Longview plan.

- Accessing the View Longview Plan ([GET /longview/plan](/api/v4/longview-plan)) endpoint now requires one of the following `global` [User Grants](/api/v4/account-users-username-grants/):
  - `"account_access": read_write`
  - `"account_access": read_only`
  - `"longview_subscription": true`
  - `"add_longview": true`

- Updated the description, request, and response for the Update Longview Plan ([PUT /longview/plan](/api/v4/longview-plan/#put)) endpoint:
  - The previous description stated that this endpoint returns a `longview_subscription` ID. The description has been corrected to state that the response consists of a `LongviewSubscription` object for the updated Longview Pro plan, or an empty set `{}` if the updated plan is Longview Free.
  - Accessing this endpoint now requires `"longview_subscription": true` as a `global` [User Grant](/api/v4/account-users-username-grants/).
  - The required OAuth scope has been changed from `account:read_write` to `longview:read_write`.
  - The request body schema has been updated to specify possible values for the `longview_subscription` field and to reflect that it is nullable, with a `null` value corresponding to Longview Free.
  - The response body and sample have been updated to include the details of the returned `LongviewSubscription` object.

- Updated the response for the List Longview Subscriptions ([GET /longview/subscription](/api/v4/longview-subscriptions)) and View Longview Subscription ([GET /longview/subscriptions/{subscriptionID}](/api/v4/longview-subscriptions-subscription-id)) endpoint:
  - The response `id` property has been revised to specify possible values.

- Updated the Object Storage Bucket response schema to include the `size` property in the List Object Storage Buckets ([GET /object-storage/buckets](/api/v4/object-storage-buckets)), Create Object Storage Bucket ([POST /object-storage/buckets](/api/v4/object-storage-buckets/#post)), View Object Storage Bucket ([GET /object-storage/buckets/{clusterId}/{bucket}](/api/v4/object-storage-buckets-cluster-id-bucket)), and List Object Storage Buckets in Cluster ([GET /object-storage/buckets/{clusterId}](/api/v4/object-storage-buckets-cluster-id)) endpoints.

### Fixed

- A bug that prevented the Update Longview Plan ([PUT /longview/plan](/api/v4/longview-plan/#put)) endpoint from functioning has been fixed. The endpoint will now update your account's Longview plan as expected.
