### PR TITLE
GitHub actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,6 @@
 name: Python package
 
-on: [push]
+on: [pull_request]
 
 jobs:
   lint:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,6 +25,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install openapi3
-    - name: blueberry
+    - name: openapi linter
       run: |
         python -m openapi3 openapi.yaml

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,30 @@
+name: Python package
+
+on: [push]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.7.x'
+        architecture: 'x64'
+    - name: Cache pip
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        # Look to see if there is a cache hit for the corresponding requirements file
+        key: ${{ runner.os }}-pip-${{ hashFiles('./ci/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+          ${{ runner.os }}-
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install openapi3
+    - name: blueberry
+      run: |
+        python -m openapi3 openapi.yaml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-sudo: false
-language: python
-python:
-  - 3.7
-script:
-  - python -m openapi3 openapi.yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-openapi3


### PR DESCRIPTION
Replace our Travis pipeline (which just runs the openapi linter) with GitHub actions.

To test, change `pull_request` to `push` on line 3 of test.yaml. Make some changes that shouldn't pass the openapi3 linter and push them to this branch on _your fork_ of this repo.