### PR TITLE
Add CAA record target validation

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -20934,7 +20934,10 @@ components:
             target set to `sample.com`. Required.
 
             `CAA`: The value. For `issue` or `issuewild` tags, the domain of your certificate issuer. For the `iodef`
-            tag, a contact or submission URL (http or mailto).
+            tag, a contact or submission URL (domain, http, https, or mailto). Requirements depend on the tag for this record:
+              * `issue`: The domain of your certificate issuer. Must be a valid domain.
+              * `issuewild`: Must begin with `*`.
+              * `iodef`: Must be either (1) a valid domain, (2) a valid domain prepended with `http://` or `https://`, or (3) a valid email address prepended with `mailto:`.
 
             `PTR`: See our guide on how to [Configure Your Linode for Reverse DNS
             (rDNS)](/docs/guides/configure-your-linode-for-reverse-dns).


### PR DESCRIPTION
Validation requirements for domain CAA records added to `target` description for DomainRecord schema