### PR TITLE
bug: Fix CLI Override Schemas

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4792,10 +4792,12 @@ paths:
                   _split:
                     x-linode-cli-display: 2.5
                   engines:
+                    type: object
                     properties:
                        quantity:
                         x-linode-cli-display: 3
                        price:
+                         type: object
                          properties:
                            hourly:
                              x-linode-cli-display: 4
@@ -4858,10 +4860,12 @@ paths:
                   _split:
                     x-linode-cli-display: 2.5
                   engines:
+                    type: object
                     properties:
                        quantity:
                         x-linode-cli-display: 3
                        price:
+                         type: object
                          properties:
                            hourly:
                              x-linode-cli-display: 4


### PR DESCRIPTION
the override schemas for database/types are missing types and its causing a parsing issue in the CLI.
this will work with current CLI production and also the new CLI spec parsing coming soon