### PR TITLE
Changed language for app expiry

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -14450,8 +14450,8 @@ components:
           type: string
           format: date-time
           description: >
-            When this app's access token expires.  Please note that apps may still have active
-            refresh tokens after this time passes.
+            When the app's access to your account expires. If `null`, the app's
+            access must be revoked manually.
           example: '2018-01-15T00:01:01'
           readOnly: true
           x-linode-cli-display: 6


### PR DESCRIPTION
Changed the description to be more clear as to what steps to take based on what the return value of expiry is. If it's a public app no refresh token is created. If it's a private app, a refresh token is created and never expires, so the API is correct in its map output.