### PR TITLE
Added note regarding times being reported in UTC

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -335,6 +335,9 @@ info:
           ]
         }'
     ```
+    ## Time Values
+
+    All times returned by the API are in UTC, regardless of the timezone configured within your user's profile (see `timezone` property within [Profile View](/docs/api/profile/#profile-view__responses)).
 
     ## Rate Limiting
 


### PR DESCRIPTION
This PR adds a _Time Values_ section to main description. This mentions all times reported by the API are in UTC.