### PR TITLE
Release 4.163.0

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.1
 info:
-  version: 4.162.0
+  version: 4.163.0
 
   title: Linode API
   description: |


### PR DESCRIPTION
### Changed

* Our new [Metadata](https://www.linode.com/docs/products/compute/compute-instances/guides/metadata/) service has completed its Beta phase and is now generally available to all customers!

  This new feature utilizes [cloud-config](https://www.linode.com/docs/products/compute/compute-instances/guides/metadata-cloud-config/) to automatically configure and install software to compute instances when using the following commands:
  * **Linode Create** ([POST /linode/instances](https://www.linode.com/docs/api/linode-instances/#linode-create))
  * **Linode Clone** ([POST /linode/instances/{linodeId}/clone](https://www.linode.com/docs/api/linode-instances/#linode-clone))
  * **Linode Rebuild** ([POST /linode/instances/{linodeId}/rebuild](https://www.linode.com/docs/api/linode-instances/#linode-rebuild))

### Fixed

* **IP Addresses Assign** ([POST /networking/ips/assign](https://www.linode.com/docs/api/networking/#ip-addresses-assign))
  * Fixed a bug that allowed [shared](https://www.linode.com/docs/api/networking/#ip-addresses-share) IP addresses to be swapped between Linodes with this command, resulting in a Linode with the same IP address listed twice. Now, an error is thrown when trying to swap shared IP addresses between two Linodes.
