### PR TITLE
Mark `nodes` in nodebalancer config as not required

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -13780,8 +13780,6 @@ paths:
                     The port Config(s) to create for this NodeBalancer.
 
                     Each Config must have a unique port and at least one Node.
-                  required:
-                  - nodes
                   items:
                     type: object
                     description: A request object representing a NodeBalancer Config, including Nodes.


### PR DESCRIPTION
I tried an API call and it doesn't seem to be required.

```
curl -H "Content-Type: application/json" \
    -H "Authorization: Bearer $TOKEN" \
    -X POST -d '{"region": "us-central"}' https://api.linode.com/v4/nodebalancers
```