### PR TITLE
Mark Some Image Attributes as Nullable 

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -23000,7 +23000,7 @@ components:
           format: date-time
           nullable: true
           description: >
-            Only Images created automatically from a deleted Linode (type=automatic) will expire.
+            Only Images created automatically from a deleted Linode (type=automatic) will expire. `null` for private Images.
           example: null
           readOnly: true
         eol:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -23006,15 +23006,17 @@ components:
         eol:
           type: string
           format: date-time
+          nullable: true
           description: >
-            The date of the public Image's planned end of life. `None` for private Images.
+            The date of the public Image's planned end of life. `null` for private Images.
           example: '2026-07-01T04:00:00'
           readOnly: true
         vendor:
           x-linode-filterable: true
           type: string
+          nullable: true
           description: >
-            The upstream distribution vendor. `None` for private Images.
+            The upstream distribution vendor. `null` for private Images.
           example: Debian
           readOnly: true
           x-linode-cli-display: 3


### PR DESCRIPTION
Some minor changes for the response schema of the image object.
- APIv4 is not specifically for Python, so we can use `null` in JSON rather than `None` in the description.
- `expiry` is `null` for private images, so added the description accordingly.
- `eol` and `vendor` are nullable per description, but we should also state that in the spec.