### PR TITLE
fix: Make RDNS nullable and required on IP address update

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12884,7 +12884,19 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/IPAddress'
+              required:
+                - rdns
+              type: object
+              properties:
+                rdns:
+                  type: string
+                  description: >
+                    The reverse DNS assigned to this address. For public IPv4 addresses,
+                    this will be set to a default value provided by Linode if not
+                    explicitly set.
+                  x-linode-cli-display: 4
+                  nullable: true
+                  example: test.example.org
       responses:
         '200':
           description: RDNS set successfully


### PR DESCRIPTION
This change makes the RDNS field nullable and required when calling the PUT `/networking/ips/{ipAddress}` endpoint. This brings the spec for this endpoint inline with the API implementation.

When `rdns` is explicitly set to `null` but is still included in the request, the API will set the RDNS address to default. If RDNS is not specified at all, the API reports that `rdns` is required.

See https://github.com/linode/linode-cli/issues/266