### PR TITLE
[Update] networking/firewalls: ports leading zeroes exclusion

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15924,7 +15924,7 @@ components:
             of single ports and port ranges. A space is permitted following each comma.
             - A range of ports is inclusive of the start and end values for the range. The
             end value of the range must be greater than the start value.
-            - Ports must be within 1 and 65535.
+            - Ports must be within 1 and 65535, and may not contain any leading zeroes. For example, port "080" is not allowed.
             - Ports may not be specified if a rule's protocol is `ICMP`. At least one port
             must be specified if a rule's protocol is `TCP` or `UDP`.
             - The ports string can have up to 15 *pieces*, where a single port is treated


### PR DESCRIPTION
Add leading zero exclusion to schema for ports set in Firewalls inbound and outbound rules.