### PR TITLE
bug: Fixed CLI example for `firewalls rules-update` action

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11092,8 +11092,8 @@ paths:
       - lang: CLI
         source: >
           linode-cli firewalls rules-update 123 \
-            --inbound '[{"protocol": "TCP", "ports": "22, 80, 8080, 443", "addresses": {"ipv4": ["192.0.2.1", "192.0.2.0/24"], "ipv6": ["2001:DB8::/32"]}}]' \
-            --outbound '[{"protocol": "TCP", "ports": "49152-65535", "addresses": {"ipv4": ["192.0.2.1", "192.0.2.0/24"], "ipv6": ["2001:DB8::/32"]}}]'
+            --inbound '[{"action":"ACCEPT", "protocol": "TCP", "ports": "22, 80, 8080, 443", "addresses": {"ipv4": ["192.0.2.1/32", "192.0.2.0/24"], "ipv6": ["2001:DB8::/32"]}}]' \
+            --outbound '[{"action":"DROP","protocol": "TCP", "ports": "49152-65535", "addresses": {"ipv4": ["192.0.2.1/32", "192.0.2.0/24"], "ipv6": ["2001:DB8::/32"]}}]'
   /networking/vlans:
     x-linode-cli-command: vlans
     get:


### PR DESCRIPTION
Closes https://github.com/linode/linode-cli/issues/254

I was taking a pass at open CLI issues and found that while this one was
fixed upstream, the example it referenced in the docs was still not
working.  With a little tinkering, I believe this fixes it.

I'm not sure if the values I put in here actually make sense for a real
use-case, I just picked valid values.  Please modify them if you think
they're silly or could be more meaningful.
