### PR TITLE
bug: Fix linode-cli image-upload plugin

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3860,7 +3860,6 @@ paths:
 
         - To initiate and complete and upload in a single step, see our guide on how to [Upload an Image](/docs/products/tools/images/guides/upload-an-image/) using Cloud Manager or the Linode CLI.
       x-linode-cli-action: upload
-      x-linode-cli-skip: true
       security:
       - personalAccessToken: []
       - oauth:


### PR DESCRIPTION
Closes linode/linode-cli#264

In 1b984f6, we removed the
`linode-cli images upload` command from the Linode CLI in favor of using
the `linode-cli image-upload` plugin, which is a much better way to
accomplish the same thing.  However, as it turns out, the plugin [relies
on that CLI operations to upload an image](https://github.com/linode/linode-cli/blob/abda241415d5805ee17f1697494a013d408d30ca/linodecli/plugins/image-upload.py#L110),
so removing the operation broke the plugin.

This change reintroduces the CLI `images upload` CLI operation.  If we'd
like to remove it in the future, I can look into reworking the plugin to
not require it (although generally CLI plugins use normal CLI operations
to make API calls, so it would take a little bit of effort to set that
up).