### PR TITLE
Fix `linode-cli account maintenance-list` action

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1198,7 +1198,7 @@ paths:
         source: >
           linode-cli account login-view 1234
   /account/maintenance:
-    x-linode-cli-command: maintenance
+    x-linode-cli-command: account
     get:
       x-linode-grant: read_only
       servers:


### PR DESCRIPTION
This is presently at `linode-cli maintenance maintenance-list`, which I
assume is an oversight.  This moves it to the documented command/action.
