### PR TITLE
Release 4.80.0

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.1
 info:
-  version: 4.79.0
+  version: 4.80.0
 
   title: Linode API
   description: |


### PR DESCRIPTION
- Bump version to 4.80.0
- Added note about allowing trailing period to `target` field on domain record schema object for all records except A/AAAA