### PR TITLE
Add required fields for Contact element

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -366,7 +366,8 @@ info:
 
   contact:
     name: Linode
-    url: /
+    url: https://linode.com
+    email: support@linode.com
 servers:
 - url: https://api.linode.com/v4
 - url: https://api.linode.com/v4beta


### PR DESCRIPTION
@displague recently informed me that the OpenAPI3 library was not
enforcing required fields for the Contact element.  I fixed the library,
but in testing it against our spec I found that we would not pass this
additional validation.

This change adds the required fields to the Contact element to allow
builds to continue to pass.  If the values I put here aren't ideal, let
me know and I'll update them.
