### PR TITLE
fix: POST /images/upload response schema

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3602,7 +3602,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  upload_url:
+                  upload_to:
                     type: string
                     description: The URL to upload the Image to.
                   image:


### PR DESCRIPTION
This was reported as an error with the Linode CLI.

The response for POST /images/upload includes an "upload_to" field, not the documented "upload_url".  This change allowed
the CLI to call this operation without issue.
