### PR TITLE
fix: Correct ipv4.vpc attribute in /linode/instances/{linodeId}/ips response

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8572,6 +8572,7 @@ paths:
                 - ipv4.private
                 - ipv4.shared
                 - ipv4.reserved
+                - ipv4.vpc
                 - ipv6.link_local
                 - ipv6.slaac
                 - ipv6.global
@@ -8601,7 +8602,7 @@ paths:
                         type: array
                         readOnly: true
                         items:
-                          $ref: '#/components/schemas/IPAddressesVPCListResponse'
+                          $ref: '#/components/schemas/VPCIPv4Address'
                         description: >
                           A list of Virtual Private Cloud (VPC)-specific addresses or ranges for the Linode.
                       reserved:
@@ -23581,104 +23582,106 @@ components:
             data:
               type: array
               items:
-                type: object
-                description: >
-                  A VPC IP address that exists in Linode's system, specific to the response for the VPC IP Addresses List command. Returned as an empty set for Linodes that are not part of a VPC.
-                properties:
-                  active:
-                    type: boolean
-                    description: >
-                      Returns `true` if the VPC interface is in use, meaning that the Linode was powered on using the `config_id` to which the interface belongs. Otherwise returns `false`.
-                    example: true
-                    readOnly: true
-                    x-linode-filterable: true
-                  address:
-                    type: string
-                    format: ip
-                    description: >
-                      An IPv4 address configured for this VPC interface. Displayed as `null` if an `address_range`.
-                    example: 192.0.2.141
-                    nullable: true
-                    readOnly: true
-                    x-linode-cli-display: 1
-                  address_range:
-                    type: string
-                    description: >
-                      A range of IPv4 addresses configured for this VPC interface. Displayed as `null` if a single `address`.
-                    nullable: true
-                    readOnly: true
-                  config_id:
-                    type: integer
-                    description: >
-                      The globally general entity identifier for the Linode configuration profile where the VPC is included.
-                    example: 4567
-                    readOnly: true
-                    x-linode-filterable: true
-                  gateway:
-                    type: string
-                    format: ip
-                    description: >
-                      The default gateway for the VPC subnet that the IP or IP range belongs to.
-                    example: 192.0.2.1
-                    nullable: true
-                    readOnly: true
-                  interface_id:
-                    type: integer
-                    description: >
-                      The globally general API entity identifier for the Linode interface.
-                    example: 2435
-                    readOnly: true
-                  linode_id:
-                    type: integer
-                    description: >
-                      The identifier for the Linode the VPC interface currently belongs to.
-                    example: 123
-                    readOnly: true
-                    x-linode-cli-display: 6
-                    x-linode-filterable: true
-                  nat_1_1:
-                    type: string
-                    format: ip
-                    description: >
-                      The public IP address used for NAT 1:1 with the VPC. This is `null` if the VPC interface uses an `address_range` or NAT 1:1 isn't used.
-                    example: null
-                    nullable: true
-                    readOnly: true
-                  prefix:
-                    type: integer
-                    description: >
-                      The number of bits set in the `subnet_mask`.
-                    example: 24
-                    nullable: true
-                    readOnly: true
-                  region:
-                    type: string
-                    description: >
-                      The region of the VPC.
-                    example: us-east
-                    readOnly: true
-                    x-linode-filterable: true
-                    x-linode-cli-display: 5
-                  subnet_id:
-                    type: integer
-                    nullable: false
-                    description: |
-                      The `id` of the VPC Subnet for this interface.
-                    example: 101
-                  subnet_mask:
-                    type: string
-                    format: ip
-                    description: >
-                       The mask that separates host bits from network bits for the `address` or `address_range`.
-                    example: 255.255.255.0
-                    readOnly: true
-                  vpc_id:
-                    type: integer
-                    description: >
-                      The unique globally general API entity identifier for the VPC.
-                    example: 7654
-                    readOnly: true
-                    x-linode-filterable: true
+                $ref: '#/components/schemas/VPCIPv4Address'
+    VPCIPv4Address:
+      type: object
+      description: >
+        A VPC IP address that exists in Linode's system, specific to the response for the VPC IP Addresses List command. Returned as an empty set for Linodes that are not part of a VPC.
+      properties:
+        active:
+          type: boolean
+          description: >
+            Returns `true` if the VPC interface is in use, meaning that the Linode was powered on using the `config_id` to which the interface belongs. Otherwise returns `false`.
+          example: true
+          readOnly: true
+          x-linode-filterable: true
+        address:
+          type: string
+          format: ip
+          description: >
+            An IPv4 address configured for this VPC interface. Displayed as `null` if an `address_range`.
+          example: 192.0.2.141
+          nullable: true
+          readOnly: true
+          x-linode-cli-display: 1
+        address_range:
+          type: string
+          description: >
+            A range of IPv4 addresses configured for this VPC interface. Displayed as `null` if a single `address`.
+          nullable: true
+          readOnly: true
+        config_id:
+          type: integer
+          description: >
+            The globally general entity identifier for the Linode configuration profile where the VPC is included.
+          example: 4567
+          readOnly: true
+          x-linode-filterable: true
+        gateway:
+          type: string
+          format: ip
+          description: >
+            The default gateway for the VPC subnet that the IP or IP range belongs to.
+          example: 192.0.2.1
+          nullable: true
+          readOnly: true
+        interface_id:
+          type: integer
+          description: >
+            The globally general API entity identifier for the Linode interface.
+          example: 2435
+          readOnly: true
+        linode_id:
+          type: integer
+          description: >
+            The identifier for the Linode the VPC interface currently belongs to.
+          example: 123
+          readOnly: true
+          x-linode-cli-display: 6
+          x-linode-filterable: true
+        nat_1_1:
+          type: string
+          format: ip
+          description: >
+            The public IP address used for NAT 1:1 with the VPC. This is `null` if the VPC interface uses an `address_range` or NAT 1:1 isn't used.
+          example: null
+          nullable: true
+          readOnly: true
+        prefix:
+          type: integer
+          description: >
+            The number of bits set in the `subnet_mask`.
+          example: 24
+          nullable: true
+          readOnly: true
+        region:
+          type: string
+          description: >
+            The region of the VPC.
+          example: us-east
+          readOnly: true
+          x-linode-filterable: true
+          x-linode-cli-display: 5
+        subnet_id:
+          type: integer
+          nullable: false
+          description: |
+            The `id` of the VPC Subnet for this interface.
+          example: 101
+        subnet_mask:
+          type: string
+          format: ip
+          description: >
+            The mask that separates host bits from network bits for the `address` or `address_range`.
+          example: 255.255.255.0
+          readOnly: true
+        vpc_id:
+          type: integer
+          description: >
+            The unique globally general API entity identifier for the VPC.
+          example: 7654
+          readOnly: true
+          x-linode-filterable: true
     IPAddressPrivate:
       type: object
       description: >


### PR DESCRIPTION
## 📖 Description

This pull request corrects the `ipv4.vpc` attribute in the response body for the GET `/linode/instances/{linodeId}/ips` endpoint. Previously this attribute was treated as a nested paginated envelope which does not match with the API's actual response:

```json
        "vpc": [
            {
                "address": "10.0.0.2",
                "address_range": null,
                "vpc_id": 59993,
                "subnet_id": 59054,
                "region": "us-mia",
                "linode_id": 57960023,
                "config_id": 61155218,
                "interface_id": 1455573,
                "active": false,
                "nat_1_1": "172.235.141.238",
                "gateway": "10.0.0.1",
                "prefix": 24,
                "subnet_mask": "255.255.255.0"
            }
        ]
```

Additionally, this mismatch was causing the CLI to raise the following error when attempting to list IPs for a Linode:

# linode-cli linodes ips-list 45794198
Traceback (most recent call last):
  File "/home/test/.local/bin/linode-cli", line 8, in <module>
    sys.exit(main())
  File "/home/test/.local/lib/python3.8/site-packages/linodecli/__init__.py", line 256, in main
    cli.handle_command(parsed.command, parsed.action, args)
  File "/home/test/.local/lib/python3.8/site-packages/linodecli/cli.py", line 133, in handle_command
    operation.process_response_json(result, self.output_handler)
  File "/home/test/.local/lib/python3.8/site-packages/linodecli/baked/operation.py", line 427, in process_response_json
    handler.print_response(self.response_model, json)
  File "/home/test/.local/lib/python3.8/site-packages/linodecli/output.py", line 160, in print_response
    self.print(
  File "/home/test/.local/lib/python3.8/site-packages/linodecli/output.py", line 101, in print
    raise ValueError(
ValueError: Expected a non-zero number of columns.This is always an error in the OpenAPI spec.

## Testing CLI Compatiblity

1. Clone the Linode CLI locally: 

```
git clone https://github.com/linode/linode-cli.git && cd linode-cli
```

2. Run the following command to build and install the CLI from this PR's OpenAPI spec:

```
make SPEC=https://raw.githubusercontent.com/lgarber-akamai/linode-api-docs/fix/networking-info-vpc/openapi.yaml install
```

3. Attempt to use the `linodes ips-list` command on an existing Linode:

```
linode-cli linodes ips-list 12345
```

4. Ensure no error is raised.
