### PR TITLE
Fix linode-cli firewalls create

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -10407,7 +10407,11 @@ paths:
       - lang: CLI
         source: >
           linode-cli firewalls create \
-            --rules '{"inbound": [{"protocol": "TCP", "ports": "22, 80, 8080, 443", "addresses": {"ipv4": ["192.0.2.1", "192.0.2.0/24"], "ipv6": ["2001:DB8::/32"]}}]}' \
+            --label example-firewall \
+            --outbound_policy ACCEPT \
+            --inbound_policy DROP \
+            --rules.inbound '[{"protocol": "TCP", "ports": "22, 80, 8080, 443", "addresses": {"ipv4": ["192.0.2.1", "192.0.2.0/24"], "ipv6": ["2001:DB8::/32"]}, "action": "ACCEPT"}]' \
+            --rules.outbound '[{"protocol": "TCP", "ports": "49152-65535", "addresses": {"ipv4": ["192.0.2.0/24"],"ipv6": ["2001:DB8::/32"]}, "action": "DROP", "label": "outbound-rule123", "description": "An example outbound rule description."}]'
   /networking/firewalls/{firewallId}:
     parameters:
       - name: firewallId
@@ -17058,10 +17062,16 @@ components:
           properties:
             inbound:
               type: array
+              x-linode-cli-format: json
+              description: |
+                The inbound rules for the firewall, in JSON format.
               items:
                 $ref: '#/components/schemas/FirewallRuleConfig'
             outbound:
               type: array
+              x-linode-cli-format: json
+              description: |
+                The outbound rules for the firewall, in JSON format.
               items:
                 $ref: '#/components/schemas/FirewallRuleConfig'
             inbound_policy:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -17064,14 +17064,14 @@ components:
               type: array
               x-linode-cli-format: json
               description: |
-                The inbound rules for the firewall, in JSON format.
+                The inbound rules for the firewall, as a JSON array.
               items:
                 $ref: '#/components/schemas/FirewallRuleConfig'
             outbound:
               type: array
               x-linode-cli-format: json
               description: |
-                The outbound rules for the firewall, in JSON format.
+                The outbound rules for the firewall, as a JSON array.
               items:
                 $ref: '#/components/schemas/FirewallRuleConfig'
             inbound_policy:


### PR DESCRIPTION
This closes https://github.com/linode/linode-cli/issues/249

It looks like the CLI wanted every single element of a firewall to come
in as a separate flag, but inbound/outbound rules include lists of
objects, and the CLI doesn't really support those as flags on the
command line.  The docs suggested the entire rules object could be
provided as a JSON string, but I decided to meet in the middle and have
`--rules.outbound` and `--rules.inbound` accept JSON strings, and have
everything else be a separate flag.  Details are in the issue linked
above.
