### PR TITLE
Add x-linode-cli-format spec extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Attribute | Location | Type | Supported By | Explanation
 `x-linode-grant` | method | string | | The level of access a user must have in order to call this endpoint.
 `x-linode-cli-display` | schema properties | integer | linode-cli | If truthy, this property will be displayed in the Linode CLI.  The numeric value determines the ordering of the displayed columns, left to right.
 `x-linode-cli-color` | schema properties | object | linode-cli | A mapping of possible property values to color codes understood by python's [colorclass module](https://pypi.python.org/pypi/colorclass).  Must include a `default_`, used for any value that doesn't match one of the keys.
-`x-linode-cli-format` | schema properties | string | Overrides the value of the "format" field for this property, but for the CLI only.  Valid values are `file` and `json`.
+`x-linode-cli-format` | schema properties | string | linode-cli |  Overrides the value of the "format" field for this property, but for the CLI only.  Valid values are `file` and `json`.
 `x-linode-cli-command` | path | string | linode-cli | The command group the methods of this path fall into when generating commands in the `linode-cli <command> <action>` format.
 `x-linode-cli-action` | method | string | linode-cli | The action this method will be mapped to when generating commands in the `linode-cli <command> <action>` format.
 `x-linode-cli-skip` | method | boolean | linode-cli | If true, the CLI will not expose this action.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Attribute | Location | Type | Supported By | Explanation
 `x-linode-grant` | method | string | | The level of access a user must have in order to call this endpoint.
 `x-linode-cli-display` | schema properties | integer | linode-cli | If truthy, this property will be displayed in the Linode CLI.  The numeric value determines the ordering of the displayed columns, left to right.
 `x-linode-cli-color` | schema properties | object | linode-cli | A mapping of possible property values to color codes understood by python's [colorclass module](https://pypi.python.org/pypi/colorclass).  Must include a `default_`, used for any value that doesn't match one of the keys.
+`x-linode-cli-format` | schema properties | string | Overrides the value of the "format" field for this property, but for the CLI only.  Valid values are `file` and `json`.
 `x-linode-cli-command` | path | string | linode-cli | The command group the methods of this path fall into when generating commands in the `linode-cli <command> <action>` format.
 `x-linode-cli-action` | method | string | linode-cli | The action this method will be mapped to when generating commands in the `linode-cli <command> <action>` format.
 `x-linode-cli-skip` | method | boolean | linode-cli | If true, the CLI will not expose this action.
@@ -52,4 +53,3 @@ Attribute | Location | Type | Supported By | Explanation
 `x-linode-cli-rows`| media type | array | A list of JSON paths where the CLI can find the value it should treat as table rows.  Only needed for irregular endpoints.
 `x-linode-cli-use-schema` | media type | schema or $ref | The schema the CLI should use when showing a row for this response.  Use with `x-linode-cli-rows`.
 `x-linode-cli-nested-list` | media type | string | The name of the property defined by this response body's schema that is a nested list.  Items in the list will be broken out into rows in the CLI's output.
-`x-linode-cli-format` | schema properties | string | Overrides the value of the "format" field for this property, but for the CLI only.  Valid values are `file` and `json`.

--- a/README.md
+++ b/README.md
@@ -52,3 +52,4 @@ Attribute | Location | Type | Supported By | Explanation
 `x-linode-cli-rows`| media type | array | A list of JSON paths where the CLI can find the value it should treat as table rows.  Only needed for irregular endpoints.
 `x-linode-cli-use-schema` | media type | schema or $ref | The schema the CLI should use when showing a row for this response.  Use with `x-linode-cli-rows`.
 `x-linode-cli-nested-list` | media type | string | The name of the property defined by this response body's schema that is a nested list.  Items in the list will be broken out into rows in the CLI's output.
+`x-linode-cli-format` | schema properties | string | Overrides the value of the "format" field for this property, but for the CLI only.  Currently, the only valid value is `file`.

--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ Attribute | Location | Type | Supported By | Explanation
 `x-linode-cli-rows`| media type | array | A list of JSON paths where the CLI can find the value it should treat as table rows.  Only needed for irregular endpoints.
 `x-linode-cli-use-schema` | media type | schema or $ref | The schema the CLI should use when showing a row for this response.  Use with `x-linode-cli-rows`.
 `x-linode-cli-nested-list` | media type | string | The name of the property defined by this response body's schema that is a nested list.  Items in the list will be broken out into rows in the CLI's output.
-`x-linode-cli-format` | schema properties | string | Overrides the value of the "format" field for this property, but for the CLI only.  Currently, the only valid value is `file`.
+`x-linode-cli-format` | schema properties | string | Overrides the value of the "format" field for this property, but for the CLI only.  Valid values are `file` and `json`.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,6 @@ Attribute | Location | Type | Supported By | Explanation
 `x-linode-cli-skip` | method | boolean | linode-cli | If true, the CLI will not expose this action.
 `x-linode-redoc-load-ids`| operation | boolean | If true, ReDoc will load this path and print a bulleted list of IDs.  This only works on public collections.
 `x-linode-ref-name`| keyword | string | [Linode Developer's Site](https://github.com/linode/developers) | Provides a mechanism by which the Developer's site can generate a dropdown menu with an Object's name when using the `oneOf` keyword with a `discriminator`. **Note**: This front end functionality is currently being developed.
-`x-linode-cli-rows`| media type | array | A list of JSON paths where the CLI can find the value it should treat as table rows.  Only needed for irregular endpoints.
-`x-linode-cli-use-schema` | media type | schema or $ref | The schema the CLI should use when showing a row for this response.  Use with `x-linode-cli-rows`.
-`x-linode-cli-nested-list` | media type | string | The name of the property defined by this response body's schema that is a nested list.  Items in the list will be broken out into rows in the CLI's output.
+`x-linode-cli-rows`| media type | array | linode-cli | A list of JSON paths where the CLI can find the value it should treat as table rows.  Only needed for irregular endpoints.
+`x-linode-cli-use-schema` | media type | schema or $ref | linode-cli | The schema the CLI should use when showing a row for this response.  Use with `x-linode-cli-rows`.
+`x-linode-cli-nested-list` | media type | string | linode-cli | The name of the property defined by this response body's schema that is a nested list.  Items in the list will be broken out into rows in the CLI's output.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -16107,6 +16107,7 @@ components:
           example: 6
         disks:
           type: array
+          x-linode-cli-format: json
           description: >
             This Node Pool's custom disk layout. Each item in this array will create a new disk
             partition for each node in this Node Pool.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -18064,6 +18064,7 @@ components:
             The script to execute when provisioning a new Linode with this StackScript.
           example: >
             "#!/bin/bash"
+          x-linode-cli-format: file
         user_defined_fields:
           type: array
           description: >


### PR DESCRIPTION
This adds the new spec extension defined in linode/linode-cli#205
to the StackScript object's `script` attribute.  This extension
overrides the "format" for this property, but only for the Linode CLI.

This also supports https://github.com/linode/linode-cli/pull/206