### PR TITLE
Fix typo in description for disk created/updated fields.

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -13850,13 +13850,13 @@ components:
         created:
           type: string
           format: date-time
-          description: When this Linode was created.
+          description: When this Disk was created.
           example: '2018-01-01T00:01:01'
           readOnly: true
         updated:
           type: string
           format: date-time
-          description: When this Linode was last updated.
+          description: When this Disk was last updated.
           example: '2018-01-01T00:01:01'
           readOnly: true
     DiskRequest:


### PR DESCRIPTION
Fix description of `created` and `updated` fields for disks so they mention "Disk" instead of "Linode"