### PR TITLE
fix: Removed unavailable account maintenance enums

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -19337,9 +19337,7 @@ components:
           type: string
           enum:
           - pending
-          - ready
           - started
-          - completed
           description: >
             The maintenance status.
           example: started


### PR DESCRIPTION
The `ready` status is returned as `pending`, `completed` items are not currently returned by the API.