### PR TITLE
Release 4.162.0

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.1
 info:
-  version: 4.161.0
+  version: 4.162.0
 
   title: Linode API
   description: |


### PR DESCRIPTION
### Changed

* **Backup Restore** ([POST /linode/instances/{linodeId}/backups/{backupId}/restore](https://www.linode.com/docs/api/linode-instances/#backup-restore))
  * Now, certain distributions assign block devices using [UUIDs](https://en.wikipedia.org/wiki/Universally_unique_identifier). This causes a potential UUID collision issue when restoring a disk to the same Compute Instance without overwriting it. If you need access to files on both the original disk and the restored disk simultaneously (such as needing to copy files between them), we suggest either restoring the backup to a separate Compute Instance or [creating](https://www.linode.com/docs/api/linode-instances/#linode-create) a new Compute Instance with the desired `backup_id`.

* **Domain Record Create** ([POST /domains/{domainId}/records](https://www.linode.com/docs/api/domains/#domain-record-create))

  **Domain Record Update** ([PUT /domains/{domainId}/records/{recordId}](https://www.linode.com/docs/api/domains/#domain-record-update))
  * In accordance with the new [RFC 8659](https://www.rfc-editor.org/rfc/rfc8659.html), CAA records with the "issue" tag can now accept additional parameters when using these commands. New parameters are entered via the record's target, following the domain and separated with semicolons (`;`), for example: `www.example.com; foo=bar`

### Fixed

* Fixed a bug that caused a 222 response when creating or updating a Linode Configuration Profile with a VLAN "ipam_address" set to `null` or `""`. Now, `""` is returned for the "ipam_address" in this case for `vlan` purpose interfaces, and `null` is always returned for both the "ipam_address" and "label" for `public` purpose interfaces.

* **Firewall Create** ([POST /networking/firewalls](https://www.linode.com/docs/api/networking/#firewall-create))

  **Firewall Rule Update** ([PUT /networking/firewalls/{firewallId}/rules](https://www.linode.com/docs/api/networking/#firewall-rules-update))

  * This release includes documentation fixes regarding creating and updating Cloud Firewall rules with these commands. Previously, we stated that inbound and outbound rules _required_ defined `ports` except for the ICMP and IPENCAP protocols. However, `ports` is _optional_ for the TCP and UDP protocols and disallowed for the ICMP and IPENCAP protocols. Additionally, if `ports` is undefined, then all ports are affected by the Firewall rule.

  * These commands also now provide additional details for configuring Cloud Firewall rules, including instructions on how to apply rules to all IPv4 and IPv6 addresses.