### PR TITLE
x linode cli allowed defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,4 @@ Attribute | Location | Type | Supported By | Explanation
 `x-linode-cli-rows`| media type | array | linode-cli | A list of JSON paths where the CLI can find the value it should treat as table rows.  Only needed for irregular endpoints.
 `x-linode-cli-use-schema` | media type | schema or $ref | linode-cli | The schema the CLI should use when showing a row for this response.  Use with `x-linode-cli-rows`.
 `x-linode-cli-nested-list` | media type | string | linode-cli | The name of the property defined by this response body's schema that is a nested list.  Items in the list will be broken out into rows in the CLI's output.
+`x-linode-cli-allowed-defaults` | requestBody | list of string | linode-cli | A list of defaults this action should accept from the CLI.  Valid values are "region", "type", and "image"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4153,6 +4153,10 @@ paths:
       requestBody:
         description: The requested initial state of a new Linode.
         required: true
+        x-linode-cli-allowed-defaults:
+        - region
+        - image
+        - type
         content:
           application/json:
             schema:
@@ -4870,6 +4874,9 @@ paths:
       requestBody:
         description: The requested state your Linode will be cloned into.
         required: true
+        x-linode-cli-allowed-defaults:
+        - region
+        - type
         content:
           application/json:
             schema:
@@ -7405,6 +7412,8 @@ paths:
         are ready.
       requestBody:
         description: Configuration for the Kubernetes cluster
+        x-linode-cli-allowed-defaults:
+        - region
         content:
           application/json:
             schema:
@@ -11192,6 +11201,8 @@ paths:
       requestBody:
         description: Information about the NodeBalancer to create.
         required: true
+        x-linode-cli-allowed-defaults:
+        - region
         content:
           application/json:
             schema:
@@ -15190,6 +15201,8 @@ paths:
       requestBody:
         description: The requested initial state of a new Volume.
         required: true
+        x-linode-cli-allowed-defaults:
+        - region
         content:
           application/json:
             schema:


### PR DESCRIPTION
- Bump version to 4.101.0
- Add missing defaults
- Include accepted defaults for CLI actions
