### PR TITLE
[Hotfix] v4.153.3-patch1

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7807,7 +7807,11 @@ paths:
                       slaac:
                         $ref: '#/components/schemas/IPAddressV6Slaac'
                       global:
-                        $ref: '#/components/schemas/IPv6Range'
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/IPv6Range'
+                        description: |
+                          A list of IPv6 range objects assigned to this Linode.
         default:
           $ref: '#/components/responses/ErrorResponse'
       x-code-samples:


### PR DESCRIPTION
* `ipv6.global` corrected to an array of objects