### PR TITLE
[Hotfix] v4.142.2

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.1
 info:
-  version: 4.142.1
+  version: 4.142.2
 
   title: Linode API
   description: |


### PR DESCRIPTION
This release corresponds to a backend hotfix release to fix a bug with CNAME record name validation. The only documentation update involved is a bump version to 4.142.2