### PR TITLE
Add workflow to run CLI E2E tests on PRs and Pushes to `dev` branch

### DIFF
--- a/.github/workflows/cli-verify-json-pr.yml
+++ b/.github/workflows/cli-verify-json-pr.yml
@@ -66,7 +66,10 @@ jobs:
           python-version: "3.10"
 
       - name: Get JSON Spec Path
-        run: echo "JSON_SPEC_PATH=$(pwd)/json-spec/openapi.json" >> $GITHUB_ENV
+        run: |
+          cd json-spec
+          ls -l
+          echo "JSON_SPEC_PATH=$(pwd)/openapi.json" >> $GITHUB_ENV
 
       - name: Install Linode CLI dependencies
         run: |

--- a/.github/workflows/cli-verify-json-pr.yml
+++ b/.github/workflows/cli-verify-json-pr.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: get 10 lines
         run: |
-          cat "${{ env.JSON_SPEC_PATH }}" | head 10
+          cat "${{ env.JSON_SPEC_PATH }}" | head -10
 
       - name: Install Linode CLI dependencies
         run: |

--- a/.github/workflows/cli-verify-json-pr.yml
+++ b/.github/workflows/cli-verify-json-pr.yml
@@ -1,0 +1,70 @@
+name: Run Tests with Linode CLI and JSON Spec
+
+on:
+  push:
+    branches:
+      - development
+  pull_request:
+    branches:
+      - development
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: 'Specify commit hash to test. This value is mandatory to ensure the tests run against a specific commit'
+        required: true
+        default: ''
+      pull_request_number:
+        description: 'Specify pull request number associated with the commit. Optional, but recommended when providing a commit hash (sha)'
+        required: false
+      test_suite:
+        description: "Specify  test suite to run from the 'tests/integration' directory. Examples: 'cli', 'domains', 'events', etc. If not provided, all suites are executed"
+        required: false
+      run_long_tests:
+        description: "Select 'True' to include long-running tests (e.g., database provisioning, server rebuilds). Defaults to 'False'"
+        required: false
+        type: choice
+        options:
+          - "True"
+          - "False"
+        default: "False"
+
+jobs:
+  test-linode-cli:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && inputs.sha != '' || github.event_name == 'push' || github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout Current Repository (JSON Spec)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
+          ref: ${{ inputs.sha || github.ref }}
+          path: json-spec
+
+      - name: Checkout Linode CLI (dev branch)
+        uses: actions/checkout@v4
+        with:
+          repository: linode/linode-cli
+          ref: dev
+          path: linode-cli
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+
+      - name: Get JSON Spec Path
+        run: echo "JSON_SPEC_PATH=$(pwd)/json-spec/spec.json" >> $GITHUB_ENV
+
+      - name: Install Linode CLI dependencies
+        run: |
+          cd linode-cli
+          SPEC=$JSON_SPEC_PATH make install
+
+      - name: Run CLI E2E Tests
+        run: |
+          cd linode-cli
+          make test-int TEST_SUITE="${{ inputs.test_suite }}" RUN_LONG_TESTS="${{ inputs.run_long_tests }}"
+        env:
+          LINODE_CLI_TOKEN: ${{ env.LINODE_CLI_TOKEN }}

--- a/.github/workflows/cli-verify-json-pr.yml
+++ b/.github/workflows/cli-verify-json-pr.yml
@@ -9,13 +9,9 @@ on:
       - development
   workflow_dispatch:
     inputs:
-      spec_file:
-        description: 'Choose a file'
-        required: false
-        type: 'file'
       sha:
         description: 'Specify commit hash to test. This value is mandatory to ensure the tests run against a specific commit'
-        required: false
+        required: true
         default: ''
       pull_request_number:
         description: 'Specify pull request number associated with the commit. Optional, but recommended when providing a commit hash (sha)'
@@ -44,7 +40,7 @@ jobs:
   test-linode-cli:
     runs-on: ubuntu-latest
     if: |
-      github.event_name == 'workflow_dispatch' || 
+      github.event_name == 'workflow_dispatch' && inputs.sha != '' || 
       github.event_name == 'push' || 
       (github.event_name == 'pull_request' && inputs.run_on_pr == 'True')
 
@@ -72,19 +68,12 @@ jobs:
       - name: Get JSON Spec Path
         run: |
           cd json-spec
-          # Set default JSON spec path
           echo "JSON_SPEC_PATH=$(pwd)/openapi.json" >> $GITHUB_ENV
-          # If spec_file is provided, use it; otherwise fallback to default
-          if [[ -n "${{ inputs.spec_file }}" ]]; then
-            echo "SPEC_FILE_PATH=${{ inputs.spec_file }}" >> $GITHUB_ENV
-          else
-            echo "SPEC_FILE_PATH=$(pwd)/openapi.json" >> $GITHUB_ENV
-          fi
 
       - name: Install Linode CLI
         run: |
           cd linode-cli
-          SPEC="${{ env.SPEC_FILE_PATH }}" make install
+          SPEC="${{ env.JSON_SPEC_PATH }}" make install
 
       - name: Run CLI E2E Tests
         run: |

--- a/.github/workflows/cli-verify-json-pr.yml
+++ b/.github/workflows/cli-verify-json-pr.yml
@@ -71,10 +71,14 @@ jobs:
           ls -l
           echo "JSON_SPEC_PATH=$(pwd)/openapi.json" >> $GITHUB_ENV
 
+      - name: get 10 lines
+        run: |
+          cat "${{ env.JSON_SPEC_PATH }}" | head 10
+
       - name: Install Linode CLI dependencies
         run: |
           cd linode-cli
-          SPEC="$JSON_SPEC_PATH" make install
+          SPEC="${{ env.JSON_SPEC_PATH }}" make install
 
       - name: Run CLI E2E Tests
         run: |

--- a/.github/workflows/cli-verify-json-pr.yml
+++ b/.github/workflows/cli-verify-json-pr.yml
@@ -9,9 +9,13 @@ on:
       - development
   workflow_dispatch:
     inputs:
+      spec_file:
+        description: 'Choose a file'
+        required: false
+        type: 'file'
       sha:
         description: 'Specify commit hash to test. This value is mandatory to ensure the tests run against a specific commit'
-        required: true
+        required: false
         default: ''
       pull_request_number:
         description: 'Specify pull request number associated with the commit. Optional, but recommended when providing a commit hash (sha)'
@@ -40,7 +44,7 @@ jobs:
   test-linode-cli:
     runs-on: ubuntu-latest
     if: |
-      github.event_name == 'workflow_dispatch' && inputs.sha != '' || 
+      github.event_name == 'workflow_dispatch' || 
       github.event_name == 'push' || 
       (github.event_name == 'pull_request' && inputs.run_on_pr == 'True')
 
@@ -68,12 +72,19 @@ jobs:
       - name: Get JSON Spec Path
         run: |
           cd json-spec
+          # Set default JSON spec path
           echo "JSON_SPEC_PATH=$(pwd)/openapi.json" >> $GITHUB_ENV
+          # If spec_file is provided, use it; otherwise fallback to default
+          if [[ -n "${{ inputs.spec_file }}" ]]; then
+            echo "SPEC_FILE_PATH=${{ inputs.spec_file }}" >> $GITHUB_ENV
+          else
+            echo "SPEC_FILE_PATH=$(pwd)/openapi.json" >> $GITHUB_ENV
+          fi
 
       - name: Install Linode CLI
         run: |
           cd linode-cli
-          SPEC="${{ env.JSON_SPEC_PATH }}" make install
+          SPEC="${{ env.SPEC_FILE_PATH }}" make install
 
       - name: Run CLI E2E Tests
         run: |

--- a/.github/workflows/cli-verify-json-pr.yml
+++ b/.github/workflows/cli-verify-json-pr.yml
@@ -17,7 +17,7 @@ on:
         description: 'Specify pull request number associated with the commit. Optional, but recommended when providing a commit hash (sha)'
         required: false
       test_suite:
-        description: "Specify  test suite to run from the 'tests/integration' directory. Examples: 'cli', 'domains', 'events', etc. If not provided, all suites are executed"
+        description: "Specify test suite to run from the 'tests/integration' directory. Examples: 'cli', 'domains', 'events', etc. If not provided, all suites are executed"
         required: false
       run_long_tests:
         description: "Select 'True' to include long-running tests (e.g., database provisioning, server rebuilds). Defaults to 'False'"
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Get JSON Spec Path
         run: echo "JSON_SPEC_PATH=$(pwd)/json-spec/spec.json" >> $GITHUB_ENV
@@ -60,11 +60,11 @@ jobs:
       - name: Install Linode CLI dependencies
         run: |
           cd linode-cli
-          SPEC=$JSON_SPEC_PATH make install
+          SPEC="$JSON_SPEC_PATH" make install
 
       - name: Run CLI E2E Tests
         run: |
           cd linode-cli
           make test-int TEST_SUITE="${{ inputs.test_suite }}" RUN_LONG_TESTS="${{ inputs.run_long_tests }}"
         env:
-          LINODE_CLI_TOKEN: ${{ env.LINODE_CLI_TOKEN }}
+          LINODE_CLI_TOKEN: ${{ secrets.LINODE_CLI_TOKEN }}

--- a/.github/workflows/cli-verify-json-pr.yml
+++ b/.github/workflows/cli-verify-json-pr.yml
@@ -68,14 +68,9 @@ jobs:
       - name: Get JSON Spec Path
         run: |
           cd json-spec
-          ls -l
           echo "JSON_SPEC_PATH=$(pwd)/openapi.json" >> $GITHUB_ENV
 
-      - name: get 10 lines
-        run: |
-          cat "${{ env.JSON_SPEC_PATH }}" | head -10
-
-      - name: Install Linode CLI dependencies
+      - name: Install Linode CLI
         run: |
           cd linode-cli
           SPEC="${{ env.JSON_SPEC_PATH }}" make install

--- a/.github/workflows/cli-verify-json-pr.yml
+++ b/.github/workflows/cli-verify-json-pr.yml
@@ -27,11 +27,22 @@ on:
           - "True"
           - "False"
         default: "False"
+      run_on_pr:
+        description: "Select 'True' to allow execution on pull requests when using workflow_dispatch. Defaults to 'False'"
+        required: false
+        type: choice
+        options:
+          - "True"
+          - "False"
+        default: "False"
 
 jobs:
   test-linode-cli:
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' && inputs.sha != '' || github.event_name == 'push' || github.event_name == 'pull_request'
+    if: |
+      github.event_name == 'workflow_dispatch' && inputs.sha != '' || 
+      github.event_name == 'push' || 
+      (github.event_name == 'pull_request' && inputs.run_on_pr == 'True')
 
     steps:
       - name: Checkout Current Repository (JSON Spec)
@@ -55,7 +66,7 @@ jobs:
           python-version: "3.10"
 
       - name: Get JSON Spec Path
-        run: echo "JSON_SPEC_PATH=$(pwd)/json-spec/spec.json" >> $GITHUB_ENV
+        run: echo "JSON_SPEC_PATH=$(pwd)/json-spec/openapi.json" >> $GITHUB_ENV
 
       - name: Install Linode CLI dependencies
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7.x'
+        python-version: '3.10'
         architecture: 'x64'
     - name: Cache pip
       uses: actions/cache@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,4 +27,4 @@ jobs:
         pip install openapi3
     - name: openapi linter
       run: |
-        python -m openapi3 openapi.yaml
+        python -m openapi3 openapi.json

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,14 +6,14 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.7.x'
         architecture: 'x64'
     - name: Cache pip
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         # Look to see if there is a cache hit for the corresponding requirements file


### PR DESCRIPTION
Description:

- Adding GHA workflow to allow CLI E2E tests on PRs and Pushes to `development` branch
- Latest dev branch in linode-cli will be checked out
- Options provided to enter sha value of the branch to run workflow via dispatch

How to Test:
- Tested on forked repository
https://github.com/ykim-akamai/linode-api-docs/actions/runs/13775588908/job/38524018465

 