### PR TITLE
Only Allow `label` in Disk Update

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8248,7 +8248,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Disk'
+              properties:
+                label:
+                  $ref: '#/components/schemas/Disk/properties/label'
       responses:
         '200':
           description: The updated Disk.


### PR DESCRIPTION
The API seems to only support updating the label of a disk in the Disk Update endpoint (`PUT` `/linode/instances/{linodeId}/disks/{diskId}`)

https://www.linode.com/docs/api/linode-instances/#disk-update__request-body-schema

```shell
myusername@mylaptop mydir % curl -H "Content-Type: application/json" \
    -H "Authorization: Bearer $TOKEN" \
    -X PUT -d '{
      "size": 25087           
    }' \
    https://api.linode.com/v4/linode/instances/12345/disks/67890

{"errors": [{"reason": "size is not an editable field.", "field": "size"}]}
```