### PR TITLE
Add tags to NodeBalancer creation API request schema

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -13760,6 +13760,18 @@ paths:
                   $ref: '#/components/schemas/NodeBalancer/properties/label'
                 client_conn_throttle:
                   $ref: '#/components/schemas/NodeBalancer/properties/client_conn_throttle'
+                tags:
+                  x-linode-filterable: true
+                  description: >
+                    An array of Tags applied to this object. Tags are for organizational
+                    purposes only.
+                  type: array
+                  items:
+                    type: string
+                  example:
+                  - test
+                  - web-dev-team
+
                 configs:
                   type: array
                   description: |


### PR DESCRIPTION
The API allows adding `tags` attribute during the creation.

```
curl -H "Content-Type: application/json" \
    -H "Authorization: Bearer $LINODE_TOKEN" \
    -X POST -d '{
      "region": "us-central",
      "tags": ["123", "234"]
    }' https://api.linode.com/v4/nodebalancers
```