### PR TITLE
Update Managed Databases Create and Update descriptions

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3291,7 +3291,10 @@ paths:
 
     #     The `allow_list` is used to control access to the Managed Database.
 
-    #     * IP addresses on this list can access the Managed Database. All other sources are blocked.
+    #     * IP addresses and ranges in this list can access the Managed Database. All other sources are blocked.
+
+    #     * If `0.0.0.0/0` is a value in this list, then all IP addresses can access the Managed Database.
+
     #     * Entering an empty array (`[]`) blocks all connections (both public and private) to the Managed Database.
 
     #     All Managed Databases include automatic, daily backups. Up to seven backups are automatically stored for each Managed Database, providing restore points for each day of the past week.
@@ -3470,11 +3473,14 @@ paths:
 
         Updating addresses in the `allow_list` overwrites any existing addresses.
 
-        * IP addresses on this list can access the Managed Database. All other sources are blocked.
+        * IP addresses and ranges on this list can access the Managed Database. All other sources are blocked.
+
+        * If `0.0.0.0/0` is a value in this list, then all IP addresses can access the Managed Database.
 
         * Entering an empty array (`[]`) blocks all connections (both public and private) to the Managed Database.
 
         * **Note**: Updates to the `allow_list` may take a short period of time to complete, making this command inappropriate for rapid successive updates to this property.
+
         All Managed Databases include automatic patch updates, which apply security patches and updates to the underlying operating system of the Managed MongoDB Database. The maintenance window for these updates is configured with the Managed Database's `updates` property.
 
         * If your database cluster is configured with a single node, you will experience downtime during this maintenance window when any updates occur. It's recommended that you adjust this window to match a time that will be the least disruptive for your application and users. You may also want to consider upgrading to a high availability plan to avoid any downtime due to maintenance.
@@ -4087,7 +4093,10 @@ paths:
 
         The `allow_list` is used to control access to the Managed Database.
 
-        * IP addresses on this list can access the Managed Database. All other sources are blocked.
+        * IP addresses and ranges in this list can access the Managed Database. All other sources are blocked.
+
+        * If `0.0.0.0/0` is a value in this list, then all IP addresses can access the Managed Database.
+
         * Entering an empty array (`[]`) blocks all connections (both public and private) to the Managed Database.
 
         All Managed Databases include automatic, daily backups. Up to seven backups are automatically stored for each Managed Database, providing restore points for each day of the past week.
@@ -4256,8 +4265,12 @@ paths:
 
         Updating addresses in the `allow_list` overwrites any existing addresses.
 
-        * IP addresses on this list can access the Managed Database. All other sources are blocked.
+        * IP addresses and ranges in this list can access the Managed Database. All other sources are blocked.
+
+        * If `0.0.0.0/0` is a value in this list, then all IP addresses can access the Managed Database.
+
         * Entering an empty array (`[]`) blocks all connections (both public and private) to the Managed Database.
+
         * **Note**: Updates to the `allow_list` may take a short period of time to complete, making this command inappropriate for rapid successive updates to this property.
 
         All Managed Databases include automatic patch updates, which apply security patches and updates to the underlying operating system of the Managed MySQL Database. The maintenance window for these updates is configured with the Managed Database's `updates` property.
@@ -4855,7 +4868,10 @@ paths:
 
         The `allow_list` is used to control access to the Managed Database.
 
-        * IP addresses on this list can access the Managed Database. All other sources are blocked.
+        * IP addresses and ranges in this list can access the Managed Database. All other sources are blocked.
+
+        * If `0.0.0.0/0` is a value in this list, then all IP addresses can access the Managed Database.
+
         * Entering an empty array (`[]`) blocks all connections (both public and private) to the Managed Database.
 
         All Managed Databases include automatic, daily backups. Up to seven backups are automatically stored for each Managed Database, providing restore points for each day of the past week.
@@ -5026,8 +5042,12 @@ paths:
 
         Updating addresses in the `allow_list` overwrites any existing addresses.
 
-        * IP addresses on this list can access the Managed Database. All other sources are blocked.
+        * IP addresses and ranges in this list can access the Managed Database. All other sources are blocked.
+
+        * If `0.0.0.0/0` is a value in this list, then all IP addresses can access the Managed Database.
+
         * Entering an empty array (`[]`) blocks all connections (both public and private) to the Managed Database.
+
         * **Note**: Updates to the `allow_list` may take a short period of time to complete, making this command inappropriate for rapid successive updates to this property.
 
         All Managed Databases include automatic patch updates, which apply security patches and updates to the underlying operating system of the Managed PostgreSQL Database. The maintenance window for these updates is configured with the Managed Database's `updates` property.
@@ -19890,6 +19910,8 @@ components:
             A list of IP addresses that can access the Managed Database. Each item can be a single IP address or a range in CIDR format.
 
             By default, this is an empty array (`[]`), which blocks all connections (both public and private) to the Managed Database.
+
+            If `0.0.0.0/0` is a value in this list, then all IP addresses can access the Managed Database.
           items:
             type: string
             format: ipv4/prefix_length


### PR DESCRIPTION
This update specifies the option to enter `0.0.0.0/0` as an `allow_list` item when creating or updating a Managed Database, which allows access for all IP addresses and ranges.

This option was previously available but undocumented here.