### PR TITLE
bug: Fixed CLI `vlans list` operation

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11099,7 +11099,6 @@ paths:
     get:
       x-linode-grant: read_only
       servers:
-      - url: https://api.linode.com/v4
       - url: https://api.linode.com/v4beta
       parameters:
       - $ref: '#/components/parameters/pageOffset'


### PR DESCRIPTION
It looks like the GET /networking/vlans endpoint is currently only
available in the /v4beta API, and not /v4.  As such, right now a call to
`linode-cli vlans list` returns a 404 message.

This change removes the normal `api.linode.com/v4` from this endpoint's
`servers` block, which will cause the CLI to use the `/v4beta` URL.
