### PR TITLE
Release v4.167.0

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.1
 info:
-  version: 4.166.0
+  version: 4.167.0
   title: Linode API
   license:
     name: Apache 2.0


### PR DESCRIPTION
### Changed

* Previously, running the [Linode View](https://www.linode.com/docs/api/linode-instances/#linode-view) operation on a suspended Linode returned a 400 response with a "This Linode has been suspended" error message. Now, running this operation on suspended Linodes returns the expected data with the new `billing_suspension` status.

### Fixed

* Fixed a bug that caused live migrations of Linode compute instances to fail if an assigned Firewall was established or updated during the migration. Now, the following Firewall operations return an error if assigned Linodes have any ongoing live migrations:
  * [Firewall Create](https://www.linode.com/docs/api/networking/#firewall-create)
  * [Firewall Update](https://www.linode.com/docs/api/networking/#firewall-update)
  * [Firewall Delete](https://www.linode.com/docs/api/networking/#firewall-delete)
  * [Firewall Device Create](https://www.linode.com/docs/api/networking/#firewall-device-create)
  * [Firewall Device Delete](https://www.linode.com/docs/api/networking/#firewall-device-delete)
  * [Firewall Rules Update](https://www.linode.com/docs/api/networking/#firewall-rules-update)