### PR TITLE
Make `Event` `username` Nullable

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -21529,6 +21529,7 @@ components:
         username:
           type: string
           readOnly: true
+          nullable: true
           description: >
             The username of the User who caused the Event.
           example: exampleUser


### PR DESCRIPTION
The Cloud Manager team found that an Event returned from the events endpoint may return `null` for a `username` if it is a `linode_migrate_datacenter` event. 