### PR TITLE
Add contentEncoding and contentMediaType for Kubeconfig

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8272,6 +8272,8 @@ paths:
                     readOnly: true
                     description: >
                       The Base64-encoded Kubeconfig file for this Cluster.
+                    contentEncoding: base64
+                    contentMediaType: application/yaml
         default:
           $ref: '#/components/responses/ErrorResponse'
       x-code-samples:
@@ -15069,7 +15071,7 @@ paths:
       - Tags
       operationId: getTaggedObjects
       x-linode-cli-command: view
-      x-linode-cli-skip: true
+      #x-linode-cli-skip: true
       parameters:
       - $ref: '#/components/parameters/pageOffset'
       - $ref: '#/components/parameters/pageSize'


### PR DESCRIPTION
This is related to https://github.com/linode/linode-cli/issues/247

The kubeconfig returned from `GET /lke/clusters/{clusterId}/kubeconfig`
is a base64-encoded YAML config.  The OpenAPI standard now supports this
[with the standard JSON Schema fields](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#considerations-for-file-uploads).

This change notes the encoding of the `kubeconfig` field, which the CLI
may use to decode the base64 data and display the actual YAML for
convenience (see linked CLI PR below).
