### PR TITLE
bring docs in line with cli help output

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -10494,8 +10494,8 @@ paths:
         source: >
           linode-cli firewalls create \
             --label example-firewall \
-            --outbound_policy ACCEPT \
-            --inbound_policy DROP \
+            --rules.outbound_policy ACCEPT \
+            --rules.inbound_policy DROP \
             --rules.inbound '[{"protocol": "TCP", "ports": "22, 80, 8080, 443", "addresses": {"ipv4": ["192.0.2.1", "192.0.2.0/24"], "ipv6": ["2001:DB8::/32"]}, "action": "ACCEPT"}]' \
             --rules.outbound '[{"protocol": "TCP", "ports": "49152-65535", "addresses": {"ipv4": ["192.0.2.0/24"],"ipv6": ["2001:DB8::/32"]}, "action": "DROP", "label": "outbound-rule123", "description": "An example outbound rule description."}]'
   /networking/firewalls/{firewallId}:


### PR DESCRIPTION
the docs at https://www.linode.com/docs/api/networking/#firewall-create are a bit out of sync with the recently updated CLI help output.

docs:

```
linode-cli firewalls create \
  --label example-firewall \
  --outbound_policy ACCEPT \
  --inbound_policy DROP \
  --rules.inbound '[{"protocol": "TCP", "ports": "22, 80, 8080, 443", "addresses": {"ipv4": ["192.0.2.1", "192.0.2.0/24"], "ipv6": ["2001:DB8::/32"]}, "action": "ACCEPT"}]' \
  --rules.outbound '[{"protocol": "TCP", "ports": "49152-65535", "addresses": {"ipv4": ["192.0.2.0/24"],"ipv6": ["2001:DB8::/32"]}, "action": "DROP", "label": "outbound-rule123", "description": "An example outbound rule description."}]'
```

cli-help:

```
$ linode-cli firewalls create --help
linode-cli firewalls create
Firewall Create

Arguments:
  --label: (required) The Firewall's label, for display purposes only.
  --rules.inbound: The inbound rules for the firewall, as a JSON array.
  --rules.outbound: The outbound rules for the firewall, as a JSON array.
  --rules.inbound_policy: The default behavior for inbound traffic.
  --rules.outbound_policy: The default behavior for outbound traffic.
  --tags: An array of tags applied to this object.
```

This commit brings the docs into line with the cli help output.