### PR TITLE
Release 4.176.0

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -548,16 +548,17 @@ paths:
     get:
       tags:
       - account
+      parameters:
+      - $ref: '#/components/parameters/pageOffset'
+      - $ref: '#/components/parameters/pageSize'
       summary: Account Availability
       description: |
-        Returns service unavailability for all available regions.
+        Returns a paginated list of the services available to you, for all Linode regions.
 
-        Only authorized Users can access this endpoint.
-
-        *This endpoint is currently in **Beta**, and should not be used for production workloads.*
+        **Note**: Only authorized Users can access this endpoint.
       operationId: getAvailability
       servers:
-      - url: https://api.linode.com/v4beta
+      - url: https://api.linode.com/v4
       security:
       - personalAccessToken: []
       - oauth:
@@ -567,7 +568,7 @@ paths:
       responses:
         '200':
           description: |
-            Returns a paginated list of regions and their unavailable resources.
+            List of regions and the services available in each.
           content:
             application/json:
               schema:
@@ -594,7 +595,7 @@ paths:
     parameters:
       - name: id
         in: path
-        description: The id of the data center.
+        description: The slug for the applicable data center. Run the [GET /regions](/docs/api/regions/#regions-list) operation to view the slug for each data center.
         required: true
         schema:
           type: string
@@ -603,12 +604,12 @@ paths:
       - account
       summary: Region Service Availability
       description: |
-        Returns a single region's service availability.
+        View the available services for your account in a specific region.
 
-        Only authorized Users can access this.
+        **Note**: Only authorized users can access this.
       operationId: getAccountAvailability
       servers:
-      - url: https://api.linode.com/v4beta
+      - url: https://api.linode.com/v4
       security:
       - personalAccessToken: []
       - oauth:
@@ -617,7 +618,7 @@ paths:
       x-linode-grant: read_only
       responses:
         '200':
-          description: Returns an object with a region and the region's unavailable resources.
+          description: The services available in the specified region.
           content:
             application/json:
               schema:
@@ -20846,20 +20847,30 @@ components:
           type: string
           readOnly: true
           description: >
-            Displays the data center represented by a slug.
+            The Akamai cloud computing data center (region), represented by a slug value. You can view a full list of regions and their associated slugs via the [GET /regions](/docs/api/regions/#regions-list) endpoint.
           example: us-east
           x-linode-cli-display: 1
-        unavailable:
+        available:
           type: array
-          readOnly: true
-          description: >
-            A list of strings of unavailable services.
-          example:
-          - "Linodes"
-          - "Block Storage"
           items:
             type: string
-          x-linode-cli-display: 2
+          readOnly: true
+          description: |
+            A list of services *available* to your account in the `region`.
+          example:
+          - "Linodes"
+          - "NodeBalancers"
+        unavailable:
+          type: array
+          items:
+            type: string
+          readOnly: true
+          description: >
+            A list of services *unavailable* to your account in the `region`.
+          example:
+          - "Kubernetes"
+          - "Block Storage"
+          x-linode-cli-display: 3
     AccountSettings:
       type: object
       description: Account Settings object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.1
 info:
-  version: 4.175.0
+  version: 4.176.0
   title: Linode API
   license:
     name: Apache 2.0

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -27259,12 +27259,12 @@ components:
         owner:
           type: string
           description: >
-            The owner of this object, as a UUID. `null` if this object representsa prefix.
+            The owner of this object, as a UUID. `null` if this object represents a prefix.
           example: bfc70ab2-e3d4-42a4-ad55-83921822270c
         size:
           type: integer
           description: >
-            The size of this object, in bytes. `null` if this object representsa prefix.
+            The size of this object, in bytes. `null` if this object represents a prefix.
           example: 123
     ObjectStorageCluster:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -892,7 +892,18 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ChildAccount'
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ChildAccount'
+                  page:
+                    $ref: '#/components/schemas/PaginationEnvelope/properties/page'
+                  pages:
+                    $ref: '#/components/schemas/PaginationEnvelope/properties/pages'
+                  results:
+                    $ref: '#/components/schemas/PaginationEnvelope/properties/results'
         default:
           $ref: '#/components/responses/ErrorResponse'
       x-code-samples:
@@ -2324,9 +2335,13 @@ paths:
         - Account
       summary: Payment Method Make Default
       description: |
-        Make the specified Payment Method the default method for automatically processing payments.
+        Make the specified Payment Method the default method for automatically processing payments. Removes the default status from any other Payment Method.
 
-        Removes the default status from any other Payment Method.
+        **Parent and child accounts**
+
+        In a [parent and child account](/docs/guides/parent-child-accounts/) environment, the following apply:
+        
+        * Child account users can't run this operation. These users don't have access to billing-related operations.
       operationId: makePaymentMethodDefault
       x-linode-cli-action: default
       security:
@@ -2773,18 +2788,17 @@ paths:
 
         This command can only be accessed by the unrestricted users of an account.
 
-        There are several conditions that must be met in order to successfully create a transfer request:
+        There are several conditions that you need to meet to successfully create a transfer request:
 
-        1. The account creating the transfer must not have a past due balance or active Terms of Service violation.
+        1. The account creating the transfer can't have a past due balance or active Terms of Service violation.
 
-        1. The service must be owned by the account that is creating the transfer.
+        1. The service needs to be owned by the account that is creating the transfer.
 
-        1. The service must not be assigned to another Service Transfer that is pending or that has been accepted and is
-        incomplete.
+        1. The service can't be assigned to another Service Transfer that is pending or that's been accepted and is incomplete.
 
-        1. Linodes must not:
+        1. Linodes can't:
 
-            * be assigned to a NodeBalancer, Firewall, VLAN, or Managed Service.
+            * be assigned to a NodeBalancer, Firewall, VLAN, VPC, or Managed Service.
 
             * have any attached Block Storage Volumes.
 
@@ -5932,7 +5946,7 @@ paths:
               properties:
                 domain:
                   type: string
-                  pattern: \A(\*\.)?([a-zA-Z0-9-_]{1,63}\.)+([a-zA-Z]{2,3}\.)?([a-zA-Z]{2,16}|xn--[a-zA-Z0-9]+)\Z
+                  pattern: ^(\*\.)?([a-zA-Z0-9-_]{1,63}\.)+([a-zA-Z]{2,3}\.)?([a-zA-Z]{2,16}|xn--[a-zA-Z0-9]+)$
                   minLength: 1
                   maxLength: 253
                   description: >
@@ -8799,6 +8813,7 @@ paths:
                 - ipv4.private
                 - ipv4.shared
                 - ipv4.reserved
+                - ipv4.vpc
                 - ipv6.link_local
                 - ipv6.slaac
                 - ipv6.global
@@ -8828,7 +8843,7 @@ paths:
                         type: array
                         readOnly: true
                         items:
-                          $ref: '#/components/schemas/IPAddressesVPCListResponse'
+                          $ref: '#/components/schemas/IPAddressesVPC'
                         description: >
                           A list of Virtual Private Cloud (VPC)-specific addresses or ranges for the Linode.
                       reserved:
@@ -13254,30 +13269,23 @@ paths:
       - Networking
       summary: IP Addresses List
       description: |
-        Returns a paginated list of IP Addresses on your Account, excluding private addresses.
+        Returns a paginated list of IP addresses on your account, excluding private addresses.
 
-        We recommend utilizing the "skip_ipv6_rdns" option to improve performance if your application frequently accesses this command and does not require IPv6 RDNS data.
+        **Note**: Use the `skip_ipv6_rdns` query string to improve performance if your application frequently accesses this command and doesn't require IPv6 RDNS data.
       operationId: getIPs
       x-linode-cli-action: ips-list
       security:
       - personalAccessToken: []
       - oauth:
         - ips:read_only
-      requestBody:
-        description: Options to request additional data.
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                skip_ipv6_rdns:
-                  type: boolean
-                  default: false
-                  description: |
-                    When `true`, the "rdns" property for any "ipv6" type addresses always returns `null` regardless of whether RDNS data exists for the address.
-
-                    The default value is `false`.
+      parameters:
+      - name: skip_ipv6_rdns
+        in: query
+        description: |
+          When `true`, the `rdns` property for any `ipv6` type addresses always returns `null` regardless of whether RDNS data exists for the address.
+        schema:
+          type: boolean
+          default: false
       responses:
         '200':
           description: A paginated list of IP Addresses.
@@ -13291,14 +13299,10 @@ paths:
       - lang: Shell
         source: >
           curl -H "Authorization: Bearer $TOKEN" \
-              -H "Content-Type: application/json" \
-              -X GET -d '{
-                "skip_ipv6_rdns": false
-                }' \
-              https://api.linode.com/v4/networking/ips
+              https://api.linode.com/v4/networking/ips?skip_ipv6_rdns=true
       - lang: CLI
         source: >
-          linode-cli networking ips-list --skip_ipv6_rdns false
+          linode-cli networking ips-list
     post:
       x-linode-grant: read_write
       tags:
@@ -16580,9 +16584,18 @@ paths:
                 properties:
                   data:
                     type: array
-                    description: This page of objects in the bucket.
                     items:
                       $ref: '#/components/schemas/ObjectStorageObject'
+                  next_marker:
+                    type: string
+                    description: >
+                      Returns the value you should pass to the `marker` query parameter to get the next page of objects. If there is no next page, `null` will be returned.
+                    example: bd021c21-e734-4823-97a4-58b41c2cd4c8.892602.184
+                    nullable: true
+                  is_truncated:
+                    type: boolean
+                    description: Designates if there is another page of bucket objects.
+                    example: true
         default:
           $ref: '#/components/responses/ErrorResponse'
       x-code-samples:
@@ -20181,7 +20194,17 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IPAddressesVPCListResponse'
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/IPAddressesVPC'
+                  page:
+                    $ref: '#/components/schemas/PaginationEnvelope/properties/page'
+                  pages:
+                    $ref: '#/components/schemas/PaginationEnvelope/properties/pages'
+                  results:
+                    $ref: '#/components/schemas/PaginationEnvelope/properties/results'
         default:
           $ref: '#/components/responses/ErrorResponse'
       x-code-samples:
@@ -20220,7 +20243,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IPAddressesVPCListResponse'
+                $ref: '#/components/schemas/IPAddressesVPC'
         default:
           $ref: '#/components/responses/ErrorResponse'
       x-code-samples:
@@ -22222,7 +22245,7 @@ components:
           x-linode-cli-display: 3
         domain:
           type: string
-          pattern: \A(\*\.)?([a-zA-Z0-9-_]{1,63}\.)+([a-zA-Z]{2,3}\.)?([a-zA-Z]{2,16}|xn--[a-zA-Z0-9]+)\Z
+          pattern: ^(\*\.)?([a-zA-Z0-9-_]{1,63}\.)+([a-zA-Z]{2,3}\.)?([a-zA-Z]{2,16}|xn--[a-zA-Z0-9]+)$
           minLength: 1
           maxLength: 253
           description: >
@@ -23784,7 +23807,7 @@ components:
               format: ipv4
               description: |
                 The IPv4 address that is configured as a 1:1 NAT for this VPC interface.
-              example: 192.0.2.1
+              example: 192.168.0.42
     IPAddressesAssignRequest:
       type: object
       description: Request object for IP Addresses Assign (POST /networking/ips/assign).
@@ -23924,7 +23947,7 @@ components:
                   vpc_nat_1_1:
                     type: object
                     description: |
-                      IPv4 address configured as a 1:1 NAT for this Interface. If no address is configured as a 1:1 NAT, `null` is returned.
+                      IPv4 address configured as a 1:1 NAT for this Interface. Empty if no address is configured as a 1:1 NAT.
 
                       **Note:** Only allowed for `vpc` type Interfaces.
                     properties:
@@ -23946,6 +23969,7 @@ components:
                         format: ipv4
                         description: |
                           The IPv4 address that is configured as a 1:1 NAT for this VPC interface.
+                        example: 192.168.0.42
     IPAddressesShareRequest:
       type: object
       description: A request object IP Addresses Share (POST /networking/ips/share)
@@ -23972,113 +23996,107 @@ components:
             * Can include both private and public IPv4 addresses.
             * You must have access to all of these addresses and they must be in the same Region as the primary Linode.
             * Enter an empty array to remove all shared IP addresses.
-    IPAddressesVPCListResponse:
+    IPAddressesVPC:
       description: The response data for the VPC IP Addresses List and View operations.
       allOf:
         - $ref: '#/components/schemas/PaginationEnvelope'
         - type: object
+          description: >
+            A VPC IP address that exists in Linode's system, specific to the response for the VPC IP Addresses List command. Returned as an empty set for Linodes that are not part of a VPC.
           properties:
-            data:
-              type: array
-              items:
-                type: object
-                description: >
-                  A VPC IP address that exists in Linode's system, specific to the response for the VPC IP Addresses List command. Returned as an empty set for Linodes that are not part of a VPC.
-                properties:
-                  active:
-                    type: boolean
-                    description: >
-                      Returns `true` if the VPC interface is in use, meaning that the Linode was powered on using the `config_id` to which the interface belongs. Otherwise returns `false`.
-                    example: true
-                    readOnly: true
-                    x-linode-filterable: true
-                  address:
-                    type: string
-                    format: ip
-                    description: >
-                      An IPv4 address configured for this VPC interface. Displayed as `null` if an `address_range`.
-                    example: 192.0.2.141
-                    nullable: true
-                    readOnly: true
-                    x-linode-cli-display: 1
-                  address_range:
-                    type: string
-                    description: >
-                      A range of IPv4 addresses configured for this VPC interface. Displayed as `null` if a single `address`.
-                    nullable: true
-                    readOnly: true
-                  config_id:
-                    type: integer
-                    description: >
-                      The globally general entity identifier for the Linode configuration profile where the VPC is included.
-                    example: 4567
-                    readOnly: true
-                    x-linode-filterable: true
-                  gateway:
-                    type: string
-                    format: ip
-                    description: >
-                      The default gateway for the VPC subnet that the IP or IP range belongs to.
-                    example: 192.0.2.1
-                    nullable: true
-                    readOnly: true
-                  interface_id:
-                    type: integer
-                    description: >
-                      The globally general API entity identifier for the Linode interface.
-                    example: 2435
-                    readOnly: true
-                  linode_id:
-                    type: integer
-                    description: >
-                      The identifier for the Linode the VPC interface currently belongs to.
-                    example: 123
-                    readOnly: true
-                    x-linode-cli-display: 6
-                    x-linode-filterable: true
-                  nat_1_1:
-                    type: string
-                    format: ip
-                    description: >
-                      The public IP address used for NAT 1:1 with the VPC. This is `null` if the VPC interface uses an `address_range` or NAT 1:1 isn't used.
-                    example: null
-                    nullable: true
-                    readOnly: true
-                  prefix:
-                    type: integer
-                    description: >
-                      The number of bits set in the `subnet_mask`.
-                    example: 24
-                    nullable: true
-                    readOnly: true
-                  region:
-                    type: string
-                    description: >
-                      The region of the VPC.
-                    example: us-east
-                    readOnly: true
-                    x-linode-filterable: true
-                    x-linode-cli-display: 5
-                  subnet_id:
-                    type: integer
-                    nullable: false
-                    description: |
-                      The `id` of the VPC Subnet for this interface.
-                    example: 101
-                  subnet_mask:
-                    type: string
-                    format: ip
-                    description: >
-                       The mask that separates host bits from network bits for the `address` or `address_range`.
-                    example: 255.255.255.0
-                    readOnly: true
-                  vpc_id:
-                    type: integer
-                    description: >
-                      The unique globally general API entity identifier for the VPC.
-                    example: 7654
-                    readOnly: true
-                    x-linode-filterable: true
+            active:
+              type: boolean
+              description: >
+                Returns `true` if the VPC interface is in use, meaning that the Linode was powered on using the `config_id` to which the interface belongs. Otherwise returns `false`.
+              example: true
+              readOnly: true
+              x-linode-filterable: true
+            address:
+              type: string
+              format: ip
+              description: >
+                An IPv4 address configured for this VPC interface. These follow the [RFC 1918](https://datatracker.ietf.org/doc/html/rfc1918) private address format. Displayed as `null` if an `address_range`.
+              example: 192.0.2.141
+              nullable: true
+              readOnly: true
+              x-linode-cli-display: 1
+            address_range:
+              type: string
+              description: >
+                A range of IPv4 addresses configured for this VPC interface. Displayed as `null` if a single `address`.
+              nullable: true
+              readOnly: true
+            config_id:
+              type: integer
+              description: >
+                The globally general entity identifier for the Linode configuration profile where the VPC is included.
+              example: 4567
+              readOnly: true
+              x-linode-filterable: true
+            gateway:
+              type: string
+              format: ip
+              description: >
+                The default gateway for the VPC subnet that the IP or IP range belongs to.
+              example: 192.0.2.1
+              nullable: true
+              readOnly: true
+            interface_id:
+              type: integer
+              description: >
+                The globally general API entity identifier for the Linode interface.
+              example: 2435
+              readOnly: true
+            linode_id:
+              type: integer
+              description: >
+                The identifier for the Linode the VPC interface currently belongs to.
+              example: 123
+              readOnly: true
+              x-linode-cli-display: 6
+              x-linode-filterable: true
+            nat_1_1:
+              type: string
+              format: ip
+              description: >
+                The public IP address used for NAT 1:1 with the VPC. This is empty if NAT 1:1 isn't used.
+              example: 192.168.0.42
+              readOnly: true
+            prefix:
+              type: integer
+              description: >
+                The number of bits set in the `subnet_mask`.
+              example: 24
+              nullable: true
+              readOnly: true
+            region:
+              type: string
+              description: >
+                The region of the VPC.
+              example: us-east
+              readOnly: true
+              x-linode-filterable: true
+              x-linode-cli-display: 5
+            subnet_id:
+              type: integer
+              nullable: false
+              description: |
+                The `id` of the VPC Subnet for this interface.
+              example: 101
+            subnet_mask:
+              type: string
+              format: ip
+              description: >
+                 The mask that separates host bits from network bits for the `address` or `address_range`.
+              example: 255.255.255.0
+              readOnly: true
+            vpc_id:
+              type: integer
+              description: >
+                The unique globally general API entity identifier for the VPC.
+              example: 7654
+              readOnly: true
+              x-linode-filterable: true
     IPAddressPrivate:
       type: object
       description: >
@@ -27209,8 +27227,7 @@ components:
     ObjectStorageObject:
       type: object
       description: >
-        An Object in Object Storage, or a "prefix" that contains one
-        or more objects when a `delimiter` is used.
+        An Object in Object Storage, or a "prefix" that contains one or more objects when a `delimiter` is used.
       properties:
         name:
           type: string
@@ -27226,32 +27243,18 @@ components:
           type: string
           format: date-time
           description: >
-            The date and time this object was last modified. `null` if this object
-            represents a prefix.
+            The date and time this object was last modified. `null` if this object represents a prefix.
           example: 2019-01-01T01:23:45
         owner:
           type: string
           description: >
-            The owner of this object, as a UUID. `null` if this object represents
-            a prefix.
+            The owner of this object, as a UUID. `null` if this object representsa prefix.
           example: bfc70ab2-e3d4-42a4-ad55-83921822270c
         size:
           type: integer
           description: >
-            The size of this object, in bytes. `null` if this object represents
-            a prefix.
+            The size of this object, in bytes. `null` if this object representsa prefix.
           example: 123
-        next_marker:
-          type: string
-          description: >
-            Returns the value you should pass to the `marker` query parameter to get the next page of objects.
-            If there is no next page, `null` will be returned.
-          example: bd021c21-e734-4823-97a4-58b41c2cd4c8.892602.184
-          nullable: true
-        is_truncated:
-          type: boolean
-          description: Designates if there is another page of bucket objects.
-          example: true
     ObjectStorageCluster:
       type: object
       description: An Object Storage Cluster


### PR DESCRIPTION
### Changed

Updated account availability-related endpoints, to apply new functionality and bring them from beta to GA:

-  **Account Availability** (GET /account/availability)
-  **Region Service Availability** (GET /account/availability/{id})

### Fixed

- **Service Transfer Create** (POST /account/service-transfers]). Included VPC in list of services that a Linode can't use.
- **VPC-related fixes**:
  - Corrections to `nat_1_1` objects for proper support.
  - Proper IP address formatting for VPC IP addresses.
  - **IP Addresses List** (GET /linode/instances/{linodeId}/ips). Corrected response example to show VPC's displayed as objects in an array and added ipv4.vpc attribute to x-linode-cli-subtables.
- **Domain Clone** (POST /domains/{domainId}/clone). Updated regex examples to proper format.
- **IP Addresses List** (GET /linode/instances/{linodeId}/ips). Replaced `requestBody` with query string.
- **Object Storage Bucket Contents List** (GET /object-storage/buckets/{clusterId}/{bucket}/object-list). Fixed incorrect response sample.
- **Parent/Child Account fixes** Applied pagination and missing warning message.