### PR TITLE
fix: Correct enum for `replication_commit_type`

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -20269,11 +20269,11 @@ components:
         replication_commit_type:
           type: string
           enum:
-          - on
-          - local
-          - remote_write
-          - remote_apply
-          - off
+          - 'on'
+          - 'local'
+          - 'remote_write'
+          - 'remote_apply'
+          - 'off'
           default: local
           example: local
           description: |


### PR DESCRIPTION
This change corrects an improperly parsed enum in the `DatabasePostgreSQL` component. Currently, the `on` and `off` enums are parsed as `true` and `false` which can cause some confusion about which inputs are valid:

![image](https://user-images.githubusercontent.com/26882005/194112371-68bb444c-8fa1-47cb-91ee-8d2a6e5ef3e9.png)

This change ensures that these enums are properly treated as strings.