### PR TITLE
new: Add cloud_init field for POST /images and POST /images/upload

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5974,7 +5974,7 @@ paths:
                   description: >
                     A detailed description of this Image.
                 cloud_init:
-                  type: bool
+                  type: boolean
                   description: Whether this Image supports cloud-init.
                   example: true
       responses:
@@ -6069,7 +6069,7 @@ paths:
                   description: Description for the uploaded Image.
                   example: This is an example image in the docs.
                 cloud_init:
-                  type: bool
+                  type: boolean
                   description: Whether the uploaded Image supports cloud-init.
                   example: true
       responses:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5973,6 +5973,10 @@ paths:
                   type: string
                   description: >
                     A detailed description of this Image.
+                cloud_init:
+                  type: bool
+                  description: Whether this Image supports cloud-init.
+                  example: true
       responses:
         '200':
           description: New private Image created successfully.
@@ -6064,6 +6068,10 @@ paths:
                   type: string
                   description: Description for the uploaded Image.
                   example: This is an example image in the docs.
+                cloud_init:
+                  type: bool
+                  description: Whether the uploaded Image supports cloud-init.
+                  example: true
       responses:
         '200':
           description: Image Upload object including the upload URL and Image object.


### PR DESCRIPTION
This PR adds documentation for the `cloud_init` field in the POST /images and POST /images/upload request bodies.

Related CLI PR: https://github.com/linode/linode-cli/pull/560