### PR TITLE
Fix `linode-cli nodebalancers config-rebuild` command

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11240,7 +11240,7 @@ paths:
                 properties:
                   nodes:
                     type: array
-                    description: >
+                    description: |
                       The NodeBalancer Node(s) that serve this port.
                       At least one Node is required per configured port.
 
@@ -11249,9 +11249,7 @@ paths:
                         * Current Nodes (identified by their ID) will be updated.
                         * New Nodes (included without an ID) will be created.
                     items:
-                      type: object
-                      allOf:
-                      - $ref: '#/components/schemas/NodeBalancerNode'
+                      $ref: '#/components/schemas/NodeBalancerNode'
       responses:
         '200':
           description: NodeBalancer created successfully.
@@ -11314,7 +11312,7 @@ paths:
             --proxy_protocol "v1" \
             --cipher_suite recommended \
             --nodes '{"address":"192.168.210.120:80","label":"node1","weight":50,"mode":"accept"}' \
-            --nodes  '{"address":"192.168.210.122:80","label":"node2","weight":50,"mode":"accept"}'
+            --nodes '{"address":"192.168.210.122:80","label":"node2","weight":50,"mode":"accept"}'
   /nodebalancers/{nodeBalancerId}/configs/{configId}/nodes:
     parameters:
     - name: nodeBalancerId

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11222,7 +11222,7 @@ paths:
         Rebuilds a NodeBalancer Config and its Nodes that you have
         permission to modify.
       operationId: rebuildNodeBalancerConfig
-      x-linode-cli-action: rebuild
+      x-linode-cli-action: config-rebuild
       security:
       - personalAccessToken: []
       - oauth:
@@ -11234,33 +11234,24 @@ paths:
         content:
           application/json:
             schema:
-              properties:
-                configs:
-                  type: array
-                  description: >
-                    Each config must have a unique port and at least one Node. Additionally:
-                      * Current Nodes excluded from the request body will be deleted.
-                      * Current Nodes (identified by their ID) will be updated.
-                      * New Nodes (included without an ID) will be created.
-                  items:
-                    allOf:
-                    - $ref: '#/components/schemas/NodeBalancerConfig'
-                    - type: object
-                      properties:
-                        nodes:
-                          type: array
-                          description: >
-                            The NodeBalancer Node(s) that serve this port.
-                            At least one Node is required per configured port.
+              allOf:
+              - $ref: "#/components/schemas/NodeBalancerConfig"
+              - type: object
+                properties:
+                  nodes:
+                    type: array
+                    description: >
+                      The NodeBalancer Node(s) that serve this port.
+                      At least one Node is required per configured port.
 
-                            Some considerations for Nodes when rebuilding a config:
-                              * Current Nodes excluded from the request body will be deleted.
-                              * Current Nodes (identified by their ID) will be updated.
-                              * New Nodes (included without an ID) will be created.
-                          items:
-                            type: object
-                            allOf:
-                            - $ref: '#/components/schemas/NodeBalancerNode'
+                      Some considerations for Nodes when rebuilding a config:
+                        * Current Nodes excluded from the request body will be deleted.
+                        * Current Nodes (identified by their ID) will be updated.
+                        * New Nodes (included without an ID) will be created.
+                    items:
+                      type: object
+                      allOf:
+                      - $ref: '#/components/schemas/NodeBalancerNode'
       responses:
         '200':
           description: NodeBalancer created successfully.
@@ -11291,15 +11282,14 @@ paths:
                 "cipher_suite": "recommended",
                 "nodes": [
                   {
-                    "id": 543231,
                     "address": "192.168.210.120:80",
-                    "label": "node54321",
+                    "label": "node1",
                     "weight": 50,
                     "mode": "accept"
                   },
                   {
                     "address": "192.168.210.122:81",
-                    "label": "thenewnode",
+                    "label": "node2",
                     "weight": 50,
                     "mode": "accept"
                   },
@@ -11322,7 +11312,9 @@ paths:
             --check_body "it works" \
             --check_passive true \
             --proxy_protocol "v1" \
-            --cipher_suite recommended
+            --cipher_suite recommended \
+            --nodes '{"address":"192.168.210.120:80","label":"node1","weight":50,"mode":"accept"}' \
+            --nodes  '{"address":"192.168.210.122:80","label":"node2","weight":50,"mode":"accept"}'
   /nodebalancers/{nodeBalancerId}/configs/{configId}/nodes:
     parameters:
     - name: nodeBalancerId


### PR DESCRIPTION
This is for linode/linode-cli#226

Looks like the spec for this endpoint was wrong, so the CLI didn't work.
This change fixes the spec to match what the endpoint wants, and in turn
fixes the CLI.