### PR TITLE
Add go module for use with new Hugo docs UI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/linode/linode-api-docs
+
+go 1.15


### PR DESCRIPTION
This is a prerequisite for generating previews of the API spec with a local copy of the repo. Once merged, these instructions can be followed to generate those local previews:

1. From the `feature/new-docs-ui branch` of your [docs](https://github.com/linode/docs) repo, run: 

        go mod edit -replace github.com/linode/linode-api-docs=/Users/nmelehan/Desktop/linode/linode-api-docs. 

    Be sure to replace the local file path of the linode-api-docs repo with the one from your computer.

1. Run the `hugo server` command with the `--ignoreVendor` option: 

        hugo server --ignoreVendor

    The local server should now live-reload with any changes you make to your local API docs repo.

1. When you previously ran the `go mod edit -replace` command, a line was added to your docs repo’s go.mod file that looks like this: 

        replace github.com/linode/linode-api-docs => /Users/nmelehan/Desktop/linode/linode-api-docs. 

    You should remove this line from that file when you are done testing the API locally.