### PR TITLE
Api release 4.189.0

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15706,7 +15706,7 @@ paths:
                   id: mysql/8.0.26
                   total_disk_size_gb: 15
                   used_disk_size_gb: 2
-                  version: 8.0.26
+                  version: 4.189.06
                 page: 1
                 pages: 1
                 results: 1
@@ -16008,7 +16008,7 @@ paths:
                     frequency: weekly
                     hour_of_day: 0
                     week_of_month: null
-                  version: 8.0.26
+                  version: 4.189.06
                 page: 1
                 pages: 1
                 results: 1
@@ -16333,7 +16333,7 @@ paths:
                     hour_of_day: 0
                     week_of_month: null
                   used_disk_size_gb: 2
-                  version: 8.0.26
+                  version: 4.189.06
                 page: 1
                 pages: 1
                 results: 1


### PR DESCRIPTION
Includes the following updates:

[Firewall Updates](https://techdocs.akamai.com/linode-api/changelog/oct-4-2024-firewall-updates)
- Get a firewall rule version ([GET /networking/firewalls/{firewallId}/history/rules/{version}](https://techdocs.akamai.com/linode-api/reference/get-firewall-rule-version))
- List firewall rule versions ([GET /networking/firewalls/{firewallId}/history](https://techdocs.akamai.com/linode-api/reference/get-firewall-rule-versions))
- Apply a Linode's firewalls ([POST /linode/instances/{linodeId}/firewalls/apply](https://techdocs.akamai.com/linode-api/reference/post-apply-firewalls)

[Types for LKE, Object Storage, NB & Longview](https://techdocs.akamai.com/linode-api/changelog/oct-11-2024)
- List Kubernetes types ([GET /lke/types](https://techdocs.akamai.com/linode-api/reference/get-lke-types))
- List Object Storage types ([GET /object-storage/types](https://techdocs.akamai.com/linode-api/reference/get-object-storage-types))
- List NodeBalancer types ([GET /nodebalancers/types](https://techdocs.akamai.com/linode-api/reference/get-node-balancer-types))
- List Longview types ([GET /longview/types](https://techdocs.akamai.com/linode-api/reference/get-longview-types))

**Linode disk maximum**. A single Linode can have up to 50 disks.
- Create a disk ([POST /linode/instances/{linodeId}/disks](https://techdocs.akamai.com/linode-api/reference/post-add-linode-disk))
- Clone a disk ([POST /linode/instances/{linodeId}/disks/{diskId}/clone](https://techdocs.akamai.com/linode-api/reference/post-clone-linode-disk))