### PR TITLE
fix: Add `readOnly` to image status

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -21880,6 +21880,7 @@ components:
         status:
           x-linode-cli-display: 7
           type: string
+          readOnly: true
           enum:
           - creating
           - pending_upload


### PR DESCRIPTION
This change sets the `status` field of the `Image` component to read-only. This is necessary as the [Image PUT](https://www.linode.com/docs/api/images/#image-update) endpoint currently displays `status` as updateable while the API returns `status is not an editable field.`