### PR TITLE
fix: Add PUT-specific status field for firewall update

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -13815,7 +13815,11 @@ paths:
                   $ref: '#/components/schemas/Firewall/properties/label'
                 status:
                   type: string
-                  description: The status to be applied to this Firewall.
+                  description: >
+                   The status to be applied to this Firewall.
+                    
+                    * When a Firewall is first created its status is `enabled`.
+                    * Use the [Delete Firewall](/docs/api/networking/#firewall-delete) endpoint to delete a Firewall.
                   enum:
                     - enabled
                     - disabled

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -13814,7 +13814,13 @@ paths:
                 label:
                   $ref: '#/components/schemas/Firewall/properties/label'
                 status:
-                  $ref: '#/components/schemas/Firewall/properties/status'
+                  type: string
+                  description: The status to be applied to this Firewall.
+                  enum:
+                    - enabled
+                    - disabled
+                  example: enabled
+                  x-linode-cli-display: 3
       responses:
         '200':
           description: Firewall updated successfully.


### PR DESCRIPTION
This change adds a specific status field for the `PUT /networking/firewalls/{firewallId}` endpoint. This is necessary as the `status` field can accept either a `disabled` or `enabled` status, but was previously hidden due to using the existing `status` component property. The existing `status` component property cannot be used as it specifies an enum for `deleted` and is read-only.

This issue currently prevents CLI users from disabling or enabling their Cloud Firewalls.

See: https://github.com/linode/linode-cli/issues/306

