### PR TITLE
fix: Make NodeBalancer 'transfer' field readOnly

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -24493,6 +24493,7 @@ components:
           x-linode-cli-display: 6
         transfer:
           type: object
+          readOnly: true
           description: >
             Information about the amount of transfer this NodeBalancer has had
             so far this month.


### PR DESCRIPTION
This change makes the NodeBalancer `transfer` field read-only. This resolves an issue that caused `transfer` to appear as an updatable field in the API documentation.