### PR TITLE
Various requested fixes

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -892,7 +892,18 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ChildAccount'
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ChildAccount'
+                  page:
+                    $ref: '#/components/schemas/PaginationEnvelope/properties/page'
+                  pages:
+                    $ref: '#/components/schemas/PaginationEnvelope/properties/pages'
+                  results:
+                    $ref: '#/components/schemas/PaginationEnvelope/properties/results'
         default:
           $ref: '#/components/responses/ErrorResponse'
       x-code-samples:
@@ -2324,9 +2335,13 @@ paths:
         - Account
       summary: Payment Method Make Default
       description: |
-        Make the specified Payment Method the default method for automatically processing payments.
+        Make the specified Payment Method the default method for automatically processing payments. Removes the default status from any other Payment Method.
 
-        Removes the default status from any other Payment Method.
+        **Parent and child accounts**
+
+        In a [parent and child account](/docs/guides/parent-child-accounts/) environment, the following apply:
+        
+        * Child account users can't run this operation. These users don't have access to billing-related operations.
       operationId: makePaymentMethodDefault
       x-linode-cli-action: default
       security:
@@ -2773,18 +2788,17 @@ paths:
 
         This command can only be accessed by the unrestricted users of an account.
 
-        There are several conditions that must be met in order to successfully create a transfer request:
+        There are several conditions that you need to meet to successfully create a transfer request:
 
-        1. The account creating the transfer must not have a past due balance or active Terms of Service violation.
+        1. The account creating the transfer can't have a past due balance or active Terms of Service violation.
 
-        1. The service must be owned by the account that is creating the transfer.
+        1. The service needs to be owned by the account that is creating the transfer.
 
-        1. The service must not be assigned to another Service Transfer that is pending or that has been accepted and is
-        incomplete.
+        1. The service can't be assigned to another Service Transfer that is pending or that's been accepted and is incomplete.
 
-        1. Linodes must not:
+        1. Linodes can't:
 
-            * be assigned to a NodeBalancer, Firewall, VLAN, or Managed Service.
+            * be assigned to a NodeBalancer, Firewall, VLAN, VPC, or Managed Service.
 
             * have any attached Block Storage Volumes.
 
@@ -5932,7 +5946,7 @@ paths:
               properties:
                 domain:
                   type: string
-                  pattern: \A(\*\.)?([a-zA-Z0-9-_]{1,63}\.)+([a-zA-Z]{2,3}\.)?([a-zA-Z]{2,16}|xn--[a-zA-Z0-9]+)\Z
+                  pattern: ^(\*\.)?([a-zA-Z0-9-_]{1,63}\.)+([a-zA-Z]{2,3}\.)?([a-zA-Z]{2,16}|xn--[a-zA-Z0-9]+)$
                   minLength: 1
                   maxLength: 253
                   description: >
@@ -8799,6 +8813,7 @@ paths:
                 - ipv4.private
                 - ipv4.shared
                 - ipv4.reserved
+                - ipv4.vpc
                 - ipv6.link_local
                 - ipv6.slaac
                 - ipv6.global
@@ -13254,30 +13269,23 @@ paths:
       - Networking
       summary: IP Addresses List
       description: |
-        Returns a paginated list of IP Addresses on your Account, excluding private addresses.
+        Returns a paginated list of IP addresses on your account, excluding private addresses.
 
-        We recommend utilizing the "skip_ipv6_rdns" option to improve performance if your application frequently accesses this command and does not require IPv6 RDNS data.
+        **Note**: Use the `skip_ipv6_rdns` query string to improve performance if your application frequently accesses this command and doesn't require IPv6 RDNS data.
       operationId: getIPs
       x-linode-cli-action: ips-list
       security:
       - personalAccessToken: []
       - oauth:
         - ips:read_only
-      requestBody:
-        description: Options to request additional data.
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                skip_ipv6_rdns:
-                  type: boolean
-                  default: false
-                  description: |
-                    When `true`, the "rdns" property for any "ipv6" type addresses always returns `null` regardless of whether RDNS data exists for the address.
-
-                    The default value is `false`.
+      parameters:
+      - name: skip_ipv6_rdns
+        in: query
+        description: |
+          When `true`, the `rdns` property for any `ipv6` type addresses always returns `null` regardless of whether RDNS data exists for the address.
+        schema:
+          type: boolean
+          default: false
       responses:
         '200':
           description: A paginated list of IP Addresses.
@@ -13291,14 +13299,10 @@ paths:
       - lang: Shell
         source: >
           curl -H "Authorization: Bearer $TOKEN" \
-              -H "Content-Type: application/json" \
-              -X GET -d '{
-                "skip_ipv6_rdns": false
-                }' \
-              https://api.linode.com/v4/networking/ips
+              https://api.linode.com/v4/networking/ips?skip_ipv6_rdns=true
       - lang: CLI
         source: >
-          linode-cli networking ips-list --skip_ipv6_rdns false
+          linode-cli networking ips-list
     post:
       x-linode-grant: read_write
       tags:
@@ -20181,7 +20185,17 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IPAddressesVPCListResponse'
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/IPAddressesVPCListResponse'
+                  page:
+                    $ref: '#/components/schemas/PaginationEnvelope/properties/page'
+                  pages:
+                    $ref: '#/components/schemas/PaginationEnvelope/properties/pages'
+                  results:
+                    $ref: '#/components/schemas/PaginationEnvelope/properties/results'
         default:
           $ref: '#/components/responses/ErrorResponse'
       x-code-samples:
@@ -22222,7 +22236,7 @@ components:
           x-linode-cli-display: 3
         domain:
           type: string
-          pattern: \A(\*\.)?([a-zA-Z0-9-_]{1,63}\.)+([a-zA-Z]{2,3}\.)?([a-zA-Z]{2,16}|xn--[a-zA-Z0-9]+)\Z
+          pattern: ^(\*\.)?([a-zA-Z0-9-_]{1,63}\.)+([a-zA-Z]{2,3}\.)?([a-zA-Z]{2,16}|xn--[a-zA-Z0-9]+)$
           minLength: 1
           maxLength: 253
           description: >
@@ -23784,7 +23798,7 @@ components:
               format: ipv4
               description: |
                 The IPv4 address that is configured as a 1:1 NAT for this VPC interface.
-              example: 192.0.2.1
+              example: 192.168.0.42
     IPAddressesAssignRequest:
       type: object
       description: Request object for IP Addresses Assign (POST /networking/ips/assign).
@@ -23924,7 +23938,7 @@ components:
                   vpc_nat_1_1:
                     type: object
                     description: |
-                      IPv4 address configured as a 1:1 NAT for this Interface. If no address is configured as a 1:1 NAT, `null` is returned.
+                      IPv4 address configured as a 1:1 NAT for this Interface. Empty if no address is configured as a 1:1 NAT.
 
                       **Note:** Only allowed for `vpc` type Interfaces.
                     properties:
@@ -23946,6 +23960,7 @@ components:
                         format: ipv4
                         description: |
                           The IPv4 address that is configured as a 1:1 NAT for this VPC interface.
+                        example: 192.168.0.42
     IPAddressesShareRequest:
       type: object
       description: A request object IP Addresses Share (POST /networking/ips/share)
@@ -23977,108 +23992,102 @@ components:
       allOf:
         - $ref: '#/components/schemas/PaginationEnvelope'
         - type: object
+          description: >
+            A VPC IP address that exists in Linode's system, specific to the response for the VPC IP Addresses List command. Returned as an empty set for Linodes that are not part of a VPC.
           properties:
-            data:
-              type: array
-              items:
-                type: object
-                description: >
-                  A VPC IP address that exists in Linode's system, specific to the response for the VPC IP Addresses List command. Returned as an empty set for Linodes that are not part of a VPC.
-                properties:
-                  active:
-                    type: boolean
-                    description: >
-                      Returns `true` if the VPC interface is in use, meaning that the Linode was powered on using the `config_id` to which the interface belongs. Otherwise returns `false`.
-                    example: true
-                    readOnly: true
-                    x-linode-filterable: true
-                  address:
-                    type: string
-                    format: ip
-                    description: >
-                      An IPv4 address configured for this VPC interface. Displayed as `null` if an `address_range`.
-                    example: 192.0.2.141
-                    nullable: true
-                    readOnly: true
-                    x-linode-cli-display: 1
-                  address_range:
-                    type: string
-                    description: >
-                      A range of IPv4 addresses configured for this VPC interface. Displayed as `null` if a single `address`.
-                    nullable: true
-                    readOnly: true
-                  config_id:
-                    type: integer
-                    description: >
-                      The globally general entity identifier for the Linode configuration profile where the VPC is included.
-                    example: 4567
-                    readOnly: true
-                    x-linode-filterable: true
-                  gateway:
-                    type: string
-                    format: ip
-                    description: >
-                      The default gateway for the VPC subnet that the IP or IP range belongs to.
-                    example: 192.0.2.1
-                    nullable: true
-                    readOnly: true
-                  interface_id:
-                    type: integer
-                    description: >
-                      The globally general API entity identifier for the Linode interface.
-                    example: 2435
-                    readOnly: true
-                  linode_id:
-                    type: integer
-                    description: >
-                      The identifier for the Linode the VPC interface currently belongs to.
-                    example: 123
-                    readOnly: true
-                    x-linode-cli-display: 6
-                    x-linode-filterable: true
-                  nat_1_1:
-                    type: string
-                    format: ip
-                    description: >
-                      The public IP address used for NAT 1:1 with the VPC. This is `null` if the VPC interface uses an `address_range` or NAT 1:1 isn't used.
-                    example: null
-                    nullable: true
-                    readOnly: true
-                  prefix:
-                    type: integer
-                    description: >
-                      The number of bits set in the `subnet_mask`.
-                    example: 24
-                    nullable: true
-                    readOnly: true
-                  region:
-                    type: string
-                    description: >
-                      The region of the VPC.
-                    example: us-east
-                    readOnly: true
-                    x-linode-filterable: true
-                    x-linode-cli-display: 5
-                  subnet_id:
-                    type: integer
-                    nullable: false
-                    description: |
-                      The `id` of the VPC Subnet for this interface.
-                    example: 101
-                  subnet_mask:
-                    type: string
-                    format: ip
-                    description: >
-                       The mask that separates host bits from network bits for the `address` or `address_range`.
-                    example: 255.255.255.0
-                    readOnly: true
-                  vpc_id:
-                    type: integer
-                    description: >
-                      The unique globally general API entity identifier for the VPC.
-                    example: 7654
-                    readOnly: true
-                    x-linode-filterable: true
+            active:
+              type: boolean
+              description: >
+                Returns `true` if the VPC interface is in use, meaning that the Linode was powered on using the `config_id` to which the interface belongs. Otherwise returns `false`.
+              example: true
+              readOnly: true
+              x-linode-filterable: true
+            address:
+              type: string
+              format: ip
+              description: >
+                An IPv4 address configured for this VPC interface. These follow the [RFC 1918](https://datatracker.ietf.org/doc/html/rfc1918) private address format. Displayed as `null` if an `address_range`.
+              example: 192.0.2.141
+              nullable: true
+              readOnly: true
+              x-linode-cli-display: 1
+            address_range:
+              type: string
+              description: >
+                A range of IPv4 addresses configured for this VPC interface. Displayed as `null` if a single `address`.
+              nullable: true
+              readOnly: true
+            config_id:
+              type: integer
+              description: >
+                The globally general entity identifier for the Linode configuration profile where the VPC is included.
+              example: 4567
+              readOnly: true
+              x-linode-filterable: true
+            gateway:
+              type: string
+              format: ip
+              description: >
+                The default gateway for the VPC subnet that the IP or IP range belongs to.
+              example: 192.0.2.1
+              nullable: true
+              readOnly: true
+            interface_id:
+              type: integer
+              description: >
+                The globally general API entity identifier for the Linode interface.
+              example: 2435
+              readOnly: true
+            linode_id:
+              type: integer
+              description: >
+                The identifier for the Linode the VPC interface currently belongs to.
+              example: 123
+              readOnly: true
+              x-linode-cli-display: 6
+              x-linode-filterable: true
+            nat_1_1:
+              type: string
+              format: ip
+              description: >
+                The public IP address used for NAT 1:1 with the VPC. This is empty if NAT 1:1 isn't used.
+              example: 192.168.0.42
+              readOnly: true
+            prefix:
+              type: integer
+              description: >
+                The number of bits set in the `subnet_mask`.
+              example: 24
+              nullable: true
+              readOnly: true
+            region:
+              type: string
+              description: >
+                The region of the VPC.
+              example: us-east
+              readOnly: true
+              x-linode-filterable: true
+              x-linode-cli-display: 5
+            subnet_id:
+              type: integer
+              nullable: false
+              description: |
+                The `id` of the VPC Subnet for this interface.
+              example: 101
+            subnet_mask:
+              type: string
+              format: ip
+              description: >
+                 The mask that separates host bits from network bits for the `address` or `address_range`.
+              example: 255.255.255.0
+              readOnly: true
+            vpc_id:
+              type: integer
+              description: >
+                The unique globally general API entity identifier for the VPC.
+              example: 7654
+              readOnly: true
+              x-linode-filterable: true
     IPAddressPrivate:
       type: object
       description: >


### PR DESCRIPTION
### Fixed

* Service Transfer Create (POST /account/service-transfers). Included VPC in list of services that a Linode can't use.
* VPC-related fixes:
  * Corrections to `nat_1._1` objects for proper support. 
  * Proper IP address formatting for VPC IP addresses.
  * IP Addresses List (GET /linode/instances/\{linodeId\}/ips). Corrected response example to show VPC's displayed as objects in an array and added `ipv4.vpc` attribute to `x-linode-cli-subtables`.
* Domain Clone (POST /domains/\{domainId\}/clone). Updated regex examples to proper format.
* IP Address List (GET /linode/instances/\{linodeId\}/ips). Replaced `requestBody` with query string.