### PR TITLE
[New] Deprecated field for Kernel schema object

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -16572,6 +16572,13 @@ components:
           description: If this Kernel is suitable for paravirtualized operations.
           example: false
           readOnly: true
+        deprecated:
+          x-linode-filterable: true
+          type: boolean
+          description: If this Kernel is marked as deprecated, this field has a value of true;
+            otherwise, this field is false.
+          example: false
+          readOnly: true
     Linode:
       type: object
       allOf:


### PR DESCRIPTION
added deprecated field for Kernel schema object

note: In the current ui all false booleans return examples as "", in the new ui all false booleans are currently returning as null. This has been filed as an issue to be resolved.