### PR TITLE
new: Add automated CLI release trigger workflow

### DIFF
--- a/.github/workflows/cli-release-trigger.yml
+++ b/.github/workflows/cli-release-trigger.yml
@@ -4,7 +4,7 @@ on:
     types: [ published ]
 jobs:
   trigger-cli-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Generate App Installation Token
         id: generate_token

--- a/.github/workflows/cli-release-trigger.yml
+++ b/.github/workflows/cli-release-trigger.yml
@@ -1,0 +1,23 @@
+name: Trigger CLI Release
+on:
+  release:
+    types: [ published ]
+jobs:
+  trigger-cli-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate App Installation Token
+        id: generate_token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # pin@v1
+        with:
+          app_id: ${{ secrets.CLI_RELEASE_APP_ID }}
+          private_key: ${{ secrets.CLI_RELEASE_PRIVATE_KEY }}
+          repository: linode/linode-cli
+
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588 # pin@v2
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
+          repository: linode/linode-cli
+          event-type: cli-release
+          client-payload: '{"spec_version": "${{ github.event.release.tag_name }}"}'


### PR DESCRIPTION
This change adds a workflow that automatically triggers a corresponding release workflow in the [linode-cli](https://github.com/linode/linode-cli) repository on publish.

I'll provide some accompanying information internally 👍 

See https://github.com/linode/linode-cli/pull/396