### PR TITLE
Add apl_enabled to LKECluster

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -25627,7 +25627,7 @@ components:
             Defines whether APL is installed during creation of the LKE cluster. Defaults to `false`.
             If set to `true`, implies `control_plane.high_availability` set to `true`.
             Can only be set when creating the cluster.
-          x-linode-cli-display: 6
+          x-linode-cli-display: 0
           example: true
         tags:
           x-linode-filterable: true

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -25621,6 +25621,14 @@ components:
                 Defines whether High Availability is enabled for the Control Plane Components of the cluster. Defaults to `false`.
               x-linode-cli-display: 5
               example: true
+        apl_enabled:
+          type: boolean
+          description: >
+            Defines whether APL is installed during creation of the LKE cluster. Defaults to `false`.
+            If set to `true`, implies `control_plane.high_availability` set to `true`.
+            Can only be set when creating the cluster.
+          x-linode-cli-display: 6
+          example: true
         tags:
           x-linode-filterable: true
           type: array


### PR DESCRIPTION
This PR adds the `apl_enabled` flag to the `LKECluster` schema, as implemented in LinodeAPI/apinext#6767