### PR TITLE
ref: Added @ required for using --data-binary with file path

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1683,7 +1683,7 @@ paths:
           curl -H "Content-Type: image/png" \
               -H "Authorization: Bearer $TOKEN" \
               -X PUT \
-              --data-binary "/path/to/image"
+              --data-binary "@/path/to/image"
               https://api.linode.com/v4/account/oauth-clients/edc6790ea9db4d224c5c/thumbnail
   /account/payment-methods:
     x-linode-cli-command: payment-methods


### PR DESCRIPTION
When using `--data-binary` with curl `@` is required to designate a file path. This updates the example `PUT` request for oauth thumbnails.

From the man page:
```
       --data-binary <data>
              (HTTP) This posts data exactly as specified with no extra processing whatsoever.

              If you start the data with the letter @, the rest should be a filename.
```