### PR TITLE
new: Add aliases for `x-linode-cli-action` actions

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -857,7 +857,9 @@ paths:
          actions taken on your Account from the last 90 days.
          The Events returned depend on your grants.
       operationId: getEvents
-      x-linode-cli-action: list
+      x-linode-cli-action:
+        - list
+        - ls
       security:
       - personalAccessToken: []
       - oauth:
@@ -1690,7 +1692,9 @@ paths:
       description: |
         Returns a paginated list of Payment Methods for this Account.
       operationId: getPaymentMethods
-      x-linode-cli-action: list
+      x-linode-cli-action:
+        - list
+        - ls
       security:
         - personalAccessToken: []
         - oauth:
@@ -1866,7 +1870,9 @@ paths:
         ([POST /account/payment-methods/{paymentMethodId}/make-default](/docs/api/account/#payment-method-make-default))
         endpoint.
       operationId: deletePaymentMethod
-      x-linode-cli-action: delete
+      x-linode-cli-action:
+        - delete
+        - rm
       security:
         - personalAccessToken: []
         - oauth:
@@ -2270,7 +2276,9 @@ paths:
 
         This command can only be accessed by the unrestricted users of an account.
       operationId: getServiceTransfers
-      x-linode-cli-action: list
+      x-linode-cli-action:
+        - list
+        - ls
       security:
       - personalAccessToken: []
       - oauth:
@@ -2723,7 +2731,9 @@ paths:
 
         Users may access all or part of your Account based on their restricted status and grants.  An unrestricted User may access everything on the account, whereas restricted User may only access entities or perform actions they've been given specific grants to.
       operationId: getUsers
-      x-linode-cli-action: list
+      x-linode-cli-action:
+        - list
+        - ls
       security:
       - personalAccessToken: []
       - oauth:
@@ -2914,7 +2924,9 @@ paths:
 
         This command can only be accessed by the unrestricted users of an account.
       operationId: deleteUser
-      x-linode-cli-action: delete
+      x-linode-cli-action:
+        - delete
+        - rm
       security:
       - personalAccessToken: []
       - oauth:
@@ -3189,7 +3201,9 @@ paths:
       servers:
       - url: https://api.linode.com/v4
       - url: https://api.linode.com/v4beta
-      x-linode-cli-action: list
+      x-linode-cli-action:
+        - list
+        - ls
       x-linode-grant: read_only
       parameters:
       - $ref: '#/components/parameters/pageOffset'
@@ -5697,7 +5711,9 @@ paths:
         Manager.  Linode is not a registrar, and in order for these to work you
         must own the domains and point your registrar at Linode's nameservers.
       operationId: getDomains
-      x-linode-cli-action: list
+      x-linode-cli-action:
+        - list
+        - ls
       security:
       - personalAccessToken: []
       - oauth:
@@ -5901,7 +5917,9 @@ paths:
         from Linode's nameservers shortly after this operation completes. This
         also deletes all associated Domain Records.
       operationId: deleteDomain
-      x-linode-cli-action: delete
+      x-linode-cli-action:
+        - delete
+        - rm
       security:
       - personalAccessToken: []
       - oauth:
@@ -6377,7 +6395,9 @@ paths:
         * To view only public Images, call this endpoint with or without authentication. To view private Images as well, call this endpoint with authentication.
       x-linode-redoc-load-ids: true
       operationId: getImages
-      x-linode-cli-action: list
+      x-linode-cli-action:
+        - list
+        - ls
       security:
       - personalAccessToken: []
       - oauth:
@@ -6691,7 +6711,9 @@ paths:
 
         **Deleting an Image is a destructive action and cannot be undone.**
       operationId: deleteImage
-      x-linode-cli-action: delete
+      x-linode-cli-action:
+        - delete
+        - rm
       security:
       - personalAccessToken: []
       - oauth:
@@ -6727,7 +6749,9 @@ paths:
       tags:
       - Linode Instances
       operationId: getLinodeInstances
-      x-linode-cli-action: list
+      x-linode-cli-action:
+        - list
+        - ls
       security:
       - personalAccessToken: []
       - oauth:
@@ -7113,7 +7137,9 @@ paths:
 
         Linodes that are in the process of [cloning](/docs/api/linode-instances/#linode-clone) or [backup restoration](/docs/api/linode-instances/#backup-restore) cannot be deleted.
       operationId: deleteLinodeInstance
-      x-linode-cli-action: delete
+      x-linode-cli-action:
+        - delete
+        - rm
       security:
       - personalAccessToken: []
       - oauth:
@@ -8774,7 +8800,9 @@ paths:
       description: |
         Lists available Kernels.
       operationId: getKernels
-      x-linode-cli-action: list
+      x-linode-cli-action:
+        - list
+        - ls
       responses:
         '200':
           description: Returns an array of Kernels.
@@ -9732,7 +9760,9 @@ paths:
 
         For more information on StackScripts, please read our [StackScripts guides](/docs/platform/stackscripts/).
       operationId: getStackScripts
-      x-linode-cli-action: list
+      x-linode-cli-action:
+        - list
+        - ls
       security:
       - personalAccessToken: []
       - oauth:
@@ -9933,7 +9963,9 @@ paths:
       description: >
         Deletes a private StackScript you have permission to `read_write`. You cannot delete a public StackScript.
       operationId: deleteStackScript
-      x-linode-cli-action: delete
+      x-linode-cli-action:
+        - delete
+        - rm
       security:
       - personalAccessToken: []
       - oauth:
@@ -11175,7 +11207,9 @@ paths:
         to. Longview Client is used to monitor stats on your Linode
         with the help of the Longview Client application.
       operationId: getLongviewClients
-      x-linode-cli-action: list
+      x-linode-cli-action:
+        - list
+        - ls
       security:
       - personalAccessToken: []
       - oauth:
@@ -11351,7 +11385,9 @@ paths:
         This _does not_ uninstall the Longview Client application for your
         Linode - you must do that manually.
       operationId: deleteLongviewClient
-      x-linode-cli-action: delete
+      x-linode-cli-action:
+        - delete
+        - rm
       security:
       - personalAccessToken: []
       - oauth:
@@ -13520,7 +13556,9 @@ paths:
       description: |
         Returns a paginated list of accessible Firewalls.
       operationId: getFirewalls
-      x-linode-cli-action: list
+      x-linode-cli-action:
+        - list
+        - ls
       security:
       - personalAccessToken: []
       - oauth:
@@ -13827,7 +13865,9 @@ paths:
       - Networking
       summary: Firewall Delete
       operationId: deleteFirewall
-      x-linode-cli-action: delete
+      x-linode-cli-action:
+        - delete
+        - rm
       security:
       - personalAccessToken: []
       - oauth:
@@ -14235,7 +14275,9 @@ paths:
 
         **Note:** See our guide on [Getting Started with VLANs](/docs/guides/getting-started-with-vlans/) to view additional [limitations](/docs/guides/getting-started-with-vlans/#limitations).
       operationId: getVLANs
-      x-linode-cli-action: list
+      x-linode-cli-action:
+        - list
+        - ls
       security:
       - personalAccessToken: []
       - oauth:
@@ -14281,7 +14323,9 @@ paths:
       description: >
         Returns a paginated list of NodeBalancers you have access to.
       operationId: getNodeBalancers
-      x-linode-cli-action: list
+      x-linode-cli-action:
+        - list
+        - ls
       security:
       - personalAccessToken: []
       - oauth:
@@ -14558,7 +14602,9 @@ paths:
         changed or removed. Deleting a NodeBalancer will cause you to lose access
         to the IP Addresses assigned to this NodeBalancer.
       operationId: deleteNodeBalancer
-      x-linode-cli-action: delete
+      x-linode-cli-action:
+        - delete
+        - rm
       security:
       - personalAccessToken: []
       - oauth:
@@ -17405,7 +17451,9 @@ paths:
       description: >
         Returns a collection of security questions and their responses, if any, for your User Profile.
       operationId: getSecurityQuestions
-      x-linode-cli-action: list
+      x-linode-cli-action:
+        - list
+        - ls
       security:
       - personalAccessToken: []
       - oauth:
@@ -17507,7 +17555,9 @@ paths:
       description: >
         Returns a collection of SSH Keys you've added to your Profile.
       operationId: getSSHKeys
-      x-linode-cli-action: list
+      x-linode-cli-action:
+        - list
+        - ls
       security:
       - personalAccessToken: []
       - oauth:
@@ -17677,7 +17727,9 @@ paths:
         must be manually deleted on the Linode or Disk.
         This endpoint will only delete the key's association from your Profile.
       operationId: deleteSSHKey
-      x-linode-cli-action: delete
+      x-linode-cli-action:
+        - delete
+        - rm
       security:
       - personalAccessToken: []
       - oauth:
@@ -17961,7 +18013,9 @@ paths:
         available in all Regions.
       x-linode-redoc-load-ids: true
       operationId: getRegions
-      x-linode-cli-action: list
+      x-linode-cli-action:
+        - list
+        - ls
       responses:
         '200':
           description: Returns an array of Regions.
@@ -18041,7 +18095,9 @@ paths:
         This collection includes all Support Tickets generated on your Account,
         with open tickets returned first.
       operationId: getTickets
-      x-linode-cli-action: list
+      x-linode-cli-action:
+        - list
+        - ls
       security:
       - personalAccessToken: []
       - oauth:
@@ -18387,7 +18443,9 @@ paths:
 
         This endpoint returns a paginated list of Tags on your account.
       operationId: getTags
-      x-linode-cli-action: list
+      x-linode-cli-action:
+        - list
+        - ls
       security:
       - personalAccessToken: []
       - oauth:
@@ -18601,7 +18659,9 @@ paths:
       tags:
       - Tags
       operationId: deleteTag
-      x-linode-cli-action: delete
+      x-linode-cli-action:
+        - delete
+        - rm
       security:
       - personalAccessToken: []
       - oauth:
@@ -18628,7 +18688,9 @@ paths:
       tags:
       - Volumes
       operationId: getVolumes
-      x-linode-cli-action: list
+      x-linode-cli-action:
+        - list
+        - ls
       security:
       - personalAccessToken: []
       - oauth:
@@ -18890,7 +18952,9 @@ paths:
 
         * Volumes that are migrating cannot be deleted until the migration is finished.
       operationId: deleteVolume
-      x-linode-cli-action: delete
+      x-linode-cli-action:
+        - delete
+        - rm
       security:
       - personalAccessToken: []
       - oauth:


### PR DESCRIPTION
This change adds aliases for various actions defined in the `x-linode-cli-action` field.

See https://github.com/linode/linode-cli/pull/316