### PR TITLE
Fixed createObjectStorageKeys response

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -10763,14 +10763,7 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                - $ref: '#/components/schemas/ObjectStorageKey'
-                - type: object
-                  properties:
-                    secret_key:
-                      type: string
-                      description: This keypair’s secret key. **Only returned on key creation**.
-                      example: OiA6F5r0niLs3QA2stbyq7mY5VCV7KqOzcmitmHw
+                $ref: '#/components/schemas/ObjectStorageKey'
         default:
           $ref: '#/components/responses/ErrorResponse'
       x-code-samples:
@@ -17812,6 +17805,11 @@ components:
           type: string
           description: This keypair's access key. This is not secret.
           example: KVAKUTGBA4WTR2NSJQ81
+          readOnly: true
+        secret_key:
+          type: string
+          description: This keypair's secret key. Only returned on key creation.
+          example: OiA6F5r0niLs3QA2stbyq7mY5VCV7KqOzcmitmHw
           readOnly: true
         limited:
           type: boolean


### PR DESCRIPTION
Reported in https://github.com/linode/linode-cli/issues/199.

Creating a new object storage key with linode-cli did not return any response. `allOf` does not appear to be valid in a response (https://swagger.io/docs/specification/describing-responses/ mentions anyOf and oneOf, but not allOf.)

Adding the secret_key property back to the ObjectStorageKey schema and removing it from the response schema for createObjectStorageKeys fixes that and allows linode-cli to return the secret key of the newly created key. For all other requests, the secret key is returned as `[REDACTED]`.

To test, check out this branch locally, check out linode-cli, then run `make build SPEC=<path_to>/linode-api-docs/openapi.yaml` in the linode-cli directory. Running `python3 -m linodecli object-storage keys-create` in the linode-cli directory should now return the secret key.