### PR TITLE
Release 4.161.0

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.1
 info:
-  version: 4.159.0
+  version: 4.161.0
 
   title: Linode API
   description: |

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -25420,14 +25420,20 @@ components:
       description: Compute instance availability information by [Type](/docs/api/linode-types/) and [Region](/docs/api/regions/).
       properties:
         region:
+          x-linode-cli-display: 1
+          x-linode-filterable: true
           type: string
           example: us-east
           description: The [Region](/docs/api/regions/) ID.
         plan:
+          x-linode-cli-display: 2
+          x-linode-filterable: true
           type: string
           example: gpu-rtx6000-1.1
           description: The compute instance [Type](/docs/api/linode-types/) ID.
         available:
+          x-linode-cli-display: 3
+          x-linode-filterable: true
           type: boolean
           example: true
           description: Whether the compute instance type is available in the region.


### PR DESCRIPTION
### Added

* You can now utilize cloud-init with our new [Metadata](https://www.linode.com/docs/products/compute/compute-instances/guides/metadata/) service to automatically configure and install software to compute instance!

  When using the [Linode Create](https://www.linode.com/docs/api/linode-instances/#linode-create) command, enter your [cloud-config](https://www.linode.com/docs/products/compute/compute-instances/guides/metadata-cloud-config/) data as a base64-encoded string to the new `metadata.user_data` property.

  Compatible [Images](https://www.linode.com/docs/api/images/#images-list) can be determined by looking for `cloud-init` under the new `capabilities` list.

  Compatible [Regions](https://www.linode.com/docs/api/regions/#regions-list) can be determined by looking for `Metadata` under the new `capabilities` list.

  **BETA** This feature is in beta and is currently limited to certain Regions and distributions. Please be aware that this feature may receive breaking updates in the future.

* **Regions Availability List** ([GET /regions/availability](https://www.linode.com/docs/api/regions/#regions-availability-list))

  **Region Availability View** ([GET /regions/{regionId}/availability](https://www.linode.com/docs/api/regions/#region-availability-view))
  * You can use these new commands to view the availability of select premium and GPU compute instance types according to Region, which are currently in high demand. These commands may be expanded to cover additional compute instance types in the future.

### Fixed

* Fixed a bug that prevented filtering results from [Managed Databases](https://www.linode.com/docs/api/databases/) endpoints.

* Fixed a bug that allowed Block Storage [Volume Detach](https://www.linode.com/docs/api/volumes/#volume-detach) requests for Volumes that were still attached to deleted Linodes. When a Linode is deleted, any attached Volumes are automatically scheduled to be detached.