### PR TITLE
fix obj pre-signed url expires max

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15906,7 +15906,7 @@ paths:
                 expires_in:
                   type: integer
                   minimum: 360
-                  maximum: 68400
+                  maximum: 86400
                   default: 3600
                   description: >
                     How long this signed URL will be valid for, in seconds.  If


### PR DESCRIPTION
Noticed when just reading the docs site; I would be very surprised if this was actually meant to be `68400`.

```
68400 sec = 19 hr
86400 sec = 24 hr
```