### PR TITLE
Fix `x-linode-cli-action` Style and Server URLs for Account Availability Endpoints 

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -539,7 +539,7 @@ paths:
             --tax_id ATU99999999 \
             --zip 19102
   /account/availability:
-    x-linode-cli-command: availability
+    x-linode-cli-command: account
     get:
       tags:
       - account
@@ -551,6 +551,8 @@ paths:
 
         *This endpoint is currently in **Beta**, and should not be used for production workloads.*
       operationId: getAvailability
+      servers:
+      - url: https://api.linode.com/v4beta
       security:
       - personalAccessToken: []
       - oauth:
@@ -581,9 +583,9 @@ paths:
               -H "Authorization: Bearer $TOKEN"
       - lang: CLI
         source: >
-          linode-cli account availability getAvailability
+          linode-cli account get-availability
   /account/availability/{id}:
-    x-linode-cli-command: availability
+    x-linode-cli-command: account
     parameters:
       - name: id
         in: path
@@ -600,6 +602,8 @@ paths:
 
         Only authorized Users can access this.
       operationId: getAccountAvailability
+      servers:
+      - url: https://api.linode.com/v4beta
       security:
       - personalAccessToken: []
       - oauth:
@@ -622,7 +626,7 @@ paths:
               -H "Authorization: Bearer $TOKEN"
       - lang: CLI
         source: >
-          linode-cli account availability getAccountAvailability us-east
+          linode-cli account get-account-availability us-east
   /account/betas:
     x-linode-cli-command: betas
     get:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -555,7 +555,7 @@ paths:
       - personalAccessToken: []
       - oauth:
         - account:read_only
-      x-linode-cli-action: getAvailability
+      x-linode-cli-action: get-availability
       x-linode-grant: read_only
       responses:
         '200':
@@ -604,7 +604,7 @@ paths:
       - personalAccessToken: []
       - oauth:
         - account:read_only
-      x-linode-cli-action: getAccountAvailability
+      x-linode-cli-action: get-account-availability
       x-linode-grant: read_only
       responses:
         '200':


### PR DESCRIPTION
- Update CLI actions from Camel case (e.g. `getAvailability`) to Hyphen-cased (e.g. `get-availability `)
- Fix server URL so the CLI will be able to target the endpoints in `v4beta` path.