### PR TITLE
IPv4 Sharing Configure => IP Addresses Share

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -13087,8 +13087,8 @@ paths:
     x-linode-cli-command: networking
     post:
       servers:
-      - url: https://api.linode.com/v4beta
       - url: https://api.linode.com/v4
+      - url: https://api.linode.com/v4beta
       x-linode-grant: read_write
       tags:
       - Networking
@@ -13096,15 +13096,9 @@ paths:
       description: |
         Configure shared IPs.
 
-        IP sharing allows IP address reassignment (also referred to as IP failover) from one Linode to another if
-        the primary Linode becomes unresponsive. This means that requests to the primary Linode's IP address can be
-        automatically rerouted to secondary Linodes at the configured shared IP addresses.
+        IP sharing allows IP address reassignment (also referred to as IP failover) from one Linode to another if the primary Linode becomes unresponsive. This means that requests to the primary Linode's IP address can be automatically rerouted to secondary Linodes at the configured shared IP addresses.
 
-        IP failover requires configuration of a failover service (such as [Keepalived](/docs/guides/ip-failover-keepalived))
-        within the internal system of the primary Linode.
-
-        **Note**: IPv6 range sharing has limited availability in certain regions. Please contact customer support for
-        assistance in enabling IPv6 range sharing for your Linodes.
+        IP failover requires configuration of a failover service (such as [Keepalived](/docs/guides/ip-failover-keepalived)) within the internal system of the primary Linode.
       operationId: shareIPs
       x-linode-cli-action: ip-share
       security:
@@ -13118,27 +13112,7 @@ paths:
         content:
           application/json:
             schema:
-              required:
-              - linode_id
-              - ips
-              properties:
-                linode_id:
-                  type: integer
-                  description: >
-                    The ID of the primary Linode that the addresses will be shared with.
-                  example: 123
-                ips:
-                  type: array
-                  items:
-                    type: string
-                    format: ip
-                  description: |
-                    A list of secondary Linode IPs to share with the primary Linode.
-                    * Can include both IPv4 addresses and IPv6 ranges (omit /56 and /64 prefix lengths)
-                    * Can include both private and public IPv4 addresses.
-                    * You must have access to all of these addresses and they must be in the same Region as the primary
-                    Linode.
-                    * Enter an empty array to remove all shared IP addresses.
+              $ref: '#/components/schemas/IPAddressesShareRequest'
       responses:
         '200':
           description: IP Address sharing successful.
@@ -13268,10 +13242,12 @@ paths:
       tags:
       - Networking
       summary: IPv4 Sharing Configure
-      description: >
-        Configure shared IPs.  A shared IP may be brought up on a Linode other
-        than the one it lists in its response.  This can be used to allow one
-        Linode to begin serving requests should another become unresponsive.
+      description: |
+        Configure shared IPs. This command is equivalent to **IP Addresses Share** ([POST /networking/ips/share](#ip-addresses-share)).
+
+        IP sharing allows IP address reassignment (also referred to as IP failover) from one Linode to another if the primary Linode becomes unresponsive. This means that requests to the primary Linode's IP address can be automatically rerouted to secondary Linodes at the configured shared IP addresses.
+
+        IP failover requires configuration of a failover service (such as [Keepalived](/docs/guides/ip-failover-keepalived)) within the internal system of the primary Linode.
       operationId: shareIPv4s
       x-linode-cli-skip: true
       security:
@@ -13285,28 +13261,7 @@ paths:
         content:
           application/json:
             schema:
-              required:
-              - linode_id
-              - ips
-              properties:
-                linode_id:
-                  type: integer
-                  description: >
-                    The ID of the Linode that the addresses will be shared with.
-                  example: 123
-                ips:
-                  type: array
-                  items:
-                    type: string
-                    format: ip
-                    example: 12.34.56.78
-                  description: >
-                    A list of IPs that will be shared with this Linode.  When
-                    this is finished, the given Linode will be able to bring up
-                    these addresses in addition to the Linodes that these
-                    addresses belong to.  You must have access to all of these
-                    addresses and they must be in the same Region as the
-                    Linode.
+              $ref: '#/components/schemas/IPAddressesShareRequest'
       responses:
         '200':
           description: Sharing configured successfully.
@@ -22169,6 +22124,33 @@ components:
           readOnly: true
           x-linode-filterable: true
           x-linode-cli-display: 5
+    IPAddressesShareRequest:
+      type: object
+      description: A request object IP Addresses Share (POST /networking/ips/share)
+      required:
+      - linode_id
+      - ips
+      properties:
+        linode_id:
+          type: integer
+          description: >
+            The ID of the primary Linode that the addresses will be shared with.
+          example: 123
+        ips:
+          type: array
+          items:
+            type: string
+            format: ip
+          example:
+          - "192.0.2.1"
+          - "2001:db8:3c4d:15::"
+          description: |
+            A list of secondary Linode IPs to share with the primary Linode.
+            * Can include both IPv4 addresses and IPv6 ranges (omit /56 and /64 prefix lengths)
+            * Can include both private and public IPv4 addresses.
+            * You must have access to all of these addresses and they must be in the same Region as the primary
+            Linode.
+            * Enter an empty array to remove all shared IP addresses.
     IPAddressPrivate:
       type: object
       description: >

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -13134,7 +13134,7 @@ paths:
                   "2001:db8:3c4d:15::"
                 ]
               }' \
-              https://api.linode.com/v4beta/networking/ips/share
+              https://api.linode.com/v4/networking/ips/share
       - lang: CLI
         source: >
           linode-cli networking ip-share \
@@ -13279,7 +13279,8 @@ paths:
               -X POST -d '{
                 "linode_id": 123,
                 "ips": [
-                  "12.34.56.78"
+                  "192.0.2.1",
+                  "192.0.2.2"
                 ]
               }' \
               https://api.linode.com/v4/networking/ipv4/share
@@ -13287,7 +13288,8 @@ paths:
         source: >
           linode-cli networking ip-share \
             --linode_id 123 \
-            --ips 12.34.56.78
+            --ips 192.0.2.1 \
+            --ips 192.0.2.2
   /networking/ipv6/pools:
     x-linode-cli-command: networking
     get:


### PR DESCRIPTION
Updates IPv4 Sharing Configure (POST /networking/ipv4/share) description to reference IP Addresses Share (POST /networking/ips/share).

Updates request bodies for both to point to the same IPAddressesShareRequest schema.

Takes IP Addresses Share out of beta.