### PR TITLE
Release 4.86.0

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5133,6 +5133,59 @@ paths:
         source: >
           linode-cli linodes disk-resize 123 25674 \
             --size 2048
+  /linode/instances/{linodeId}/firewalls:
+    parameters:
+    - name: linodeId
+      in: path
+      description: ID of the Linode to look up.
+      required: true
+      schema:
+        type: integer
+    x-linode-cli-command: linodes
+    get:
+      x-linode-grant: read_only
+      parameters:
+      - $ref: '#/components/parameters/pageOffset'
+      - $ref: '#/components/parameters/pageSize'
+      tags:
+      - Linode Instances
+      summary: Firewalls List
+      description: >
+        View Firewall information for Firewalls associated with this Linode.
+      operationId: getLinodeFirewalls
+      x-linode-cli-action: firewalls-list
+      security:
+      - personalAccessToken: []
+      - oauth:
+        - linodes:read_only
+      responses:
+        '200':
+          description: Returns a paginated list of Firewalls associated with this Linode.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Firewall'
+                  page:
+                    $ref: '#/components/schemas/PaginationEnvelope/properties/page'
+                  pages:
+                    $ref: '#/components/schemas/PaginationEnvelope/properties/pages'
+                  results:
+                    $ref: '#/components/schemas/PaginationEnvelope/properties/results'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      x-code-samples:
+      - lang: Shell
+        source: >
+          curl -H "Authorization: Bearer $TOKEN" \
+              https://api.linode.com/v4/linode/instances/123/firewalls
+      - lang: CLI
+        source: >
+          linode-cli linodes firewalls-list 123
   /linode/instances/{linodeId}/ips:
     parameters:
     - name: linodeId

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15232,7 +15232,7 @@ components:
           readOnly: true
           description: >
             This Account's current estimated invoice in US dollars. This is not
-            your final invoice balance. Bandwidth charges are not included in
+            your final invoice balance. Transfer charges are not included in
             the estimate.
           example: 145
           x-linode-cli-display: 4

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15870,43 +15870,70 @@ components:
           description: >
             The type of Record this is in the DNS system. For example, A
             records associate a domain name with an IPv4 address, and AAAA
-            records associate a domain name with an IPv6 address.
+            records associate a domain name with an IPv6 address. For more information, see our guide on
+            [DNS Records](/docs/guides/dns-records-an-introduction).
           example: A
           x-linode-cli-display: 2
         name:
           type: string
-          description: >
-            The name of this Record. This field's actual usage depends on the
-            type of record this represents. For A and AAAA records, this is
-            the subdomain being associated with an IP address.
+          description: |
+            The name of this Record. For requests, this property's actual usage and whether it is required depends on the type of record this represents:
+
+            `A` and `AAAA`: The hostname or FQDN of the Record.
+
+            `NS`: The subdomain, if any, to use with the Domain of the Record.
+
+            `MX`: The subdomain.
+
+            `CNAME`: The hostname. Must be unique. Required.
+
+            `TXT`: The hostname.
+
+            `SRV`: Unused. Use the `service` property to set the service name for this record.
+
+            `CAA`: The subdomain. Omit or enter an empty string ("") to apply to the entire Domain.
+
+            `PTR`: See our guide on how to [Configure Your Linode for Reverse DNS (rDNS)](/docs/guides/configure-your-linode-for-reverse-dns).
           minLength: 1
           maxLength: 100
           example: test
           x-linode-cli-display: 3
         target:
           type: string
-          description: >
-            The target for this Record. This field's actual usage depends on
-            the type of record this represents. For A and AAAA records, this
-            is the address the named Domain should resolve to.
+          description: |
+            The target for this Record. For requests, this property's actual usage and whether it is required depends on the type of record this represents:
 
+            `A` and `AAAA`: The IP address. Use `[remote_addr]` to submit the IPv4 address of the request. Required.
 
-            With the exception of A and AAAA records, this field accepts
-            a trailing period.
-          example: 12.34.56.78
+            `NS`: The name server. Must be a valid domain. Required.
+
+            `MX`: The mail server. Must be a valid domain. Required.
+
+            `CNAME`: The alias. Must be a valid domain. Required.
+
+            `TXT`: The value. Required.
+
+            `SRV`: The target domain or subdomain. If a subdomain is entered, it is automatically used with the Domain. To configure for a different domain, enter a valid FQDN. For example, the value `www` with a Domain for `example.com` results in a target set to `www.example.com`, whereas the value `sample.com` results in a target set to `sample.com`. Required.
+
+            `CAA`: The value. For `issue` or `issuewild` tags, the domain of your certificate issuer. For the `iodef` tag, a contact or submission URL (http or mailto).
+
+            `PTR`: See our guide on how to [Configure Your Linode for Reverse DNS (rDNS)](/docs/guides/configure-your-linode-for-reverse-dns).
+
+            With the exception of A, AAAA, and CAA records, this field accepts a trailing period.
+          example: 192.0.2.0
           x-linode-cli-display: 4
         priority:
           type: integer
           minimum: 0
           maximum: 255
           description: >
-            The priority of the target host. Lower values are preferred.
+            The priority of the target host for this Record. Lower values are preferred. Only valid and required for SRV record requests.
           example: 50
           x-linode-cli-display: 6
         weight:
           type: integer
           description: >
-            The relative weight of this Record. Higher values are preferred.
+            The relative weight of this Record. Higher values are preferred. Only valid and required for SRV record requests.
           example: 50
           minimum: 0
           maximum: 65535
@@ -15914,7 +15941,7 @@ components:
         port:
           type: integer
           description: >
-            The port this Record points to.
+            The port this Record points to. Only valid and required for SRV record requests.
           example: 80
           minimum: 0
           maximum: 65535
@@ -15922,14 +15949,15 @@ components:
           type: string
           nullable: true
           description: >
-            The service this Record identified. Only valid for SRV records.
+            The name of the service. An underscore (_) is prepended and a period (.) is appended automatically to the submitted value for this property. Only valid and required for SRV record requests.
           example: null
         protocol:
           type: string
           nullable: true
           description: >
-            The protocol this Record's service communicates with. Only valid
-            for SRV records.
+            The protocol this Record's service communicates with. An underscore (_) is prepended
+            automatically to the submitted value for this property. Only valid
+            for SRV record requests.
           example: null
         ttl_sec:
           type: integer
@@ -15943,10 +15971,13 @@ components:
           x-linode-cli-display: 5
         tag:
           type: string
+          enum:
+          - issue
+          - issuewild
+          - iodef
           nullable: true
           description: >
-            The tag portion of a CAA record. It is invalid to set this on
-            other record types.
+            The tag portion of a CAA record. Only valid and required for CAA record requests.
           example: null
           x-linode-filterable: true
         created:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.1
 info:
-  version: 4.85.0
+  version: 4.86.0
 
   title: Linode API
   description: |

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9741,6 +9741,7 @@ paths:
             schema:
               type: object
               required:
+                - label
                 - rules
               properties:
                 label:
@@ -16439,8 +16440,7 @@ components:
           x-linode-filterable: true
           type: string
           description: >
-            The Firewall's label, for display purposes only. If no label is provided for a Firewall,
-            a default will be assigned.
+            The Firewall's label, for display purposes only.
 
             Firewall labels have the following constraints:
 
@@ -16448,6 +16448,7 @@ components:
               * May only consist of alphanumeric characters, dashes (`-`), underscores (`_`) or periods (`.`).
               * Cannot have two dashes (`--`), underscores (`__`) or periods (`..`) in a row.
               * Must be between 3 and 32 characters.
+              * Must be unique.
           example: firewall123
           minLength: 3
           maxLength: 32

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2625,7 +2625,11 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Domain'
+              required:
+              - domain
+              - type
+              allOf:
+              - $ref: '#/components/schemas/Domain'
       responses:
         '200':
           description: |
@@ -2653,7 +2657,8 @@ paths:
                     "status": "active",
                     "master_ips": ["127.0.0.1","255.255.255.1","123.123.123.7"],
                     "axfr_ips": ["44.55.66.77"],
-                    "display_group": "Example Display Group"
+                    "group": "Example Display Group",
+                    "tags": ["tag1","tag2"]
                 }' \
                 https://api.linode.com/v4/domains
         - lang: CLI
@@ -2750,7 +2755,8 @@ paths:
                   "status": "active",
                   "master_ips": ["127.0.0.1","255.255.255.1","123.123.123.7"],
                   "axfr_ips": ["44.55.66.77"],
-                  "display_group": "Example Display Group"
+                  "group": "Example Display Group",
+                  "tags": ["tag1","tag2"]
               }' \
               https://api.linode.com/v4/domains/123
       - lang: CLI
@@ -15771,10 +15777,6 @@ components:
         A domain zonefile in our DNS system.  You must own the domain name and
         tell your registrar to use Linode's nameservers in order for a domain
         in our system to be treated as authoritative.
-      required:
-      - id
-      - domain
-      - type
       properties:
         id:
           type: integer
@@ -15795,6 +15797,8 @@ components:
         domain:
           type: string
           pattern: ([a-zA-Z0-9-_]{1,63}\.)+([a-zA-Z]{2,3}\.)?([a-zA-Z]{2,16}|xn--[a-zA-Z0-9]+\.?)
+          minLength: 1
+          maxLength: 255
           description: >
             The domain this Domain represents. Domain labels cannot be longer than
             63 characters and must conform to [RFC1035](https://tools.ietf.org/html/rfc1035).
@@ -15818,6 +15822,7 @@ components:
           enum:
           - disabled
           - active
+          default: active
           description: >
             Used to control whether this Domain is currently being rendered.
           example: active
@@ -15844,11 +15849,16 @@ components:
           x-linode-cli-display: 5
         retry_sec:
           type: integer
-          description: >
+          default: 0
+          description: |
             The interval, in seconds, at which a failed refresh should be retried.
-            Valid values are 300, 3600, 7200, 14400, 28800, 57600,
-            86400, 172800, 345600, 604800, 1209600, and 2419200 - any other
-            value will be rounded to the nearest valid value.
+
+            * Valid values are
+            0, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.
+
+            * Any other value is rounded up to the nearest valid value.
+
+            * A value of 0 is equivalent to the default value of 14400.
           example: 300
         master_ips:
           type: array
@@ -15871,34 +15881,44 @@ components:
           example: []
         expire_sec:
           type: integer
-          description: >
+          default: 0
+          description: |
             The amount of time in seconds that may pass before this Domain is no longer
-            authoritative. Valid values are
-            300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600,
-            604800, 1209600, and 2419200 - any other value will be rounded to
-            the nearest valid value.
+            authoritative.
+
+            * Valid values are
+            0, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.
+
+            * Any other value is rounded up to the nearest valid value.
+
+            * A value of 0 is equivalent to the default value of 1209600.
           example: 300
         refresh_sec:
           type: integer
-          description: >
+          default: 0
+          description: |
             The amount of time in seconds before this Domain should be refreshed.
-            Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600,
-            604800, 1209600, and 2419200 - any other value will be rounded to
-            the nearest valid value.
+
+            * Valid values are
+            0, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.
+
+            * Any other value is rounded up to the nearest valid value.
+
+            * A value of 0 is equivalent to the default value of 14400.
           example: 300
         ttl_sec:
           type: integer
+          default: 0
           description: >
             "Time to Live" - the amount of time in seconds that this Domain's
             records may be cached by resolvers or other domain servers.
 
-            * Valid values are 0, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800,
-            345600, 604800, 1209600, and 2419200 - any other value will be
-            rounded to the nearest valid value.
+            * Valid values are
+            0, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.
 
-            * ttl_sec will default to 0 if no value is provided.
+            * Any other value is rounded up to the nearest valid value.
 
-            * A value of 0 is equivalent to a value of 86400.
+            * A value of 0 is equivalent to the default value of 86400.
           example: 300
         tags:
           x-linode-filterable: true

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -655,7 +655,7 @@ paths:
             https://api.linode.com/v4/account/entity-transfers
       - lang: CLI
         source: >
-          linode-cli account entity-transfers \
+          linode-cli entity-transfers \
             list
     post:
       x-linode-grant: unrestricted only
@@ -672,7 +672,18 @@ paths:
 
 
         When a transfer is [accepted](/docs/api/account/#entity-transfer-accept), the requested entities are moved to
-        the receiving account. A transfer can take up to three hours to complete once accepted. When a transfer is
+        the receiving account. Linode services will not experience interruptions due to the transfer process, but
+        please take note of the following:
+
+
+        - If any of the Linodes included in the request have Backups enabled, that data and associated costs will be
+        removed/cancelled.
+
+        - DNS records will not be transferred or updated. Please ensure that DNS records have been updated or
+        communicated to the recipient prior to the transfer.
+
+
+        A transfer can take up to three hours to complete once accepted. When a transfer is
         completed, billing for transferred entities ends for the sending account and begins for the receiving account.
 
 
@@ -740,8 +751,10 @@ paths:
             https://api.linode.com/v4/account/entity-transfers
       - lang: CLI
         source: >
-          linode-cli account entity-transfers \
-            create --linodes 111,222
+          linode-cli entity-transfers \
+            create \
+            --entities.linodes 111 \
+            --entities.linodes 222
   /account/entity-transfers/{token}:
     x-linode-cli-command: entity-transfers
     parameters:
@@ -786,7 +799,7 @@ paths:
             https://api.linode.com/v4/account/entity-transfers/123E4567-E89B-12D3-A456-426614174000
       - lang: CLI
         source: >
-          linode-cli account entity-transfers \
+          linode-cli entity-transfers \
             view 123E4567-E89B-12D3-A456-426614174000
     delete:
       x-linode-grant: unrestricted only
@@ -805,7 +818,7 @@ paths:
 
         This command can only be accessed by the unrestricted users of the account that created this transfer.
       operationId: deleteEntityTransfer
-      x-linode-cli-action: delete
+      x-linode-cli-action: cancel
       security:
       - personalAccessToken: []
       - oauth:
@@ -828,8 +841,8 @@ paths:
             https://api.linode.com/v4/account/entity-transfers/123E4567-E89B-12D3-A456-426614174000
       - lang: CLI
         source: >
-          linode-cli account entity-transfers \
-            delete 123E4567-E89B-12D3-A456-426614174000
+          linode-cli entity-transfers \
+            cancel 123E4567-E89B-12D3-A456-426614174000
   /account/entity-transfers/{token}/accept:
     x-linode-cli-command: entity-transfers
     parameters:
@@ -907,7 +920,7 @@ paths:
             https://api.linode.com/v4/account/entity-transfers/123E4567-E89B-12D3-A456-426614174000/accept
       - lang: CLI
         source: >
-          linode-cli account entity-transfers \
+          linode-cli entity-transfers \
             accept 123E4567-E89B-12D3-A456-426614174000
   /account/events:
     x-linode-cli-command: events
@@ -16059,7 +16072,15 @@ components:
             The token used to identify and accept or cancel this transfer.
           example: "123E4567-E89B-12D3-A456-426614174000"
         status:
+          x-linode-cli-display: 2
           x-linode-filterable: true
+          x-linode-cli-color:
+            accepted: yellow
+            cancelled: red
+            completed: green
+            failed: red
+            pending: yellow
+            stale: red
           type: string
           enum:
           - accepted
@@ -16073,7 +16094,7 @@ components:
 
 
             `accepted`: The transfer has been accepted by another user and is currently in progress.
-            Transfers can take several hours to complete.
+            Transfers can take up to 3 hours to complete.
 
 
             `cancelled`: The transfer has been cancelled by the sender.
@@ -16104,12 +16125,14 @@ components:
             When this transfer was last updated.
           example: '2021-02-11T16:37:03'
         is_sender:
+          x-linode-cli-display: 4
           x-linode-filterable: true
           type: boolean
           description: >
             If the requesting account created this transfer.
           example: true
         expiry:
+          x-linode-cli-display: 3
           type: string
           format: date-time
           description: >
@@ -16121,6 +16144,7 @@ components:
             A collection of the entities to include in this transfer request, separated by type.
           properties:
             linodes:
+              x-linode-cli-display: 5
               type: array
               items:
                 type: integer


### PR DESCRIPTION
### Added

- The following endpoints for the new Service Transfer feature, which enables transfers of Linodes between customer accounts, have been added:
  - Service Transfers List ([GET /account/service-transfers](https://linode.com/docs/api/account/#service-transfers-list)). Returns a collection of all created and accepted Service Transfers.
  - Service Transfer Create ([POST /account/service-transfers](https://linode.com/docs/api/account/#service-transfer-create)). Creates a transfer request for the specified services. At this time, only Linodes can be transferred.
  - Service Transfer Cancel ([DELETE /account/service-transfers/{token}](https://linode.com/docs/api/account/#service-transfer-cancel)). Cancels the Service Transfer for the provided token.
  - Service Transfer View ([GET /account/service-transfers/{token}](https://linode.com/docs/api/account/#service-transfer-view)). Returns the details of the Service Transfer for the provided token.
  - Service Transfer Accept ([POST /account/service-transfers/{token}/accept](https://linode.com/docs/api/account/#service-transfer-accept)). Accept an Service Transfer for the provided token to receive the services included in the transfer to your account.

### Changed

- The following endpoints have been deprecated:
  - Entity Transfers List ([GET /account/entity-transfers](https://linode.com/docs/api/account/#entity-transfers-list)).
  - Entity Transfer Create ([POST /account/entity-transfers](https://linode.com/docs/api/account/#entity-transfer-create)).
  - Entity Transfer Cancel ([DELETE /account/entity-transfers/{token}](https://linode.com/docs/api/account/#entity-transfer-cancel)).
  - Entity Transfer View ([GET /account/entity-transfers/{token}](https://linode.com/docs/api/account/#entity-transfer-view)).
  - Entity Transfer Accept ([POST /account/entity-transfers/{token}/accept](https://linode.com/docs/api/account/#entity-transfer-accept)).

- The Firewall Create ([POST /networking/firewalls](https://linode.com/docs/api/networking/#firewall-create)) beta endpoint has been updated with the following:
  - The required `rules.inbound_policy` and `rules.outbound_policy` properties were added to allow controlling default behavior for inbound and outbound traffic, respectively.
  - The `rules.inbound.action` and `rules.outbound.action` properties were added to control traffic for individual rules. These properties are required for inbound and outbound rules and override the `rules.inbound_policy` and `rules.outbound_policy` properties, respectively.
  - Previously, `rules.inbound` was required. It is now optional.
  - The `rules.inbound.label`, `rules.inbound.description`, `rules.outbound.label`, and `rules.outbound.description` properties were added for organization and display purposes.
  - Previously, up to five active Firewalls could be assigned to a single Linode service. Now, only one active Firewall can be assigned to a single Linode service.

### Fixed

- A bug has been fixed that prevented correct filtering for the Service Transfers List ([GET /account/service-transfers](https://linode.com/docs/api/account/#service-transfers-list)) endpoint `is_sender` property.

- The Volume Attach ([POST /volumes/{volumeId}/attach](https://www.linode.com/docs/api/volumes/#volume-attach)) endpoint erroneously marked the `linode_id` property as nullable and required. This has been corrected to state that the property is optional and only accepts an integer .
