### PR TITLE
bug: Add missing CLI commands/actions to operations

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -598,9 +598,11 @@ paths:
               --expiry_year 2025 \
               --cvv 111
   /account/entity-transfers:
+    x-linode-cli-command: account
     get:
       deprecated: true
       x-linode-grant: unrestricted only
+      x-linode-cli-action: entity-transfers-list
       parameters:
       - $ref: '#/components/parameters/pageOffset'
       - $ref: '#/components/parameters/pageSize'
@@ -639,6 +641,7 @@ paths:
     post:
       deprecated: true
       x-linode-grant: unrestricted only
+      x-linode-cli-action: entity-transfer-create
       tags:
       - Account
       summary: Entity Transfer Create
@@ -685,6 +688,7 @@ paths:
             }' \
             https://api.linode.com/v4/account/entity-transfers
   /account/entity-transfers/{token}:
+    x-linode-cli-command: account
     parameters:
       - name: token
         in: path
@@ -696,6 +700,7 @@ paths:
     get:
       deprecated: true
       x-linode-grant: unrestricted only
+      x-linode-cli-action: entity-transfer-view
       tags:
       - Account
       summary: Entity Transfer View
@@ -724,6 +729,7 @@ paths:
     delete:
       deprecated: true
       x-linode-grant: unrestricted only
+      x-linode-cli-action: entity-transfer-cancel
       tags:
       - Account
       summary: Entity Transfer Cancel
@@ -751,6 +757,7 @@ paths:
             -X DELETE \
             https://api.linode.com/v4/account/entity-transfers/123E4567-E89B-12D3-A456-426614174000
   /account/entity-transfers/{token}/accept:
+    x-linode-cli-command: account
     parameters:
       - name: token
         in: path
@@ -762,6 +769,7 @@ paths:
     post:
       deprecated: true
       x-linode-grant: unrestricted only
+      x-linode-cli-action: entity-transfer-accept
       tags:
       - Account
       summary: Entity Transfer Accept
@@ -3344,6 +3352,7 @@ paths:
         source: >
           linode-cli domains zone-file 123
   /domains/import:
+    x-linode-cli-command: domains
     post:
       x-linode-grant: read_write
       x-linode-cli-command: domains

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -598,11 +598,10 @@ paths:
               --expiry_year 2025 \
               --cvv 111
   /account/entity-transfers:
-    x-linode-cli-command: account
     get:
       deprecated: true
       x-linode-grant: unrestricted only
-      x-linode-cli-action: entity-transfers-list
+      x-linode-cli-skip: true
       parameters:
       - $ref: '#/components/parameters/pageOffset'
       - $ref: '#/components/parameters/pageSize'
@@ -641,7 +640,7 @@ paths:
     post:
       deprecated: true
       x-linode-grant: unrestricted only
-      x-linode-cli-action: entity-transfer-create
+      x-linode-cli-skip: true
       tags:
       - Account
       summary: Entity Transfer Create
@@ -688,7 +687,6 @@ paths:
             }' \
             https://api.linode.com/v4/account/entity-transfers
   /account/entity-transfers/{token}:
-    x-linode-cli-command: account
     parameters:
       - name: token
         in: path
@@ -700,7 +698,7 @@ paths:
     get:
       deprecated: true
       x-linode-grant: unrestricted only
-      x-linode-cli-action: entity-transfer-view
+      x-linode-cli-skip: true
       tags:
       - Account
       summary: Entity Transfer View
@@ -729,7 +727,7 @@ paths:
     delete:
       deprecated: true
       x-linode-grant: unrestricted only
-      x-linode-cli-action: entity-transfer-cancel
+      x-linode-cli-skip: true
       tags:
       - Account
       summary: Entity Transfer Cancel
@@ -757,7 +755,6 @@ paths:
             -X DELETE \
             https://api.linode.com/v4/account/entity-transfers/123E4567-E89B-12D3-A456-426614174000
   /account/entity-transfers/{token}/accept:
-    x-linode-cli-command: account
     parameters:
       - name: token
         in: path
@@ -769,7 +766,7 @@ paths:
     post:
       deprecated: true
       x-linode-grant: unrestricted only
-      x-linode-cli-action: entity-transfer-accept
+      x-linode-cli-skip: true
       tags:
       - Account
       summary: Entity Transfer Accept


### PR DESCRIPTION
This is for the Linode CLI.

In the current CLI release, we see this:

```bash
wsmith@linode::linode-cli[master]$ linode-cli default --help
linode-cli default [ACTION]

Available actions:
┌──────────────────────┬────────────────────────┐
│ action               │ summary                │
├──────────────────────┼────────────────────────┤
│ getEntityTransfers   │ Entity Transfers List  │
│ createEntityTransfer │ Entity Transfer Create │
│ getEntityTransfer    │ Entity Transfer View   │
│ deleteEntityTransfer │ Entity Transfer Cancel │
│ acceptEntityTransfer │ Entity Transfer Accept │
│ import               │ Domain Import          │
└──────────────────────┴────────────────────────┘
```

These operations appear in "default" because they have no
`x-linode-cli-command` defined in the spec (so they fall into the
default command).  This isn't ideal.  Additionally, many of those
commands are using their operationId as their action since they lack a
`x-linode-cli-action` element.

This change adds a command and action to all of the above.
