### PR TITLE
Update /account/credit-card (deprecated endpoint)

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -566,7 +566,8 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreditCard'
+              allOf:
+              - $ref: '#/components/schemas/CreditCard'
       responses:
         '200':
           description: Credit Card updated.


### PR DESCRIPTION
this prevents the Gatsby build from breaking. Not sure if it makes sense to add it back in. I think it's okay, but would love a second opinion.