### PR TITLE
Fixed Node Create and Node Update CLI examples

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15479,7 +15479,7 @@ paths:
               https://api.linode.com/v4/nodebalancers/12345/configs/4567/nodes
       - lang: CLI
         source: >
-          linode-cli nodebalancers node-update \
+          linode-cli nodebalancers node-create \
             12345 4567 \
             --address 192.168.210.120:80 \
             --label node54321 \
@@ -15581,7 +15581,7 @@ paths:
               https://api.linode.com/v4/nodebalancers/12345/configs/4567/nodes/54321
       - lang: CLI
         source: >
-          linode-cli nodebalancers node-create \
+          linode-cli nodebalancers node-update \
             12345 4567 54321 \
             --address 192.168.210.120:80 \
             --label node54321 \


### PR DESCRIPTION
Fixed:

- Updated Node balancer CLI commands to use proper operator.