### PR TITLE
Release 4.77.0

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.1
 info:
-  version: 4.76.1
+  version: 4.77.0
 
   title: Linode API
   description: |


### PR DESCRIPTION
### Added

 - Added the `message` field to the Event schema object. The message field provides additional information about the event. Additional information may include, but is not limited to, a more detailed representation of events which can help diagnose non-obvious failures. This new field is available on the following Account Event endpoints:

     - Event List ([GET /account/events](/api/v4/account-events))
     - Event View ([GET /account/events/{eventId}](/api/v4/account-events-event-id))

 - Added the `deprecated` field to the Kernel schema object. If this Kernel is marked as deprecated, this field has a value of true; otherwise, this field is false. This new field is available on the Linode Instances Kernel endpoints:

     - Kernels List ([GET /linode/kernels](/api/v4/linode-kernels))
     - Kernel View ([GET /linode/kernels/{kernelId}](/api/v4/linode-kernels-kernel-id))

 ### Changed

 - Updated the endpoint names to follow the convention `noun` followed by `verb`. For example, `View Account` is now named `Account View`.

 - Updated the description for the Object Storage Key Create ([POST /object-storage/keys](/api/v4/object-storage-keys/#post)) endpoint with information on the available Access Key and Limited Access Key creation options.

 - Updated the `bucket_access` field description in the `ObjectStorageKey` schema object with a note about the results of ommiting this field when creating a limited access Object Storage Key.

 ### Fixed

 - The User's Grants View ([GET /account/users/{username}/grants](/api/v4/account-users-username-grants)) endpoint was updated to have a less restrictive authorization of `account:read_only` instead of `account:read_write`. This fixes the discrepancy between specification and endpoint behavior.