### PR TITLE
new: Add subtables extension to `firewalls rules-update` command

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -13556,6 +13556,9 @@ paths:
         description: The Firewall Rules information to update.
         content:
           application/json:
+            x-linode-cli-subtables:
+            - inbound
+            - outbound
             schema:
               allOf:
               - $ref: '#/components/schemas/Firewall/properties/rules'


### PR DESCRIPTION
This change makes use of the `x-linode-cli-subtables` spec extension in the `PUT networking/firewalls/{id}/rules` response. This is an oversight from PR #843.