### PR TITLE
Release 4.79.0

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11277,7 +11277,7 @@ paths:
 
 
         This endpoint is available for convenience. It is recommended that instead you
-        use the more more [fully-featured S3 API](https://docs.ceph.com/docs/mimic/radosgw/s3/bucketops/#put-bucket-acl) directly.
+        use the more more [fully-featured S3 API](https://docs.aws.amazon.com/cli/latest/reference/s3api/get-object-acl.html) directly.
       tags:
       - Object Storage
       security:
@@ -11325,6 +11325,90 @@ paths:
       - lang: Shell
         source: >
           curl -H "Authorization: Bearer $TOKEN" \
+            https://api.linode.com/v4/object-storage/buckets/us-east-1/example-bucket/object-acl?name=example.txt
+    put:
+      operationId: viewObjectStorageBucketAccess
+      x-linode-cli-skip: true
+      servers:
+      - url: https://api.linode.com/v4
+      summary: Object Storage Object ACL Config Update
+      description: |
+        Update an Object's configured Access Control List (ACL) in this Object Storage bucket.
+        ACLs define who can access your buckets and objects and specify the level of access
+        granted to those users.
+
+
+        This endpoint is available for convenience. It is recommended that instead you
+        use the more more [fully-featured S3 API](https://docs.aws.amazon.com/cli/latest/reference/s3api/put-object-acl.html) directly.
+      tags:
+      - Object Storage
+      security:
+      - personalAccessToken: []
+      - oauth:
+        - object_storage:read_write
+      parameters:
+      - name: name
+        in: query
+        required: true
+        description: >
+          The `name` of the object for which to update its Access Control List (ACL).
+          Use the [Object Storage Bucket Contents List](/docs/api/object-storage/#object-storage-bucket-contents-list)
+          endpoint to access all object names in a bucket.
+        schema:
+          type: string
+      requestBody:
+        description: The changes to make to this Object's access controls.
+        content:
+          application/json:
+            schema:
+              properties:
+                acl:
+                  type: string
+                  enum:
+                  - private
+                  - public-read
+                  - authenticated-read
+                  - public-read-write
+                  - custom
+                  description: >
+                    The Access Control Level of the bucket, as a canned ACL string.
+                    For more fine-grained control of ACLs, use the S3 API directly.
+                  example: public-read
+      responses:
+        '200':
+          description: The Object's canned ACL and policy.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  acl:
+                    type: string
+                    enum:
+                    - private
+                    - public-read
+                    - authenticated-read
+                    - public-read-write
+                    - custom
+                    description: >
+                      The Access Control Level of the bucket, as a canned ACL string.
+                      For more fine-grained control of ACLs, use the S3 API directly.
+                    example: public-read
+                  acl_xml:
+                    type: string
+                    description: >
+                      The full XML of the object's ACL policy.
+                    example: "<AccessControlPolicy>...</AccessControlPolicy>"
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      x-code-samples:
+      - lang: Shell
+        source: >
+          curl -H "Content-Type: application/json" \
+          -H "Authorization: Bearer $TOKEN" \
+            -X PUT -d '{
+              "acl": "public-read"
+            }' \
             https://api.linode.com/v4/object-storage/buckets/us-east-1/example-bucket/object-acl?name=example.txt
   /object-storage/buckets/{clusterId}/{bucket}/object-list:
     parameters:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -598,7 +598,8 @@ paths:
                 -X POST -d '{
                   "card_number": "4111111111111111",
                   "expiry_month": 11,
-                  "expiry_year": 2020
+                  "expiry_year": 2020,
+                  "cvv": "111"
                 }' \
                 https://api.linode.com/v4/account/credit-card
         - lang: CLI
@@ -606,7 +607,8 @@ paths:
             linode-cli account update-card \
               --card_number 4111111111111111 \
               --expiry_month 11 \
-              --expiry_year 2025
+              --expiry_year 2025 \
+              --cvv 111
   /account/events:
     x-linode-cli-command: events
     get:
@@ -14706,6 +14708,7 @@ components:
       - card_number
       - expiry_month
       - expiry_year
+      - cvv
       properties:
         card_number:
           type: string
@@ -19088,9 +19091,9 @@ components:
           x-linode-cli-display: 3
     PaymentRequest:
       type: object
-      description: Payment object request.
       required:
       - usd
+      description: Payment object request.
       properties:
         cvv:
           type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.1
 info:
-  version: 4.78.3
+  version: 4.79.0
 
   title: Linode API
   description: |


### PR DESCRIPTION
* Bump version to 4.79.0

### Added

- Added the [Object Storage Object ACL View](/docs/api/object-storage/#object-storage-object-acl-config-view) (GET /object-storage/buckets/{clusterId}/{bucket}/object-acl) endpoint. This endpoint returns an Object Storage bucket's currently configured Access Control List (ACL). ACLs define who can access your buckets and objects and specify the level of access granted to those users.

- Added the [Object Storage Bucket Access Update](/docs/api/object-storage/#object-storage-bucket-access-update) (PUT /object-storage/buckets/{clusterId}/{bucket}/access) endpoint. Use this endpoint to update a bucket's basic Cross-origin Resource Sharing (CORS) and Access Control Level (ACL) settings.

- Added the [Object Storage Transfer View](/docs/api/object-storage/#object-storage-object-acl-config-view) (GET /object-storage/transfer) endpoint. This endpoint returns the amount of outbound data transfer used by your account's Object Storage buckets. Object Storage adds 1 terabyte of outbound data transfer to your data transfer pool. See the [Object Storage Pricing and Limitations](/docs/guides/pricing-and-limitations/) guide for details on Object Storage transfer quotas.

- Added the `objects` field to the following Object Storage endpoints:

    - [Object Storage Buckets List](/docs/api/object-storage/#object-storage-buckets-list) (GET /object-storage/buckets)
    - [Object Storage Buckets in Cluster List](/docs/api/object-storage/#object-storage-buckets-in-cluster-list) (GET /object-storage/buckets/{clusterId})
    - [Object Storage Bucket View](/docs/api/object-storage/#object-storage-bucket-view) (GET /object-storage/buckets/{clusterId}/{bucket})

    The `object` field returns the number of objects stored in a bucket.

### Fixed

- Error messages for Firewalls endpoints have been improved. When applicable, they now return a [Firewall Device's](/docs/api/networking/#firewall-device-create) `label` and `id`.
