### PR TITLE
Volume Attach permissions fix

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -18373,7 +18373,7 @@ paths:
       description: >
         Attaches a Volume on your Account
         to an existing Linode on your Account. In order for this request to
-        complete successfully, your User must have `read_only` or `read_write`
+        complete successfully, your User must have `read_write`
         permission to the Volume and `read_write` permission to the Linode.
         Additionally, the Volume and Linode must be located in the same Region.
       tags:


### PR DESCRIPTION
Fixed permissions guidance for the Volume Attach section of the API site.