### PR TITLE
cli: Add engine to CLI allowed defaults for database creation

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3334,6 +3334,7 @@ paths:
     #   requestBody:
     #     description: Information about the Managed MongoDB Database you are creating.
     #     x-linode-cli-allowed-defaults:
+    #     - engine
     #     - region
     #     - type
     #     required: true
@@ -4114,6 +4115,7 @@ paths:
       requestBody:
         description: Information about the Managed MySQL Database you are creating.
         x-linode-cli-allowed-defaults:
+        - engine
         - region
         - type
         required: true
@@ -4867,6 +4869,7 @@ paths:
       requestBody:
         description: Information about the Managed PostgreSQL Database you are creating.
         x-linode-cli-allowed-defaults:
+        - engine
         - region
         - type
         required: true


### PR DESCRIPTION
The DX team is adding `engine` as a newly allowed default value to linode-cli: https://github.com/linode/linode-cli/pull/427.

Updating the API docs before we merge the CLI change. 