### PR TITLE
[Release] v4.85.0

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5133,6 +5133,59 @@ paths:
         source: >
           linode-cli linodes disk-resize 123 25674 \
             --size 2048
+  /linode/instances/{linodeId}/firewalls:
+    parameters:
+    - name: linodeId
+      in: path
+      description: ID of the Linode to look up.
+      required: true
+      schema:
+        type: integer
+    x-linode-cli-command: linodes
+    get:
+      x-linode-grant: read_only
+      parameters:
+      - $ref: '#/components/parameters/pageOffset'
+      - $ref: '#/components/parameters/pageSize'
+      tags:
+      - Linode Instances
+      summary: Firewalls List
+      description: >
+        View Firewall information for Firewalls associated with this Linode.
+      operationId: getLinodeFirewalls
+      x-linode-cli-action: firewalls-list
+      security:
+      - personalAccessToken: []
+      - oauth:
+        - linodes:read_only
+      responses:
+        '200':
+          description: Returns a paginated list of Firewalls associated with this Linode.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Firewall'
+                  page:
+                    $ref: '#/components/schemas/PaginationEnvelope/properties/page'
+                  pages:
+                    $ref: '#/components/schemas/PaginationEnvelope/properties/pages'
+                  results:
+                    $ref: '#/components/schemas/PaginationEnvelope/properties/results'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      x-code-samples:
+      - lang: Shell
+        source: >
+          curl -H "Authorization: Bearer $TOKEN" \
+              https://api.linode.com/v4/linode/instances/123/firewalls
+      - lang: CLI
+        source: >
+          linode-cli linodes firewalls-list 123
   /linode/instances/{linodeId}/ips:
     parameters:
     - name: linodeId

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15232,7 +15232,7 @@ components:
           readOnly: true
           description: >
             This Account's current estimated invoice in US dollars. This is not
-            your final invoice balance. Bandwidth charges are not included in
+            your final invoice balance. Transfer charges are not included in
             the estimate.
           example: 145
           x-linode-cli-display: 4

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.1
 info:
-  version: 4.84.1
+  version: 4.85.0
 
   title: Linode API
   description: |

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2625,7 +2625,11 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Domain'
+              required:
+              - domain
+              - type
+              allOf:
+              - $ref: '#/components/schemas/Domain'
       responses:
         '200':
           description: |
@@ -2653,7 +2657,8 @@ paths:
                     "status": "active",
                     "master_ips": ["127.0.0.1","255.255.255.1","123.123.123.7"],
                     "axfr_ips": ["44.55.66.77"],
-                    "display_group": "Example Display Group"
+                    "group": "Example Display Group",
+                    "tags": ["tag1","tag2"]
                 }' \
                 https://api.linode.com/v4/domains
         - lang: CLI
@@ -2750,7 +2755,8 @@ paths:
                   "status": "active",
                   "master_ips": ["127.0.0.1","255.255.255.1","123.123.123.7"],
                   "axfr_ips": ["44.55.66.77"],
-                  "display_group": "Example Display Group"
+                  "group": "Example Display Group",
+                  "tags": ["tag1","tag2"]
               }' \
               https://api.linode.com/v4/domains/123
       - lang: CLI
@@ -15771,10 +15777,6 @@ components:
         A domain zonefile in our DNS system.  You must own the domain name and
         tell your registrar to use Linode's nameservers in order for a domain
         in our system to be treated as authoritative.
-      required:
-      - id
-      - domain
-      - type
       properties:
         id:
           type: integer
@@ -15795,6 +15797,8 @@ components:
         domain:
           type: string
           pattern: ([a-zA-Z0-9-_]{1,63}\.)+([a-zA-Z]{2,3}\.)?([a-zA-Z]{2,16}|xn--[a-zA-Z0-9]+\.?)
+          minLength: 1
+          maxLength: 255
           description: >
             The domain this Domain represents. Domain labels cannot be longer than
             63 characters and must conform to [RFC1035](https://tools.ietf.org/html/rfc1035).
@@ -15818,6 +15822,7 @@ components:
           enum:
           - disabled
           - active
+          default: active
           description: >
             Used to control whether this Domain is currently being rendered.
           example: active
@@ -15844,11 +15849,16 @@ components:
           x-linode-cli-display: 5
         retry_sec:
           type: integer
-          description: >
+          default: 0
+          description: |
             The interval, in seconds, at which a failed refresh should be retried.
-            Valid values are 300, 3600, 7200, 14400, 28800, 57600,
-            86400, 172800, 345600, 604800, 1209600, and 2419200 - any other
-            value will be rounded to the nearest valid value.
+
+            * Valid values are
+            0, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.
+
+            * Any other value is rounded up to the nearest valid value.
+
+            * A value of 0 is equivalent to the default value of 14400.
           example: 300
         master_ips:
           type: array
@@ -15871,34 +15881,44 @@ components:
           example: []
         expire_sec:
           type: integer
-          description: >
+          default: 0
+          description: |
             The amount of time in seconds that may pass before this Domain is no longer
-            authoritative. Valid values are
-            300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600,
-            604800, 1209600, and 2419200 - any other value will be rounded to
-            the nearest valid value.
+            authoritative.
+
+            * Valid values are
+            0, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.
+
+            * Any other value is rounded up to the nearest valid value.
+
+            * A value of 0 is equivalent to the default value of 1209600.
           example: 300
         refresh_sec:
           type: integer
-          description: >
+          default: 0
+          description: |
             The amount of time in seconds before this Domain should be refreshed.
-            Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600,
-            604800, 1209600, and 2419200 - any other value will be rounded to
-            the nearest valid value.
+
+            * Valid values are
+            0, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.
+
+            * Any other value is rounded up to the nearest valid value.
+
+            * A value of 0 is equivalent to the default value of 14400.
           example: 300
         ttl_sec:
           type: integer
+          default: 0
           description: >
             "Time to Live" - the amount of time in seconds that this Domain's
             records may be cached by resolvers or other domain servers.
 
-            * Valid values are 0, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800,
-            345600, 604800, 1209600, and 2419200 - any other value will be
-            rounded to the nearest valid value.
+            * Valid values are
+            0, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.
 
-            * ttl_sec will default to 0 if no value is provided.
+            * Any other value is rounded up to the nearest valid value.
 
-            * A value of 0 is equivalent to a value of 86400.
+            * A value of 0 is equivalent to the default value of 86400.
           example: 300
         tags:
           x-linode-filterable: true

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -655,7 +655,7 @@ paths:
             https://api.linode.com/v4/account/entity-transfers
       - lang: CLI
         source: >
-          linode-cli account entity-transfers \
+          linode-cli entity-transfers \
             list
     post:
       x-linode-grant: unrestricted only
@@ -672,7 +672,18 @@ paths:
 
 
         When a transfer is [accepted](/docs/api/account/#entity-transfer-accept), the requested entities are moved to
-        the receiving account. A transfer can take up to three hours to complete once accepted. When a transfer is
+        the receiving account. Linode services will not experience interruptions due to the transfer process, but
+        please take note of the following:
+
+
+        - If any of the Linodes included in the request have Backups enabled, that data and associated costs will be
+        removed/cancelled.
+
+        - DNS records will not be transferred or updated. Please ensure that DNS records have been updated or
+        communicated to the recipient prior to the transfer.
+
+
+        A transfer can take up to three hours to complete once accepted. When a transfer is
         completed, billing for transferred entities ends for the sending account and begins for the receiving account.
 
 
@@ -740,8 +751,10 @@ paths:
             https://api.linode.com/v4/account/entity-transfers
       - lang: CLI
         source: >
-          linode-cli account entity-transfers \
-            create --linodes 111,222
+          linode-cli entity-transfers \
+            create \
+            --entities.linodes 111 \
+            --entities.linodes 222
   /account/entity-transfers/{token}:
     x-linode-cli-command: entity-transfers
     parameters:
@@ -786,7 +799,7 @@ paths:
             https://api.linode.com/v4/account/entity-transfers/123E4567-E89B-12D3-A456-426614174000
       - lang: CLI
         source: >
-          linode-cli account entity-transfers \
+          linode-cli entity-transfers \
             view 123E4567-E89B-12D3-A456-426614174000
     delete:
       x-linode-grant: unrestricted only
@@ -805,7 +818,7 @@ paths:
 
         This command can only be accessed by the unrestricted users of the account that created this transfer.
       operationId: deleteEntityTransfer
-      x-linode-cli-action: delete
+      x-linode-cli-action: cancel
       security:
       - personalAccessToken: []
       - oauth:
@@ -828,8 +841,8 @@ paths:
             https://api.linode.com/v4/account/entity-transfers/123E4567-E89B-12D3-A456-426614174000
       - lang: CLI
         source: >
-          linode-cli account entity-transfers \
-            delete 123E4567-E89B-12D3-A456-426614174000
+          linode-cli entity-transfers \
+            cancel 123E4567-E89B-12D3-A456-426614174000
   /account/entity-transfers/{token}/accept:
     x-linode-cli-command: entity-transfers
     parameters:
@@ -907,7 +920,7 @@ paths:
             https://api.linode.com/v4/account/entity-transfers/123E4567-E89B-12D3-A456-426614174000/accept
       - lang: CLI
         source: >
-          linode-cli account entity-transfers \
+          linode-cli entity-transfers \
             accept 123E4567-E89B-12D3-A456-426614174000
   /account/events:
     x-linode-cli-command: events
@@ -16059,7 +16072,15 @@ components:
             The token used to identify and accept or cancel this transfer.
           example: "123E4567-E89B-12D3-A456-426614174000"
         status:
+          x-linode-cli-display: 2
           x-linode-filterable: true
+          x-linode-cli-color:
+            accepted: yellow
+            cancelled: red
+            completed: green
+            failed: red
+            pending: yellow
+            stale: red
           type: string
           enum:
           - accepted
@@ -16073,7 +16094,7 @@ components:
 
 
             `accepted`: The transfer has been accepted by another user and is currently in progress.
-            Transfers can take several hours to complete.
+            Transfers can take up to 3 hours to complete.
 
 
             `cancelled`: The transfer has been cancelled by the sender.
@@ -16104,12 +16125,14 @@ components:
             When this transfer was last updated.
           example: '2021-02-11T16:37:03'
         is_sender:
+          x-linode-cli-display: 4
           x-linode-filterable: true
           type: boolean
           description: >
             If the requesting account created this transfer.
           example: true
         expiry:
+          x-linode-cli-display: 3
           type: string
           format: date-time
           description: >
@@ -16121,6 +16144,7 @@ components:
             A collection of the entities to include in this transfer request, separated by type.
           properties:
             linodes:
+              x-linode-cli-display: 5
               type: array
               items:
                 type: integer


### PR DESCRIPTION
### Fixed

- The Maintenance List ([GET /account/maintenance](https://www.linode.com/docs/api/account/#maintenance-list)) beta endpoint previously returned information for inactive Linodes. This has been fixed to exclude information for inactive Linodes.

- The Domain Update ([PUT /domains/{domainId}](https://www.linode.com/docs/api/domains/#domain-update)) endpoint request body schema erroneously stated that the `domain` and `type` properties were required. The spec has been updated to mark these properties as optional.

- The Domain Create ([POST /domains](https://www.linode.com/docs/api/domains/#domain-create)) endpoint and Domain Update ([PUT /domains/{domainId}](https://www.linode.com/docs/api/domains/#domain-update)) endpoint SHELL request samples incorrectly stated a `display_group` property and excluded the `tags` property. The samples have been updated to state the `group` and `tags` properties.

- The following Domain schema properties have been updated to include the following missing value traits:
  - `domain`: minimum 1 and maximum 255 characters
  - `status`: a default value of active
  - `refresh_sec`: a valid, default value of 0, which is equivalent to 14400
  - `retry_sec`: a valid, default value of 0, which is equivalent to 14400
  - `expire_sec`: a valid, default value of 0, which is equivalent to 1209600

- The Account View ([GET /account](https://www.linode.com/docs/api/account/#account-view)) endpoint response body `balance_uninvoiced` description inaccurately stated that "Bandwidth charges are not included in the estimate." This has been corrected to state that "Transfer charges are not included in the estimate."
