### PR TITLE
[Hotfix] v4.142.3-patch1

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -10766,37 +10766,32 @@ paths:
               schema:
                 type: object
                 properties:
-                  data:
-                    type: object
+                  id:
+                    type: string
+                    readOnly: true
                     description: >
-                      The selected node in the cluster.
-                    properties:
-                      id:
-                        type: string
-                        readOnly: true
-                        description: >
-                          The Node's ID.
-                        example: "12345-6aa78910bc"
-                      instance_id:
-                        type: integer
-                        description: >
-                          The Linode's ID. If no Linode is currently provisioned for this Node, this is `null`.
-                        example: 123456
-                      status:
-                        type: string
-                        description: >
-                          The creation status of this Node. This status is distinct from this Node's readiness as a
-                          Kubernetes Node Object as determined by the command `kubectl get nodes`.
+                      The Node's ID.
+                    example: "12345-6aa78910bc"
+                  instance_id:
+                    type: integer
+                    description: >
+                      The Linode's ID. If no Linode is currently provisioned for this Node, this is `null`.
+                    example: 123456
+                  status:
+                    type: string
+                    description: >
+                      The creation status of this Node. This status is distinct from this Node's readiness as a
+                      Kubernetes Node Object as determined by the command `kubectl get nodes`.
 
 
-                          `not_ready` indicates that the Linode is still being created.
+                      `not_ready` indicates that the Linode is still being created.
 
 
-                          `ready` indicates that the Linode has successfully been created and is running Kubernetes software.
-                        enum:
-                        - ready
-                        - not_ready
-                        example: ready
+                      `ready` indicates that the Linode has successfully been created and is running Kubernetes software.
+                    enum:
+                    - ready
+                    - not_ready
+                    example: ready
         default:
           $ref: '#/components/responses/ErrorResponse'
       x-code-samples:


### PR DESCRIPTION
Fixed the response schema by removing the "data" property. This also enables a fix to the `linode-cli lke node-view` command, which was returning the following error:

```
KeyError: 'data'
```