### PR TITLE
VPC IP address GET updates

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8553,7 +8553,7 @@ paths:
       description: |
         Returns networking information for a single Linode.
 
-        **Note:** If the target Linode has several configurations that include a Virtual Private Cloud (VPC) interface, address information for all of VPCs will be listed in the response.
+        **Note:** If the target Linode has several configuration profiles that include a Virtual Private Cloud (VPC) interface, address information for all of VPCs will be listed in the response.
       operationId: getLinodeIPs
       x-linode-cli-action: ips-list
       security:
@@ -14607,79 +14607,6 @@ paths:
       - lang: CLI
         source: >
           linode-cli vlans list
-  /networking/vpcs/ips:
-    x-linode-cli-command: networking
-    get:
-      x-linode-grant: read_only
-      tags:
-      - Networking
-      summary: VPC IP Addresses List
-      description: |
-        Returns a paginated list of Virtual Private Client (VPC) IP addresses and address ranges on your account.
-
-        **Note:** If a Linode has several configurations that include a VPC interface, address information for all of them will be listed in the response.
-      operationId: getVPCIPs
-      x-linode-cli-action: vpcs-ips-list
-      security:
-      - personalAccessToken: []
-      - oauth:
-        - ips:read_only
-      responses:
-        '200':
-          description: A paginated list of VPC interface IP addresses.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/IPAddressesVPCListResponse'
-        default:
-          $ref: '#/components/responses/ErrorResponse'
-      x-code-samples:
-      - lang: Shell
-        source: >
-          curl -H "Authorization: Bearer $TOKEN" \
-              https://api.linode.com/v4/networking/vpcs/ips
-      - lang: CLI
-        source: >
-          linode-cli networking vpcs-ips-list
-  /networking/vpcs/{id}/ips:
-    parameters:
-    - name: id
-      in: path
-      required: true
-      description: The unique identifier for the target VPC interface.
-      schema:
-        type: integer
-    x-linode-cli-command: networking
-    get:
-      x-linode-grant: read_only
-      tags:
-      - Networking
-      summary: VPC IP Addresses View
-      description: |
-        Returns a paginated list of IP addresses for a single Virtual Private Client (VPC) interface.
-      operationId: viewVPCIPs
-      x-linode-cli-action: vpcs-ip-view
-      security:
-      - personalAccessToken: []
-      - oauth:
-        - ips:read_only
-      responses:
-        '200':
-          description: The IP addresses for the requested VPC interface.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/IPAddressesVPCListResponse'
-        default:
-          $ref: '#/components/responses/ErrorResponse'
-      x-code-samples:
-      - lang: Shell
-        source: >
-          curl -H "Authorization: Bearer $TOKEN" \
-              https://api.linode.com/v4/networking/vpcs/123/ips
-      - lang: CLI
-        source: >
-          linode-cli networking 123 vpcs-ip-view
   /nodebalancers:
     x-linode-cli-command: nodebalancers
     get:
@@ -19984,6 +19911,85 @@ paths:
             linode-cli vpcs update $vpcId \
               --description "A description of my VPC."
               --label cool-vpc
+  /vpcs/ips:
+    get:
+      x-linode-grant: read_only
+      tags:
+      - VPCs
+      summary: VPC IP Addresses List
+      servers:
+      - url: https://api.linode.com/v4
+      parameters:
+      - $ref: '#/components/parameters/pageOffset'
+      - $ref: '#/components/parameters/pageSize'
+      description: |
+        Returns a paginated list of VPC IP addresses and address ranges on your account.
+
+        **Note**: If a Linode has several configuration profiles that include a VPC interface, address information for all of them is listed in the response. Since VPCs can use the same address space, you may see duplicate IP addresses.
+      operationId: getVPCIPs
+      x-linode-cli-action:
+      - ip-list
+      - ip-ls
+      security:
+      - personalAccessToken: []
+      - oauth:
+        - ips:read_only
+      responses:
+        '200':
+          description: A paginated list of VPC interface IP addresses.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IPAddressesVPCListResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      x-code-samples:
+      - lang: Shell
+        source: >
+          curl -H "Authorization: Bearer $TOKEN" \
+              https://api.linode.com/v4/networking/vpcs/ips
+      - lang: CLI
+        source: >
+          linode-cli vpcs ip list
+  /vpcs/{vpcId}/ips:
+    parameters:
+    - $ref: '#/components/parameters/vpcId'
+    get:
+      tags:
+      - VPCs
+      summary: VPC IP Addresses View
+      servers:
+      - url: https://api.linode.com/v4
+      parameters:
+      - $ref: '#/components/parameters/pageOffset'
+      - $ref: '#/components/parameters/pageSize'
+      description: |
+        Returns a paginated list of IP addresses for a single VPC.
+      operationId: viewVPCIPs
+      x-linode-cli-action:
+        - ip-list
+        - ip-ls
+      security:
+      - personalAccessToken: []
+      - oauth:
+        - ips:read_only
+      responses:
+        '200':
+          description: The IP addresses for the requested VPC interface.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IPAddressesVPCListResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      x-code-samples:
+      - lang: Shell
+        source: >
+          curl -H "Authorization: Bearer $TOKEN" \
+              https://api.linode.com/v4/vpcs/123/ips
+      - lang: CLI
+        source: >
+          linode-cli vpcs ip-list 123
   /vpcs/{vpcId}/subnets:
     x-linode-cli-command: vpcs
     parameters:
@@ -23563,7 +23569,7 @@ components:
             * You must have access to all of these addresses and they must be in the same Region as the primary Linode.
             * Enter an empty array to remove all shared IP addresses.
     IPAddressesVPCListResponse:
-      description: The response data for the Virtual Private Client (VPC) IP Addresses List and View operations.
+      description: The response data for the VPC IP Addresses List and View operations.
       allOf:
         - $ref: '#/components/schemas/PaginationEnvelope'
         - type: object
@@ -23573,7 +23579,7 @@ components:
               items:
                 type: object
                 description: >
-                  A Virtual Private Client (VPC) IP address that exists in Linode's system, specific to the response for the VPC IP Addresses List command. Returned as an empty set for Linodes that are not part of a VPC.
+                  A VPC IP address that exists in Linode's system, specific to the response for the VPC IP Addresses List command. Returned as an empty set for Linodes that are not part of a VPC.
                 properties:
                   active:
                     type: boolean
@@ -23600,7 +23606,7 @@ components:
                   config_id:
                     type: integer
                     description: >
-                      The ID assigned to the Linode configuration where the VPC is included.
+                      The globally general entity identifier for the Linode configuration profile where the VPC is included.
                     example: 4567
                     readOnly: true
                     x-linode-filterable: true
@@ -23608,20 +23614,20 @@ components:
                     type: string
                     format: ip
                     description: >
-                      The default gateway for this address. Displayed as `null` if the VPC uses an `address_range`.
+                      The default gateway for the VPC subnet that the IP or IP range belongs to.
                     example: 192.0.2.1
                     nullable: true
                     readOnly: true
                   interface_id:
                     type: integer
                     description: >
-                      The unique ID assigned to the Linode's interface in the subnet associated with the VPC.
+                      The globally general API entity identifier for the Linode interface.
                     example: 2435
                     readOnly: true
                   linode_id:
                     type: integer
                     description: >
-                      The ID of the Linode the VPC interface currently belongs to. For IPv4 addresses in a VPC, this is the Linode that this address was assigned to at creation. You can move these addresses using the [/networking/ipv4/assign](https://www.linode.com/docs/api/networking/#ips-to-linodes-assign) endpoint.
+                      The identifier for the Linode the VPC interface currently belongs to.
                     example: 123
                     readOnly: true
                     x-linode-cli-display: 6
@@ -23659,7 +23665,7 @@ components:
                   vpc_id:
                     type: integer
                     description: >
-                      The unique ID assigned to the VPC interface.
+                      The unique globally general API entity identifier for the VPC.
                     example: 7654
                     readOnly: true
                     x-linode-filterable: true

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -23582,6 +23582,7 @@ components:
                       Returns `true` if the VPC interface is in use, meaning that the Linode was powered on using the `config_id` to which the interface belongs. Otherwise returns `false`.
                     example: true
                     readOnly: true
+                    x-linode-filterable: true
                   address:
                     type: string
                     format: ip
@@ -23590,7 +23591,6 @@ components:
                     example: 192.0.2.141
                     nullable: true
                     readOnly: true
-                    x-linode-filterable: true
                     x-linode-cli-display: 1
                   address_range:
                     type: string
@@ -23604,6 +23604,7 @@ components:
                       The ID assigned to the Linode configuration where the VPC is included.
                     example: 4567
                     readOnly: true
+                    x-linode-filterable: true
                   gateway:
                     type: string
                     format: ip
@@ -23625,6 +23626,7 @@ components:
                     example: 123
                     readOnly: true
                     x-linode-cli-display: 6
+                    x-linode-filterable: true
                   nat_1_1:
                     type: string
                     format: ip
@@ -23640,7 +23642,6 @@ components:
                     example: 24
                     nullable: true
                     readOnly: true
-                    x-linode-filterable: true
                   region:
                     type: string
                     description: >
@@ -23662,6 +23663,7 @@ components:
                       The unique ID assigned to the VPC interface.
                     example: 7654
                     readOnly: true
+                    x-linode-filterable: true
     IPAddressPrivate:
       type: object
       description: >

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -23655,6 +23655,12 @@ components:
                     readOnly: true
                     x-linode-filterable: true
                     x-linode-cli-display: 5
+                  subnet_id:
+                    type: integer
+                    nullable: false
+                    description: |
+                      The `id` of the VPC Subnet for this interface.
+                    example: 101
                   subnet_mask:
                     type: string
                     format: ip

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8599,7 +8599,7 @@ paths:
                         type: array
                         readOnly: true
                         items:
-                          $ref: '#/components/schemas/IPAddressVPC'
+                          $ref: '#/components/schemas/IPAddressesVPCListResponse'
                         description: >
                           A list of Virtual Private Cloud (VPC)-specific addresses or ranges for the Linode.
                       reserved:
@@ -14641,24 +14641,23 @@ paths:
       - lang: CLI
         source: >
           linode-cli networking vpcs-ips-list
-  /networking/vpcs/ips/{address}:
+  /networking/vpcs/{id}/ips:
     parameters:
-    - name: address
+    - name: id
       in: path
       required: true
-      description: The address to operate on.
+      description: The unique identifier for the target VPC interface.
       schema:
-        type: string
-        format: ip
+        type: integer
     x-linode-cli-command: networking
     get:
       x-linode-grant: read_only
       tags:
       - Networking
-      summary: VPC IP Address View
-      description: >
-        Returns information about a single Virtual Private Client (VPC) interface IP address on your account.
-      operationId: getVPCIP
+      summary: VPC IP Addresses View
+      description: |
+        Returns a paginated list of IP addresses for a single Virtual Private Client (VPC) interface.
+      operationId: viewVPCIPs
       x-linode-cli-action: vpcs-ip-view
       security:
       - personalAccessToken: []
@@ -14666,21 +14665,21 @@ paths:
         - ips:read_only
       responses:
         '200':
-          description: The requested VPC interface IP address.
+          description: The IP addresses for the requested VPC interface.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IPAddressVPC'
+                $ref: '#/components/schemas/IPAddressesVPCListResponse'
         default:
           $ref: '#/components/responses/ErrorResponse'
       x-code-samples:
       - lang: Shell
         source: >
           curl -H "Authorization: Bearer $TOKEN" \
-              https://api.linode.com/v4/networking/vpcs/ips/97.107.143.141
+              https://api.linode.com/v4/networking/vpcs/123/ips
       - lang: CLI
         source: >
-          linode-cli networking vpcs-ip-view 97.107.143.141
+          linode-cli networking 123 vpcs-ip-view
   /nodebalancers:
     x-linode-cli-command: nodebalancers
     get:
@@ -23564,7 +23563,7 @@ components:
             * You must have access to all of these addresses and they must be in the same Region as the primary Linode.
             * Enter an empty array to remove all shared IP addresses.
     IPAddressesVPCListResponse:
-      description: The response data for the Virtual Private Client (VPC) IP Addresses List (GET /networking/vpcs/ips) command.
+      description: The response data for the Virtual Private Client (VPC) IP Addresses List and View operations.
       allOf:
         - $ref: '#/components/schemas/PaginationEnvelope'
         - type: object
@@ -23731,93 +23730,6 @@ components:
           example: us-east
           readOnly: true
           x-linode-cli-display: 5
-    IPAddressVPC:
-      type: object
-      description: >
-        A Virtual Private Client (VPC) IP address that exists in Linode's system, specific to the response for the VPC IP Addresses List command. Returned as an empty set for Linodes that are not part of a VPC.
-      properties:
-        active:
-          type: boolean
-          description: >
-            Returns `true` if the VPC interface is in use, meaning that the Linode was powered on using the `config_id` to which the interface belongs. Otherwise returns `false`.
-          example: true
-          readOnly: true
-        address:
-          type: string
-          format: ip
-          description: >
-            An IPv4 address configured for this VPC interface. Displayed as `null` if an `address_range`.
-          example: 192.0.2.141
-          readOnly: true
-          x-linode-cli-display: 1
-        address_range:
-          type: string
-          description: >
-            A range of IPv4 addresses configured for this VPC interface. Displayed as `null` if a single `address`.
-          nullable: true
-          readOnly: true
-          x-linode-cli-display: 1
-        config_id:
-          type: integer
-          description: >
-            The ID assigned to the Linode configuration where the VPC is included.
-          example: 4567
-          readOnly: true
-        gateway:
-          type: string
-          format: ip
-          description: >
-            The default gateway for this address. Displayed as `null` if the VPC uses an `address_range`.
-          example: 192.0.2.1
-          nullable: true
-          readOnly: true
-        interface_id:
-          type: integer
-          description: >
-            The unique ID assigned to the Linode's interface in the subnet associated with the VPC.
-          example: 2435
-          readOnly: true
-        linode_id:
-          type: integer
-          description: >
-            The ID of the Linode the VPC interface currently belongs to. For IPv4 addresses in a VPC, this is the Linode that this address was assigned to at creation. You can move these addresses using the [/networking/ipv4/assign](https://www.linode.com/docs/api/networking/#ips-to-linodes-assign) endpoint.
-          example: 123
-          readOnly: true
-          x-linode-cli-display: 6
-        nat_1_1:
-          type: string
-          format: ip
-          description: >
-            The public IP address used for NAT 1:1 with the VPC. This is `null` if the VPC interface uses an `address_range` or NAT 1:1 isn't used.
-          example: null
-          nullable: true
-          readOnly: true
-        prefix:
-          type: integer
-          description: >
-            The number of bits set in the `subnet_mask`.
-          example: 24
-          readOnly: true
-        region:
-          type: string
-          description: >
-            The region this VPC interface IP `address` or `address_range` resides in.
-          example: us-east
-          readOnly: true
-          x-linode-cli-display: 5
-        subnet_mask:
-          type: string
-          format: ip
-          description: >
-            The mask that separates host bits from network bits for the `address` or `address_range`.
-          example: 255.255.255.0
-          readOnly: true
-        vpc_id:
-          type: integer
-          description: >
-            The unique ID assigned to the VPC interface.
-          example: 7654
-          readOnly: true
     IPAddressV6LinkLocal:
       type: object
       description: >

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6613,7 +6613,7 @@ paths:
                     "subnet_id": 101,
                     "ipv4": {
                       "vpc": "10.0.1.2",
-                      "nat_1_1": "203.0.113.2"
+                      "nat_1_1": "add"
                     }
                   }
                 ],
@@ -24627,6 +24627,8 @@ components:
                 * Setting the value to a specific public IPv4 address that is assigned to the Linode enables a 1:1 NAT between that address and the VPC Subnet IPv4 address.
                 * The public IPv4 address can't be shared with another Linode.
                 * If omitted, set to `null`, or set to an empty string (`""`), no 1:1 NAT is established.
+
+                **Note**: When creating a new compute-instance, you can't set this to a specific IPv4 address. When a new compute instance is created, the network establishes a public IPv4 address for it. Since this address doesn't exist yet, you can't include a custom IPv4 address to change it. Once your compute instances is created, you can [update your configuration profile interface](https://www.linode.com/docs/api/linode-instances/#configuration-profile-interface-update) to change the `nat_1_1` address.
               example: '203.0.113.2'
         # ipv6:
         #   type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -24658,7 +24658,7 @@ components:
           type: array
           nullable: true
           description: |
-            An array of IPv4 CIDR VPC Subnet ranges that are routed to this Interface. **IPv6 ranges are also available to select participants in the Beta program.**
+            An array of IPv4 CIDR VPC Subnet ranges that are routed to this Interface.
 
             * Array items are only allowed for `vpc` type Interfaces.
             * This must be empty for non-`vpc` type Interfaces.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -19975,7 +19975,7 @@ paths:
         - ips:read_only
       responses:
         '200':
-          description: The IP addresses for the requested VPC interface.
+          description: The IP addresses for the requested VPC.
           content:
             application/json:
               schema:
@@ -23650,7 +23650,7 @@ components:
                   region:
                     type: string
                     description: >
-                      The region this VPC interface IP `address` or `address_range` resides in.
+                      The region of the VPC.
                     example: us-east
                     readOnly: true
                     x-linode-filterable: true

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -19923,10 +19923,10 @@ paths:
       - $ref: '#/components/parameters/pageOffset'
       - $ref: '#/components/parameters/pageSize'
       description: |
-        Returns a paginated list of VPC IP addresses and address ranges on your account.
+        Returns a paginated list of all VPC IP addresses and address ranges on your account.
 
         **Note**: If a Linode has several configuration profiles that include a VPC interface, address information for all of them is listed in the response. Since VPCs can use the same address space, you may see duplicate IP addresses.
-      operationId: getVPCIPs
+      operationId: getAllVPCIPs
       x-linode-cli-action:
       - ip-list
       - ip-ls
@@ -19965,7 +19965,7 @@ paths:
       - $ref: '#/components/parameters/pageSize'
       description: |
         Returns a paginated list of IP addresses for a single VPC.
-      operationId: viewVPCIPs
+      operationId: getVPCIPs
       x-linode-cli-action:
         - ip-list
         - ip-ls

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8550,8 +8550,10 @@ paths:
       tags:
       - Linode Instances
       summary: Networking Information List
-      description: >
+      description: |
         Returns networking information for a single Linode.
+
+        **Note:** If the target Linode has several configurations that include a Virtual Private Cloud (VPC) interface, address information for all of VPCs will be listed in the response.
       operationId: getLinodeIPs
       x-linode-cli-action: ips-list
       security:
@@ -8593,13 +8595,13 @@ paths:
                         description: >
                           A list of private IP Address objects belonging to this Linode.
                         readOnly: true
-                      shared:
+                      vpc:
                         type: array
                         readOnly: true
                         items:
-                          $ref: '#/components/schemas/IPAddress'
+                          $ref: '#/components/schemas/IPAddressVPC'
                         description: >
-                          A list of shared IP Address objects assigned to this Linode.
+                          A list of Virtual Private Cloud (VPC)-specific addresses or ranges for the Linode.
                       reserved:
                         type: array
                         readOnly: true
@@ -8607,6 +8609,13 @@ paths:
                           $ref: '#/components/schemas/IPAddress'
                         description: >
                           A list of reserved IP Address objects belonging to this Linode.
+                      shared:
+                        type: array
+                        readOnly: true
+                        items:
+                          $ref: '#/components/schemas/IPAddress'
+                        description: >
+                          A list of shared IP Address objects assigned to this Linode.
                   ipv6:
                     type: object
                     description: >
@@ -14598,6 +14607,80 @@ paths:
       - lang: CLI
         source: >
           linode-cli vlans list
+  /networking/vpcs/ips:
+    x-linode-cli-command: networking
+    get:
+      x-linode-grant: read_only
+      tags:
+      - Networking
+      summary: VPC IP Addresses List
+      description: |
+        Returns a paginated list of Virtual Private Client (VPC) IP addresses and address ranges on your account.
+
+        **Note:** If a Linode has several configurations that include a VPC interface, address information for all of them will be listed in the response.
+      operationId: getVPCIPs
+      x-linode-cli-action: vpcs-ips-list
+      security:
+      - personalAccessToken: []
+      - oauth:
+        - ips:read_only
+      responses:
+        '200':
+          description: A paginated list of VPC interface IP addresses.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IPAddressesVPCListResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      x-code-samples:
+      - lang: Shell
+        source: >
+          curl -H "Authorization: Bearer $TOKEN" \
+              https://api.linode.com/v4/networking/vpcs/ips
+      - lang: CLI
+        source: >
+          linode-cli networking vpcs-ips-list
+  /networking/vpcs/ips/{address}:
+    parameters:
+    - name: address
+      in: path
+      required: true
+      description: The address to operate on.
+      schema:
+        type: string
+        format: ip
+    x-linode-cli-command: networking
+    get:
+      x-linode-grant: read_only
+      tags:
+      - Networking
+      summary: VPC IP Address View
+      description: >
+        Returns information about a single Virtual Private Client (VPC) interface IP address on your account.
+      operationId: getVPCIP
+      x-linode-cli-action: vpcs-ip-view
+      security:
+      - personalAccessToken: []
+      - oauth:
+        - ips:read_only
+      responses:
+        '200':
+          description: The requested VPC interface IP address.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IPAddressVPC'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      x-code-samples:
+      - lang: Shell
+        source: >
+          curl -H "Authorization: Bearer $TOKEN" \
+              https://api.linode.com/v4/networking/vpcs/ips/97.107.143.141
+      - lang: CLI
+        source: >
+          linode-cli networking vpcs-ip-view 97.107.143.141
   /nodebalancers:
     x-linode-cli-command: nodebalancers
     get:
@@ -23454,7 +23537,6 @@ components:
                         format: ipv4
                         description: |
                           The IPv4 address that is configured as a 1:1 NAT for this VPC interface.
-              example: 192.0.2.1
     IPAddressesShareRequest:
       type: object
       description: A request object IP Addresses Share (POST /networking/ips/share)
@@ -23481,6 +23563,105 @@ components:
             * Can include both private and public IPv4 addresses.
             * You must have access to all of these addresses and they must be in the same Region as the primary Linode.
             * Enter an empty array to remove all shared IP addresses.
+    IPAddressesVPCListResponse:
+      description: The response data for the Virtual Private Client (VPC) IP Addresses List (GET /networking/vpcs/ips) command.
+      allOf:
+        - $ref: '#/components/schemas/PaginationEnvelope'
+        - type: object
+          properties:
+            data:
+              type: array
+              items:
+                type: object
+                description: >
+                  A Virtual Private Client (VPC) IP address that exists in Linode's system, specific to the response for the VPC IP Addresses List command. Returned as an empty set for Linodes that are not part of a VPC.
+                properties:
+                  active:
+                    type: boolean
+                    description: >
+                      Returns `true` if the VPC interface is in use, meaning that the Linode was powered on using the `config_id` to which the interface belongs. Otherwise returns `false`.
+                    example: true
+                    readOnly: true
+                  address:
+                    type: string
+                    format: ip
+                    description: >
+                      An IPv4 address configured for this VPC interface. Displayed as `null` if an `address_range`.
+                    example: 192.0.2.141
+                    nullable: true
+                    readOnly: true
+                    x-linode-filterable: true
+                    x-linode-cli-display: 1
+                  address_range:
+                    type: string
+                    description: >
+                      A range of IPv4 addresses configured for this VPC interface. Displayed as `null` if a single `address`.
+                    nullable: true
+                    readOnly: true
+                  config_id:
+                    type: integer
+                    description: >
+                      The ID assigned to the Linode configuration where the VPC is included.
+                    example: 4567
+                    readOnly: true
+                  gateway:
+                    type: string
+                    format: ip
+                    description: >
+                      The default gateway for this address. Displayed as `null` if the VPC uses an `address_range`.
+                    example: 192.0.2.1
+                    nullable: true
+                    readOnly: true
+                  interface_id:
+                    type: integer
+                    description: >
+                      The unique ID assigned to the Linode's interface in the subnet associated with the VPC.
+                    example: 2435
+                    readOnly: true
+                  linode_id:
+                    type: integer
+                    description: >
+                      The ID of the Linode the VPC interface currently belongs to. For IPv4 addresses in a VPC, this is the Linode that this address was assigned to at creation. You can move these addresses using the [/networking/ipv4/assign](https://www.linode.com/docs/api/networking/#ips-to-linodes-assign) endpoint.
+                    example: 123
+                    readOnly: true
+                    x-linode-cli-display: 6
+                  nat_1_1:
+                    type: string
+                    format: ip
+                    description: >
+                      The public IP address used for NAT 1:1 with the VPC. This is `null` if the VPC interface uses an `address_range` or NAT 1:1 isn't used.
+                    example: null
+                    nullable: true
+                    readOnly: true
+                  prefix:
+                    type: integer
+                    description: >
+                      The number of bits set in the `subnet_mask`.
+                    example: 24
+                    nullable: true
+                    readOnly: true
+                    x-linode-filterable: true
+                  region:
+                    type: string
+                    description: >
+                      The region this VPC interface IP `address` or `address_range` resides in.
+                    example: us-east
+                    readOnly: true
+                    x-linode-filterable: true
+                    x-linode-cli-display: 5
+                  subnet_mask:
+                    type: string
+                    format: ip
+                    description: >
+                       The mask that separates host bits from network bits for the `address` or `address_range`.
+                    example: 255.255.255.0
+                    readOnly: true
+                  vpc_id:
+                    type: integer
+                    description: >
+                      The unique ID assigned to the VPC interface.
+                    example: 7654
+                    readOnly: true
     IPAddressPrivate:
       type: object
       description: >
@@ -23548,10 +23729,97 @@ components:
           example: us-east
           readOnly: true
           x-linode-cli-display: 5
+    IPAddressVPC:
+      type: object
+      description: >
+        A Virtual Private Client (VPC) IP address that exists in Linode's system, specific to the response for the VPC IP Addresses List command. Returned as an empty set for Linodes that are not part of a VPC.
+      properties:
+        active:
+          type: boolean
+          description: >
+            Returns `true` if the VPC interface is in use, meaning that the Linode was powered on using the `config_id` to which the interface belongs. Otherwise returns `false`.
+          example: true
+          readOnly: true
+        address:
+          type: string
+          format: ip
+          description: >
+            An IPv4 address configured for this VPC interface. Displayed as `null` if an `address_range`.
+          example: 192.0.2.141
+          readOnly: true
+          x-linode-cli-display: 1
+        address_range:
+          type: string
+          description: >
+            A range of IPv4 addresses configured for this VPC interface. Displayed as `null` if a single `address`.
+          nullable: true
+          readOnly: true
+          x-linode-cli-display: 1
+        config_id:
+          type: integer
+          description: >
+            The ID assigned to the Linode configuration where the VPC is included.
+          example: 4567
+          readOnly: true
+        gateway:
+          type: string
+          format: ip
+          description: >
+            The default gateway for this address. Displayed as `null` if the VPC uses an `address_range`.
+          example: 192.0.2.1
+          nullable: true
+          readOnly: true
+        interface_id:
+          type: integer
+          description: >
+            The unique ID assigned to the Linode's interface in the subnet associated with the VPC.
+          example: 2435
+          readOnly: true
+        linode_id:
+          type: integer
+          description: >
+            The ID of the Linode the VPC interface currently belongs to. For IPv4 addresses in a VPC, this is the Linode that this address was assigned to at creation. You can move these addresses using the [/networking/ipv4/assign](https://www.linode.com/docs/api/networking/#ips-to-linodes-assign) endpoint.
+          example: 123
+          readOnly: true
+          x-linode-cli-display: 6
+        nat_1_1:
+          type: string
+          format: ip
+          description: >
+            The public IP address used for NAT 1:1 with the VPC. This is `null` if the VPC interface uses an `address_range` or NAT 1:1 isn't used.
+          example: null
+          nullable: true
+          readOnly: true
+        prefix:
+          type: integer
+          description: >
+            The number of bits set in the `subnet_mask`.
+          example: 24
+          readOnly: true
+        region:
+          type: string
+          description: >
+            The region this VPC interface IP `address` or `address_range` resides in.
+          example: us-east
+          readOnly: true
+          x-linode-cli-display: 5
+        subnet_mask:
+          type: string
+          format: ip
+          description: >
+            The mask that separates host bits from network bits for the `address` or `address_range`.
+          example: 255.255.255.0
+          readOnly: true
+        vpc_id:
+          type: integer
+          description: >
+            The unique ID assigned to the VPC interface.
+          example: 7654
+          readOnly: true
     IPAddressV6LinkLocal:
       type: object
       description: >
-        A link-local IPv6 address that exists in Linode's system,.
+        A link-local IPv6 address that exists in Linode's system.
       properties:
         address:
           type: string


### PR DESCRIPTION
With this update:

- Added new endpoint: `/networking/vpcs/ips` (VPC IP Addresses List). Returns a list of all VPC IP addresses on the account.
- Added new endpoint: `/networking/vpcs/:id/ips` (IP Address View for a specific VPC). Returns all IP addresses for a specific VPC (`:id`).
- Added the "vpc" array to the `/linode/instances/{linodeId}/ips` (Networking Information List) endpoint. Includes all VPC IP addresses for a specified Linode.
- Corrected support for `nat_1_1` member within the `ipv4` object when creating a new Linode.
- Removed message for IPv6 beta support with VPC's when creating a Linode. (IPv6 is not supported.)