### PR TITLE
Managed Databases Backup Restore status update

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3786,7 +3786,7 @@ paths:
 
         Requires `read_write` access to the Database.
 
-        The Database must have an `active` status to perform this command.
+        The Database must have an `active`, `degraded`, or `failed` status to perform this command.
 
         **Note**: Restoring from a backup will erase all existing data on the database instance and replace it with backup data.
 
@@ -4542,7 +4542,7 @@ paths:
 
         Requires `read_write` access to the Database.
 
-        The Database must have an `active` status to perform this command.
+        The Database must have an `active`, `degraded`, or `failed` status to perform this command.
 
         **Note**: Restoring from a backup will erase all existing data on the database instance and replace it with backup data.
 


### PR DESCRIPTION
* Restoring Managed Databases has been enabled for failed and degraded clusters.