### PR TITLE
fix: Correct `GET /regions/{regionId}/availability` response documentation

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -17851,11 +17851,13 @@ paths:
       x-linode-cli-action: view-avail
       responses:
         '200':
-          description: A single Region object.
+          description: The availability data for a single Region.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RegionAvailability'
+                type: array
+                items:
+                  $ref: '#/components/schemas/RegionAvailability'
         default:
           $ref: '#/components/responses/ErrorResponse'
       x-code-samples:


### PR DESCRIPTION
This change updates the response documentation for the `GET /regions/{regionId}/availability` to properly reflect what is returned from the API.

This change has been tested against the Linode CLI and seems to work as expected.

Sample API response:

```json
[
  {
    "region": "us-east",
    "plan": "gpu-rtx6000-1.1",
    "available": false
  },
  {
    "region": "us-east",
    "plan": "gpu-rtx6000-2.1",
    "available": false
  }
]
```

Thanks in advance :slightly_smiling_face: 