### PR TITLE
Changed columns for `linode-cli events list`

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -16603,6 +16603,7 @@ components:
           - host_reboot
           - image_delete
           - image_update
+          - image_upload
           - ipaddress_update
           - lassie_reboot
           - lish_boot
@@ -16701,14 +16702,13 @@ components:
           description: >
             The total duration in seconds that it takes for the Event to complete.
           example: 300.56
-          x-linode-cli-display: 10
+          x-linode-cli-display: 7
         entity:
           type: object
           readOnly: true
           description: >
             Detailed information about the Event's entity, including ID, type,
             label, and URL used to access it.
-          x-linode-cli-display: 4
           properties:
             id:
               type: integer
@@ -16738,6 +16738,7 @@ components:
                 The current label of this object. The label may reflect changes
                 that occur with this Event.
               example: Problem booting my Linode
+              x-linode-cli-display: 5
             type:
               type: string
               enum:
@@ -16781,7 +16782,6 @@ components:
           description: |
             Detailed information about the Event's secondary entity, which provides additional information
             for events such as, but not limited to, `linode_boot`, `linode_reboot`, `linode_create`, and `linode_clone` Event actions.
-          x-linode-cli-display: 5
           properties:
             id:
               type: string
@@ -16826,13 +16826,11 @@ components:
           readOnly: true
           description: If this Event has been read.
           example: true
-          x-linode-cli-display: 9
         seen:
           type: boolean
           readOnly: true
           description: If this Event has been seen.
           example: true
-          x-linode-cli-display: 8
         status:
           type: string
           readOnly: true
@@ -16843,7 +16841,7 @@ components:
           - notification
           - scheduled
           - started
-          x-linode-cli-display: 7
+          x-linode-cli-display: 8
           x-linode-cli-color:
             failed: red
             finished: green
@@ -16874,6 +16872,7 @@ components:
             information may include, but is not limited to, a more detailed
             representation of events which can help diagnose non-obvious failures.
           example: None
+          x-linode-cli-display: 9
     Firewall:
       type: object
       description: >


### PR DESCRIPTION
After looking through Events with the CLI, it seemed that many of the
columns were not super useful; for instance, `seen` and `read` are hard
to change via the CLI and are more relevant to Cloud, and `message`
isn't present at all.  `entity.label` is also absent, although it looks
like there were intentions to show it.

This change does the following:

 * Removes `seen` and `read` from default column display list
 * Adds `entity.label` and `message` to default column display list

New output looks like this:

```
┌───────────┬──────────┬─────────────────┬────────────────────────────────┬─────────────────────┬──────────┬──────────────┬───────────────────────┐
│ id        │ username │ action          │ label                          │ created             │ duration │ status       │ message               │
├───────────┼──────────┼─────────────────┼────────────────────────────────┼─────────────────────┼──────────┼──────────────┼───────────────────────┤
│ 162178765 │ wsmith   │ image_upload    │ test-image-2                   │ 2021-04-21T17:18:10 │ 4967     │ finished     │                       │
│ 162176559 │ wsmith   │ image_upload    │ test-image                     │ 2021-04-21T17:07:56 │ 59       │ failed       │ Upload window expired │
```