### PR TITLE
Fix typo in openapi yaml for fullvirt

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -18800,7 +18800,7 @@ components:
             * `paravirt` is suitable for most cases. Linodes running in paravirt mode
               share some qualities with the host, ultimately making it run faster since
               there is less transition between it and the host.
-            * `full_virt` affords more customization, but is slower because 100% of the VM
+            * `fullvirt` affords more customization, but is slower because 100% of the VM
               is virtualized.
           enum:
           - paravirt


### PR DESCRIPTION
The term is "fullvirt" not "full_virt" making everthing consistent