### PR TITLE
Updates for API version 4.197.0

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -613,7 +613,7 @@
             "type": "string"
           },
           "tax_id": {
-            "description": "The tax identification number assigned to this account, used for tax calculations in a `country` that collects tax. Set to an empty string (`\"\"`) for countries that don't collect tax.\n\n> 📘\n>\n> This value is externally validated. If the validation is successful, a `tax_id_valid` [event](https://techdocs.akamai.com/linode-api/reference/get-events) is triggered. If unsuccessful, a `tax_id_invalid` event is triggered and an error response is issued for an operation that included it.",
+            "description": "The tax identification number (TIN) assigned to this account, used for tax calculations. A TIN is set by the national authorities in your `country`, based on your `address_1`, and it may be named differently between countries. Set to an empty string (`\"\"`) if a TIN doesn't apply or for countries that don't collect tax.\n\n> 📘\n>\n> This value is externally validated. If the validation is successful, a `tax_id_valid` [event](https://techdocs.akamai.com/linode-api/reference/get-events) is triggered. If unsuccessful, a `tax_id_invalid` event is triggered and an error response is issued for an operation that included it.",
             "example": "ATU99999999",
             "maxLength": 25,
             "type": "string"
@@ -1090,7 +1090,7 @@
                   "x-linode-filterable": true
                 },
                 "state": {
-                  "description": "__Filterable__ The state or province for the billing address (`address_1` and `address_2, if applicable`). If in the United States (US) or Canada (CA), this is the two-letter ISO 3166 State or Province code.\n\n__Note__. If this is a US military address, use state abbreviations (AA, AE, AP).",
+                  "description": "__Filterable__ The state or province for the billing address (`address_1` and `address_2, if applicable`). If in the United States (US) or Canada (CA), this is the two-letter ISO 3166 State or Province code.\n\n> 📘\n>\n> If this is a US military address, use state abbreviations (AA, AE, AP).",
                   "example": "CA",
                   "maxLength": 24,
                   "type": "string",
@@ -2397,7 +2397,8 @@
                     "ticket_abuse",
                     "notice",
                     "maintenance",
-                    "promotion"
+                    "promotion",
+                    "tax_id_verifying"
                   ],
                   "example": "ticket_important",
                   "readOnly": true,
@@ -2815,10 +2816,10 @@
         "allOf": [
           {
             "additionalProperties": false,
-            "description": "A User on your Account. Unrestricted users can log in and access information about your Account, while restricted users may only access entities or perform actions they've been granted access to.",
+            "description": "A user on your account. Unrestricted users can log in and access information about your account, while restricted users may only access entities or perform actions they've been granted access to.",
             "properties": {
               "email": {
-                "description": "The email address for the User. Linode sends emails to this address for account management communications. May be used for other communications as configured.",
+                "description": "This user's email address. Akamai uses this address for account management communications.",
                 "example": "example_user@linode.com",
                 "format": "email",
                 "type": "string",
@@ -2826,18 +2827,18 @@
               },
               "last_login": {
                 "additionalProperties": false,
-                "description": "__Read-only__ Information for the most recent login attempt for this User.\n\n`null` if no login attempts have been made since creation of this User.\n\nRun the [List user logins](https://techdocs.akamai.com/linode-api/reference/get-account-logins) operation for additional login information.",
+                "description": "__Read-only__ Details on this user's last login attempt. Returned as `null` if this user hasn't attempted a login since it was created. You can run the [List user logins](https://techdocs.akamai.com/linode-api/reference/get-account-logins) operation for additional login information.",
                 "nullable": true,
                 "properties": {
                   "login_datetime": {
-                    "description": "__Read-only__ The date and time of this User's most recent login attempt.",
+                    "description": "__Read-only__ The date and time of this user's most recent login attempt.",
                     "example": "2018-01-01T01:01:01",
                     "format": "date-time",
                     "readOnly": true,
                     "type": "string"
                   },
                   "status": {
-                    "description": "__Read-only__ The result of the most recent login attempt for this User.",
+                    "description": "__Read-only__ The result of this user's most recent login attempt.",
                     "enum": [
                       "successful",
                       "failed"
@@ -2851,7 +2852,7 @@
                 "type": "object"
               },
               "password_created": {
-                "description": "__Read-only__ The date and time when this User's current password was created.\n\nUser passwords are first created during the Account sign-up process, and updated using the [Reset Password](https://login.linode.com/forgot/password) webpage.\n\n`null` if this User has not created a password yet.",
+                "description": "__Read-only__ When this user's current password was created. You initially create a password during the account sign-up process, and you can update it using the [Reset Password](https://login.linode.com/forgot/password) webpage. Returned as `null` if this user doesn't have a password set.",
                 "example": "2018-01-01T01:01:01",
                 "format": "date-time",
                 "nullable": true,
@@ -2859,13 +2860,13 @@
                 "type": "string"
               },
               "restricted": {
-                "description": "If `true`, the User must be granted access to perform actions or access entities on this Account. Run [List a user's grants](https://techdocs.akamai.com/linode-api/reference/get-user-grants) for details on how to configure grants for a restricted User.",
+                "description": "If `true`, this user needs specific access granted to perform actions or access entities on your account. Run [List a user's grants](https://techdocs.akamai.com/linode-api/reference/get-user-grants) for details on how to configure grants for a restricted user.",
                 "example": true,
                 "type": "boolean",
                 "x-linode-cli-display": 3
               },
               "ssh_keys": {
-                "description": "__Read-only__ A list of SSH Key labels added by this User.\n\nUsers can add keys with the [Add an SSH key](https://techdocs.akamai.com/linode-api/reference/post-add-ssh-key) operation.\n\nThese keys are deployed when this User is included in the `authorized_users` field of the following requests:\n\n- [Create a Linode](https://techdocs.akamai.com/linode-api/reference/post-linode-instance)\n- [Rebuild a Linode](https://techdocs.akamai.com/linode-api/reference/post-rebuild-linode-instance)\n- [Create a disk](https://techdocs.akamai.com/linode-api/reference/post-add-linode-disk)",
+                "description": "__Read-only__ A list of the labels for SSH keys added by this user. Users can add keys with the [Add an SSH key](https://techdocs.akamai.com/linode-api/reference/post-add-ssh-key) operation. These keys are deployed when this user is included in the `authorized_users` field of the following requests:\n\n- [Create a Linode](https://techdocs.akamai.com/linode-api/reference/post-linode-instance)\n\n- [Rebuild a Linode](https://techdocs.akamai.com/linode-api/reference/post-rebuild-linode-instance)\n\n- [Create a disk](https://techdocs.akamai.com/linode-api/reference/post-add-linode-disk)",
                 "example": [
                   "home-pc",
                   "laptop"
@@ -2877,13 +2878,13 @@
                 "type": "array"
               },
               "tfa_enabled": {
-                "description": "__Read-only__ A boolean value indicating if the User has Two Factor Authentication (TFA) enabled. Run the [Create a two factor secret](https://techdocs.akamai.com/linode-api/reference/post-tfa-enable) operation to enable TFA.",
+                "description": "__Read-only__ Whether this user has Two Factor Authentication (TFA) enabled. Run the [Create a two factor secret](https://techdocs.akamai.com/linode-api/reference/post-tfa-enable) operation to enable TFA.",
                 "example": true,
                 "readOnly": true,
                 "type": "boolean"
               },
               "username": {
-                "description": "__Filterable__ The User's username. This is used for logging in, and may also be displayed alongside actions the User performs (for example, in Events or public StackScripts).",
+                "description": "__Filterable__ The name of this user. This user needs to use this value to log in. It may also display alongside actions this user performs, including events or public StackScripts.",
                 "example": "example_user",
                 "maxLength": 32,
                 "minLength": 3,
@@ -2898,7 +2899,7 @@
                 "x-linode-filterable": true
               },
               "verified_phone_number": {
-                "description": "__Read-only__ The phone number verified for this User Profile with the [Verify a phone number](https://techdocs.akamai.com/linode-api/reference/post-profile-phone-number-verify) operation.\n\n`null` if this User Profile has no verified phone number.",
+                "description": "__Read-only__ The [verified](https://techdocs.akamai.com/linode-api/reference/post-profile-phone-number-verify) phone number for this user profile. Returned as `null` if the user doesn't have a verified phone number.",
                 "example": "+5555555555",
                 "format": "phone",
                 "nullable": true,
@@ -2946,10 +2947,10 @@
               "allOf": [
                 {
                   "additionalProperties": false,
-                  "description": "A User on your Account. Unrestricted users can log in and access information about your Account, while restricted users may only access entities or perform actions they've been granted access to.",
+                  "description": "A user on your account. Unrestricted users can log in and access information about your account, while restricted users may only access entities or perform actions they've been granted access to.",
                   "properties": {
                     "email": {
-                      "description": "The email address for the User. Linode sends emails to this address for account management communications. May be used for other communications as configured.",
+                      "description": "This user's email address. Akamai uses this address for account management communications.",
                       "example": "example_user@linode.com",
                       "format": "email",
                       "type": "string",
@@ -2957,18 +2958,18 @@
                     },
                     "last_login": {
                       "additionalProperties": false,
-                      "description": "__Read-only__ Information for the most recent login attempt for this User.\n\n`null` if no login attempts have been made since creation of this User.\n\nRun the [List user logins](https://techdocs.akamai.com/linode-api/reference/get-account-logins) operation for additional login information.",
+                      "description": "__Read-only__ Details on this user's last login attempt. Returned as `null` if this user hasn't attempted a login since it was created. You can run the [List user logins](https://techdocs.akamai.com/linode-api/reference/get-account-logins) operation for additional login information.",
                       "nullable": true,
                       "properties": {
                         "login_datetime": {
-                          "description": "__Read-only__ The date and time of this User's most recent login attempt.",
+                          "description": "__Read-only__ The date and time of this user's most recent login attempt.",
                           "example": "2018-01-01T01:01:01",
                           "format": "date-time",
                           "readOnly": true,
                           "type": "string"
                         },
                         "status": {
-                          "description": "__Read-only__ The result of the most recent login attempt for this User.",
+                          "description": "__Read-only__ The result of this user's most recent login attempt.",
                           "enum": [
                             "successful",
                             "failed"
@@ -2982,7 +2983,7 @@
                       "type": "object"
                     },
                     "password_created": {
-                      "description": "__Read-only__ The date and time when this User's current password was created.\n\nUser passwords are first created during the Account sign-up process, and updated using the [Reset Password](https://login.linode.com/forgot/password) webpage.\n\n`null` if this User has not created a password yet.",
+                      "description": "__Read-only__ When this user's current password was created. You initially create a password during the account sign-up process, and you can update it using the [Reset Password](https://login.linode.com/forgot/password) webpage. Returned as `null` if this user doesn't have a password set.",
                       "example": "2018-01-01T01:01:01",
                       "format": "date-time",
                       "nullable": true,
@@ -2990,13 +2991,13 @@
                       "type": "string"
                     },
                     "restricted": {
-                      "description": "If `true`, the User must be granted access to perform actions or access entities on this Account. Run [List a user's grants](https://techdocs.akamai.com/linode-api/reference/get-user-grants) for details on how to configure grants for a restricted User.",
+                      "description": "If `true`, this user needs specific access granted to perform actions or access entities on your account. Run [List a user's grants](https://techdocs.akamai.com/linode-api/reference/get-user-grants) for details on how to configure grants for a restricted user.",
                       "example": true,
                       "type": "boolean",
                       "x-linode-cli-display": 3
                     },
                     "ssh_keys": {
-                      "description": "__Read-only__ A list of SSH Key labels added by this User.\n\nUsers can add keys with the [Add an SSH key](https://techdocs.akamai.com/linode-api/reference/post-add-ssh-key) operation.\n\nThese keys are deployed when this User is included in the `authorized_users` field of the following requests:\n\n- [Create a Linode](https://techdocs.akamai.com/linode-api/reference/post-linode-instance)\n- [Rebuild a Linode](https://techdocs.akamai.com/linode-api/reference/post-rebuild-linode-instance)\n- [Create a disk](https://techdocs.akamai.com/linode-api/reference/post-add-linode-disk)",
+                      "description": "__Read-only__ A list of the labels for SSH keys added by this user. Users can add keys with the [Add an SSH key](https://techdocs.akamai.com/linode-api/reference/post-add-ssh-key) operation. These keys are deployed when this user is included in the `authorized_users` field of the following requests:\n\n- [Create a Linode](https://techdocs.akamai.com/linode-api/reference/post-linode-instance)\n\n- [Rebuild a Linode](https://techdocs.akamai.com/linode-api/reference/post-rebuild-linode-instance)\n\n- [Create a disk](https://techdocs.akamai.com/linode-api/reference/post-add-linode-disk)",
                       "example": [
                         "home-pc",
                         "laptop"
@@ -3008,13 +3009,13 @@
                       "type": "array"
                     },
                     "tfa_enabled": {
-                      "description": "__Read-only__ A boolean value indicating if the User has Two Factor Authentication (TFA) enabled. Run the [Create a two factor secret](https://techdocs.akamai.com/linode-api/reference/post-tfa-enable) operation to enable TFA.",
+                      "description": "__Read-only__ Whether this user has Two Factor Authentication (TFA) enabled. Run the [Create a two factor secret](https://techdocs.akamai.com/linode-api/reference/post-tfa-enable) operation to enable TFA.",
                       "example": true,
                       "readOnly": true,
                       "type": "boolean"
                     },
                     "username": {
-                      "description": "__Filterable__ The User's username. This is used for logging in, and may also be displayed alongside actions the User performs (for example, in Events or public StackScripts).",
+                      "description": "__Filterable__ The name of this user. This user needs to use this value to log in. It may also display alongside actions this user performs, including events or public StackScripts.",
                       "example": "example_user",
                       "maxLength": 32,
                       "minLength": 3,
@@ -3029,7 +3030,7 @@
                       "x-linode-filterable": true
                     },
                     "verified_phone_number": {
-                      "description": "__Read-only__ The phone number verified for this User Profile with the [Verify a phone number](https://techdocs.akamai.com/linode-api/reference/post-profile-phone-number-verify) operation.\n\n`null` if this User Profile has no verified phone number.",
+                      "description": "__Read-only__ The [verified](https://techdocs.akamai.com/linode-api/reference/post-profile-phone-number-verify) phone number for this user profile. Returned as `null` if the user doesn't have a verified phone number.",
                       "example": "+5555555555",
                       "format": "phone",
                       "nullable": true,
@@ -3455,10 +3456,10 @@
         "allOf": [
           {
             "additionalProperties": false,
-            "description": "A User on your Account. Unrestricted users can log in and access information about your Account, while restricted users may only access entities or perform actions they've been granted access to.",
+            "description": "A user on your account. Unrestricted users can log in and access information about your account, while restricted users may only access entities or perform actions they've been granted access to.",
             "properties": {
               "email": {
-                "description": "The email address for the User. Linode sends emails to this address for account management communications. May be used for other communications as configured.",
+                "description": "This user's email address. Akamai uses this address for account management communications.",
                 "example": "example_user@linode.com",
                 "format": "email",
                 "type": "string",
@@ -3466,18 +3467,18 @@
               },
               "last_login": {
                 "additionalProperties": false,
-                "description": "__Read-only__ Information for the most recent login attempt for this User.\n\n`null` if no login attempts have been made since creation of this User.\n\nRun the [List user logins](https://techdocs.akamai.com/linode-api/reference/get-account-logins) operation for additional login information.",
+                "description": "__Read-only__ Details on this user's last login attempt. Returned as `null` if this user hasn't attempted a login since it was created. You can run the [List user logins](https://techdocs.akamai.com/linode-api/reference/get-account-logins) operation for additional login information.",
                 "nullable": true,
                 "properties": {
                   "login_datetime": {
-                    "description": "__Read-only__ The date and time of this User's most recent login attempt.",
+                    "description": "__Read-only__ The date and time of this user's most recent login attempt.",
                     "example": "2018-01-01T01:01:01",
                     "format": "date-time",
                     "readOnly": true,
                     "type": "string"
                   },
                   "status": {
-                    "description": "__Read-only__ The result of the most recent login attempt for this User.",
+                    "description": "__Read-only__ The result of this user's most recent login attempt.",
                     "enum": [
                       "successful",
                       "failed"
@@ -3491,7 +3492,7 @@
                 "type": "object"
               },
               "password_created": {
-                "description": "__Read-only__ The date and time when this User's current password was created.\n\nUser passwords are first created during the Account sign-up process, and updated using the [Reset Password](https://login.linode.com/forgot/password) webpage.\n\n`null` if this User has not created a password yet.",
+                "description": "__Read-only__ When this user's current password was created. You initially create a password during the account sign-up process, and you can update it using the [Reset Password](https://login.linode.com/forgot/password) webpage. Returned as `null` if this user doesn't have a password set.",
                 "example": "2018-01-01T01:01:01",
                 "format": "date-time",
                 "nullable": true,
@@ -3499,13 +3500,13 @@
                 "type": "string"
               },
               "restricted": {
-                "description": "If `true`, the User must be granted access to perform actions or access entities on this Account. Run [List a user's grants](https://techdocs.akamai.com/linode-api/reference/get-user-grants) for details on how to configure grants for a restricted User.",
+                "description": "If `true`, this user needs specific access granted to perform actions or access entities on your account. Run [List a user's grants](https://techdocs.akamai.com/linode-api/reference/get-user-grants) for details on how to configure grants for a restricted user.",
                 "example": true,
                 "type": "boolean",
                 "x-linode-cli-display": 3
               },
               "ssh_keys": {
-                "description": "__Read-only__ A list of SSH Key labels added by this User.\n\nUsers can add keys with the [Add an SSH key](https://techdocs.akamai.com/linode-api/reference/post-add-ssh-key) operation.\n\nThese keys are deployed when this User is included in the `authorized_users` field of the following requests:\n\n- [Create a Linode](https://techdocs.akamai.com/linode-api/reference/post-linode-instance)\n- [Rebuild a Linode](https://techdocs.akamai.com/linode-api/reference/post-rebuild-linode-instance)\n- [Create a disk](https://techdocs.akamai.com/linode-api/reference/post-add-linode-disk)",
+                "description": "__Read-only__ A list of the labels for SSH keys added by this user. Users can add keys with the [Add an SSH key](https://techdocs.akamai.com/linode-api/reference/post-add-ssh-key) operation. These keys are deployed when this user is included in the `authorized_users` field of the following requests:\n\n- [Create a Linode](https://techdocs.akamai.com/linode-api/reference/post-linode-instance)\n\n- [Rebuild a Linode](https://techdocs.akamai.com/linode-api/reference/post-rebuild-linode-instance)\n\n- [Create a disk](https://techdocs.akamai.com/linode-api/reference/post-add-linode-disk)",
                 "example": [
                   "home-pc",
                   "laptop"
@@ -3517,13 +3518,13 @@
                 "type": "array"
               },
               "tfa_enabled": {
-                "description": "__Read-only__ A boolean value indicating if the User has Two Factor Authentication (TFA) enabled. Run the [Create a two factor secret](https://techdocs.akamai.com/linode-api/reference/post-tfa-enable) operation to enable TFA.",
+                "description": "__Read-only__ Whether this user has Two Factor Authentication (TFA) enabled. Run the [Create a two factor secret](https://techdocs.akamai.com/linode-api/reference/post-tfa-enable) operation to enable TFA.",
                 "example": true,
                 "readOnly": true,
                 "type": "boolean"
               },
               "username": {
-                "description": "__Filterable__ The User's username. This is used for logging in, and may also be displayed alongside actions the User performs (for example, in Events or public StackScripts).",
+                "description": "__Filterable__ The name of this user. This user needs to use this value to log in. It may also display alongside actions this user performs, including events or public StackScripts.",
                 "example": "example_user",
                 "maxLength": 32,
                 "minLength": 3,
@@ -3538,7 +3539,7 @@
                 "x-linode-filterable": true
               },
               "verified_phone_number": {
-                "description": "__Read-only__ The phone number verified for this User Profile with the [Verify a phone number](https://techdocs.akamai.com/linode-api/reference/post-profile-phone-number-verify) operation.\n\n`null` if this User Profile has no verified phone number.",
+                "description": "__Read-only__ The [verified](https://techdocs.akamai.com/linode-api/reference/post-profile-phone-number-verify) phone number for this user profile. Returned as `null` if the user doesn't have a verified phone number.",
                 "example": "+5555555555",
                 "format": "phone",
                 "nullable": true,
@@ -3564,10 +3565,10 @@
         "allOf": [
           {
             "additionalProperties": false,
-            "description": "A User on your Account. Unrestricted users can log in and access information about your Account, while restricted users may only access entities or perform actions they've been granted access to.",
+            "description": "A user on your account. Unrestricted users can log in and access information about your account, while restricted users may only access entities or perform actions they've been granted access to.",
             "properties": {
               "email": {
-                "description": "The email address for the User. Linode sends emails to this address for account management communications. May be used for other communications as configured.",
+                "description": "This user's email address. Akamai uses this address for account management communications.",
                 "example": "example_user@linode.com",
                 "format": "email",
                 "type": "string",
@@ -3575,18 +3576,18 @@
               },
               "last_login": {
                 "additionalProperties": false,
-                "description": "__Read-only__ Information for the most recent login attempt for this User.\n\n`null` if no login attempts have been made since creation of this User.\n\nRun the [List user logins](https://techdocs.akamai.com/linode-api/reference/get-account-logins) operation for additional login information.",
+                "description": "__Read-only__ Details on this user's last login attempt. Returned as `null` if this user hasn't attempted a login since it was created. You can run the [List user logins](https://techdocs.akamai.com/linode-api/reference/get-account-logins) operation for additional login information.",
                 "nullable": true,
                 "properties": {
                   "login_datetime": {
-                    "description": "__Read-only__ The date and time of this User's most recent login attempt.",
+                    "description": "__Read-only__ The date and time of this user's most recent login attempt.",
                     "example": "2018-01-01T01:01:01",
                     "format": "date-time",
                     "readOnly": true,
                     "type": "string"
                   },
                   "status": {
-                    "description": "__Read-only__ The result of the most recent login attempt for this User.",
+                    "description": "__Read-only__ The result of this user's most recent login attempt.",
                     "enum": [
                       "successful",
                       "failed"
@@ -3600,7 +3601,7 @@
                 "type": "object"
               },
               "password_created": {
-                "description": "__Read-only__ The date and time when this User's current password was created.\n\nUser passwords are first created during the Account sign-up process, and updated using the [Reset Password](https://login.linode.com/forgot/password) webpage.\n\n`null` if this User has not created a password yet.",
+                "description": "__Read-only__ When this user's current password was created. You initially create a password during the account sign-up process, and you can update it using the [Reset Password](https://login.linode.com/forgot/password) webpage. Returned as `null` if this user doesn't have a password set.",
                 "example": "2018-01-01T01:01:01",
                 "format": "date-time",
                 "nullable": true,
@@ -3608,13 +3609,13 @@
                 "type": "string"
               },
               "restricted": {
-                "description": "If `true`, the User must be granted access to perform actions or access entities on this Account. Run [List a user's grants](https://techdocs.akamai.com/linode-api/reference/get-user-grants) for details on how to configure grants for a restricted User.",
+                "description": "If `true`, this user needs specific access granted to perform actions or access entities on your account. Run [List a user's grants](https://techdocs.akamai.com/linode-api/reference/get-user-grants) for details on how to configure grants for a restricted user.",
                 "example": true,
                 "type": "boolean",
                 "x-linode-cli-display": 3
               },
               "ssh_keys": {
-                "description": "__Read-only__ A list of SSH Key labels added by this User.\n\nUsers can add keys with the [Add an SSH key](https://techdocs.akamai.com/linode-api/reference/post-add-ssh-key) operation.\n\nThese keys are deployed when this User is included in the `authorized_users` field of the following requests:\n\n- [Create a Linode](https://techdocs.akamai.com/linode-api/reference/post-linode-instance)\n- [Rebuild a Linode](https://techdocs.akamai.com/linode-api/reference/post-rebuild-linode-instance)\n- [Create a disk](https://techdocs.akamai.com/linode-api/reference/post-add-linode-disk)",
+                "description": "__Read-only__ A list of the labels for SSH keys added by this user. Users can add keys with the [Add an SSH key](https://techdocs.akamai.com/linode-api/reference/post-add-ssh-key) operation. These keys are deployed when this user is included in the `authorized_users` field of the following requests:\n\n- [Create a Linode](https://techdocs.akamai.com/linode-api/reference/post-linode-instance)\n\n- [Rebuild a Linode](https://techdocs.akamai.com/linode-api/reference/post-rebuild-linode-instance)\n\n- [Create a disk](https://techdocs.akamai.com/linode-api/reference/post-add-linode-disk)",
                 "example": [
                   "home-pc",
                   "laptop"
@@ -3626,13 +3627,13 @@
                 "type": "array"
               },
               "tfa_enabled": {
-                "description": "__Read-only__ A boolean value indicating if the User has Two Factor Authentication (TFA) enabled. Run the [Create a two factor secret](https://techdocs.akamai.com/linode-api/reference/post-tfa-enable) operation to enable TFA.",
+                "description": "__Read-only__ Whether this user has Two Factor Authentication (TFA) enabled. Run the [Create a two factor secret](https://techdocs.akamai.com/linode-api/reference/post-tfa-enable) operation to enable TFA.",
                 "example": true,
                 "readOnly": true,
                 "type": "boolean"
               },
               "username": {
-                "description": "__Filterable__ The User's username. This is used for logging in, and may also be displayed alongside actions the User performs (for example, in Events or public StackScripts).",
+                "description": "__Filterable__ The name of this user. This user needs to use this value to log in. It may also display alongside actions this user performs, including events or public StackScripts.",
                 "example": "example_user",
                 "maxLength": 32,
                 "minLength": 3,
@@ -3647,7 +3648,7 @@
                 "x-linode-filterable": true
               },
               "verified_phone_number": {
-                "description": "__Read-only__ The phone number verified for this User Profile with the [Verify a phone number](https://techdocs.akamai.com/linode-api/reference/post-profile-phone-number-verify) operation.\n\n`null` if this User Profile has no verified phone number.",
+                "description": "__Read-only__ The [verified](https://techdocs.akamai.com/linode-api/reference/post-profile-phone-number-verify) phone number for this user profile. Returned as `null` if the user doesn't have a verified phone number.",
                 "example": "+5555555555",
                 "format": "phone",
                 "nullable": true,
@@ -3691,6 +3692,10 @@
         "additionalProperties": false,
         "description": "Acknowledgment status for agreements on your account. When acknowledging any agreements, set them to `true` and omit any remainders.",
         "properties": {
+          "billing_agreement": {
+            "description": "Certain regions require that you share your tax identification number (TIN) with Akamai. When you do, you need to acknowledge Akamai's [privacy statement](https://www.akamai.com/legal/privacy-statement) agreement, in regards to its protection. When set to `true`, you've acknowledged this agreement.",
+            "type": "boolean"
+          },
           "eu_model": {
             "description": "The acknowledgement status for the [cross-border data transfer](https://www.akamai.com/legal/compliance/privacy-trust-center/cross-border-data-transfer-statement) agreement.",
             "example": true,
@@ -3976,7 +3981,7 @@
             "x-linode-filterable": true
           },
           "state": {
-            "description": "__Filterable__ The state or province for the billing address (`address_1` and `address_2, if applicable`). If in the United States (US) or Canada (CA), this is the two-letter ISO 3166 State or Province code.\n\n__Note__. If this is a US military address, use state abbreviations (AA, AE, AP).",
+            "description": "__Filterable__ The state or province for the billing address (`address_1` and `address_2, if applicable`). If in the United States (US) or Canada (CA), this is the two-letter ISO 3166 State or Province code.\n\n> 📘\n>\n> If this is a US military address, use state abbreviations (AA, AE, AP).",
             "example": "CA",
             "maxLength": 24,
             "type": "string",
@@ -4838,10 +4843,6 @@
                 "example": true,
                 "type": "boolean"
               },
-              "add_placement_groups": {
-                "description": "If `true`, this User may add Placement Groups.",
-                "type": "boolean"
-              },
               "add_stackscripts": {
                 "description": "If `true`, this User may add StackScripts.",
                 "example": true,
@@ -4983,41 +4984,6 @@
           },
           "nodebalancer": {
             "description": "The grants this User has for each NodeBalancer that is owned by this Account.",
-            "items": {
-              "additionalProperties": false,
-              "description": "Represents the level of access a restricted User has to a specific resource on the Account.",
-              "properties": {
-                "id": {
-                  "description": "The ID of the entity this grant applies to.",
-                  "example": 123,
-                  "type": "integer"
-                },
-                "label": {
-                  "description": "__Read-only__ The current label of the entity this grant applies to, for display purposes.",
-                  "example": "example-entity",
-                  "readOnly": true,
-                  "type": "string"
-                },
-                "permissions": {
-                  "description": "The level of access this User has to this entity.  If `null`, this User has no access.",
-                  "enum": [
-                    "read_only",
-                    "read_write"
-                  ],
-                  "example": "read_only",
-                  "nullable": true,
-                  "type": "string"
-                }
-              },
-              "type": "object",
-              "x-akamai": {
-                "file-path": "schemas/grant.yaml"
-              }
-            },
-            "type": "array"
-          },
-          "placement_group": {
-            "description": "The grants this User has for each Placement Group that is owned by this Account.",
             "items": {
               "additionalProperties": false,
               "description": "Represents the level of access a restricted User has to a specific resource on the Account.",
@@ -5621,7 +5587,8 @@
               "ticket_abuse",
               "notice",
               "maintenance",
-              "promotion"
+              "promotion",
+              "tax_id_verifying"
             ],
             "example": "ticket_important",
             "readOnly": true,
@@ -6362,10 +6329,10 @@
       },
       "user": {
         "additionalProperties": false,
-        "description": "A User on your Account. Unrestricted users can log in and access information about your Account, while restricted users may only access entities or perform actions they've been granted access to.",
+        "description": "A user on your account. Unrestricted users can log in and access information about your account, while restricted users may only access entities or perform actions they've been granted access to.",
         "properties": {
           "email": {
-            "description": "The email address for the User. Linode sends emails to this address for account management communications. May be used for other communications as configured.",
+            "description": "This user's email address. Akamai uses this address for account management communications.",
             "example": "example_user@linode.com",
             "format": "email",
             "type": "string",
@@ -6373,18 +6340,18 @@
           },
           "last_login": {
             "additionalProperties": false,
-            "description": "__Read-only__ Information for the most recent login attempt for this User.\n\n`null` if no login attempts have been made since creation of this User.\n\nRun the [List user logins](https://techdocs.akamai.com/linode-api/reference/get-account-logins) operation for additional login information.",
+            "description": "__Read-only__ Details on this user's last login attempt. Returned as `null` if this user hasn't attempted a login since it was created. You can run the [List user logins](https://techdocs.akamai.com/linode-api/reference/get-account-logins) operation for additional login information.",
             "nullable": true,
             "properties": {
               "login_datetime": {
-                "description": "__Read-only__ The date and time of this User's most recent login attempt.",
+                "description": "__Read-only__ The date and time of this user's most recent login attempt.",
                 "example": "2018-01-01T01:01:01",
                 "format": "date-time",
                 "readOnly": true,
                 "type": "string"
               },
               "status": {
-                "description": "__Read-only__ The result of the most recent login attempt for this User.",
+                "description": "__Read-only__ The result of this user's most recent login attempt.",
                 "enum": [
                   "successful",
                   "failed"
@@ -6398,7 +6365,7 @@
             "type": "object"
           },
           "password_created": {
-            "description": "__Read-only__ The date and time when this User's current password was created.\n\nUser passwords are first created during the Account sign-up process, and updated using the [Reset Password](https://login.linode.com/forgot/password) webpage.\n\n`null` if this User has not created a password yet.",
+            "description": "__Read-only__ When this user's current password was created. You initially create a password during the account sign-up process, and you can update it using the [Reset Password](https://login.linode.com/forgot/password) webpage. Returned as `null` if this user doesn't have a password set.",
             "example": "2018-01-01T01:01:01",
             "format": "date-time",
             "nullable": true,
@@ -6406,13 +6373,13 @@
             "type": "string"
           },
           "restricted": {
-            "description": "If `true`, the User must be granted access to perform actions or access entities on this Account. Run [List a user's grants](https://techdocs.akamai.com/linode-api/reference/get-user-grants) for details on how to configure grants for a restricted User.",
+            "description": "If `true`, this user needs specific access granted to perform actions or access entities on your account. Run [List a user's grants](https://techdocs.akamai.com/linode-api/reference/get-user-grants) for details on how to configure grants for a restricted user.",
             "example": true,
             "type": "boolean",
             "x-linode-cli-display": 3
           },
           "ssh_keys": {
-            "description": "__Read-only__ A list of SSH Key labels added by this User.\n\nUsers can add keys with the [Add an SSH key](https://techdocs.akamai.com/linode-api/reference/post-add-ssh-key) operation.\n\nThese keys are deployed when this User is included in the `authorized_users` field of the following requests:\n\n- [Create a Linode](https://techdocs.akamai.com/linode-api/reference/post-linode-instance)\n- [Rebuild a Linode](https://techdocs.akamai.com/linode-api/reference/post-rebuild-linode-instance)\n- [Create a disk](https://techdocs.akamai.com/linode-api/reference/post-add-linode-disk)",
+            "description": "__Read-only__ A list of the labels for SSH keys added by this user. Users can add keys with the [Add an SSH key](https://techdocs.akamai.com/linode-api/reference/post-add-ssh-key) operation. These keys are deployed when this user is included in the `authorized_users` field of the following requests:\n\n- [Create a Linode](https://techdocs.akamai.com/linode-api/reference/post-linode-instance)\n\n- [Rebuild a Linode](https://techdocs.akamai.com/linode-api/reference/post-rebuild-linode-instance)\n\n- [Create a disk](https://techdocs.akamai.com/linode-api/reference/post-add-linode-disk)",
             "example": [
               "home-pc",
               "laptop"
@@ -6424,13 +6391,13 @@
             "type": "array"
           },
           "tfa_enabled": {
-            "description": "__Read-only__ A boolean value indicating if the User has Two Factor Authentication (TFA) enabled. Run the [Create a two factor secret](https://techdocs.akamai.com/linode-api/reference/post-tfa-enable) operation to enable TFA.",
+            "description": "__Read-only__ Whether this user has Two Factor Authentication (TFA) enabled. Run the [Create a two factor secret](https://techdocs.akamai.com/linode-api/reference/post-tfa-enable) operation to enable TFA.",
             "example": true,
             "readOnly": true,
             "type": "boolean"
           },
           "username": {
-            "description": "__Filterable__ The User's username. This is used for logging in, and may also be displayed alongside actions the User performs (for example, in Events or public StackScripts).",
+            "description": "__Filterable__ The name of this user. This user needs to use this value to log in. It may also display alongside actions this user performs, including events or public StackScripts.",
             "example": "example_user",
             "maxLength": 32,
             "minLength": 3,
@@ -6445,7 +6412,7 @@
             "x-linode-filterable": true
           },
           "verified_phone_number": {
-            "description": "__Read-only__ The phone number verified for this User Profile with the [Verify a phone number](https://techdocs.akamai.com/linode-api/reference/post-profile-phone-number-verify) operation.\n\n`null` if this User Profile has no verified phone number.",
+            "description": "__Read-only__ The [verified](https://techdocs.akamai.com/linode-api/reference/post-profile-phone-number-verify) phone number for this user profile. Returned as `null` if the user doesn't have a verified phone number.",
             "example": "+5555555555",
             "format": "phone",
             "nullable": true,
@@ -6564,7 +6531,7 @@
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
     "title": "Akamai: Linode API",
-    "version": "4.193.0"
+    "version": "4.197.0"
   },
   "openapi": "3.0.1",
   "paths": {
@@ -6796,7 +6763,7 @@
                       "type": "string"
                     },
                     "tax_id": {
-                      "description": "The tax identification number assigned to this account, used for tax calculations in a `country` that collects tax. Set to an empty string (`\"\"`) for countries that don't collect tax.\n\n> 📘\n>\n> This value is externally validated. If the validation is successful, a `tax_id_valid` [event](https://techdocs.akamai.com/linode-api/reference/get-events) is triggered. If unsuccessful, a `tax_id_invalid` event is triggered and an error response is issued for an operation that included it.",
+                      "description": "The tax identification number (TIN) assigned to this account, used for tax calculations. A TIN is set by the national authorities in your `country`, based on your `address_1`, and it may be named differently between countries. Set to an empty string (`\"\"`) if a TIN doesn't apply or for countries that don't collect tax.\n\n> 📘\n>\n> This value is externally validated. If the validation is successful, a `tax_id_valid` [event](https://techdocs.akamai.com/linode-api/reference/get-events) is triggered. If unsuccessful, a `tax_id_invalid` event is triggered and an error response is issued for an operation that included it.",
                       "example": "ATU99999999",
                       "maxLength": 25,
                       "type": "string"
@@ -7113,7 +7080,7 @@
                     "type": "string"
                   },
                   "tax_id": {
-                    "description": "The tax identification number assigned to this account, used for tax calculations in a `country` that collects tax. Set to an empty string (`\"\"`) for countries that don't collect tax.\n\n> 📘\n>\n> This value is externally validated. If the validation is successful, a `tax_id_valid` [event](https://techdocs.akamai.com/linode-api/reference/get-events) is triggered. If unsuccessful, a `tax_id_invalid` event is triggered and an error response is issued for an operation that included it.",
+                    "description": "The tax identification number (TIN) assigned to this account, used for tax calculations. A TIN is set by the national authorities in your `country`, based on your `address_1`, and it may be named differently between countries. Set to an empty string (`\"\"`) if a TIN doesn't apply or for countries that don't collect tax.\n\n> 📘\n>\n> This value is externally validated. If the validation is successful, a `tax_id_valid` [event](https://techdocs.akamai.com/linode-api/reference/get-events) is triggered. If unsuccessful, a `tax_id_invalid` event is triggered and an error response is issued for an operation that included it.",
                     "example": "{{tax_id}}",
                     "maxLength": 25,
                     "type": "string"
@@ -7357,7 +7324,7 @@
                       "type": "string"
                     },
                     "tax_id": {
-                      "description": "The tax identification number assigned to this account, used for tax calculations in a `country` that collects tax. Set to an empty string (`\"\"`) for countries that don't collect tax.\n\n> 📘\n>\n> This value is externally validated. If the validation is successful, a `tax_id_valid` [event](https://techdocs.akamai.com/linode-api/reference/get-events) is triggered. If unsuccessful, a `tax_id_invalid` event is triggered and an error response is issued for an operation that included it.",
+                      "description": "The tax identification number (TIN) assigned to this account, used for tax calculations. A TIN is set by the national authorities in your `country`, based on your `address_1`, and it may be named differently between countries. Set to an empty string (`\"\"`) if a TIN doesn't apply or for countries that don't collect tax.\n\n> 📘\n>\n> This value is externally validated. If the validation is successful, a `tax_id_valid` [event](https://techdocs.akamai.com/linode-api/reference/get-events) is triggered. If unsuccessful, a `tax_id_invalid` event is triggered and an error response is issued for an operation that included it.",
                       "example": "ATU99999999",
                       "maxLength": 25,
                       "type": "string"
@@ -7488,6 +7455,11 @@
                 "additionalProperties": false,
                 "description": "Acknowledgment status for agreements on your account. When acknowledging any agreements, set them to `true` and omit any remainders.",
                 "properties": {
+                  "billing_agreement": {
+                    "description": "Certain regions require that you share your tax identification number (TIN) with Akamai. When you do, you need to acknowledge Akamai's [privacy statement](https://www.akamai.com/legal/privacy-statement) agreement, in regards to its protection. When set to `true`, you've acknowledged this agreement.",
+                    "example": "{{billing_agreement}}",
+                    "type": "boolean"
+                  },
                   "eu_model": {
                     "description": "The acknowledgement status for the [cross-border data transfer](https://www.akamai.com/legal/compliance/privacy-trust-center/cross-border-data-transfer-statement) agreement.",
                     "example": "{{eu_model}}",
@@ -7614,6 +7586,10 @@
                   "additionalProperties": false,
                   "description": "Acknowledgment status for agreements on your account. When acknowledging any agreements, set them to `true` and omit any remainders.",
                   "properties": {
+                    "billing_agreement": {
+                      "description": "Certain regions require that you share your tax identification number (TIN) with Akamai. When you do, you need to acknowledge Akamai's [privacy statement](https://www.akamai.com/legal/privacy-statement) agreement, in regards to its protection. When set to `true`, you've acknowledged this agreement.",
+                      "type": "boolean"
+                    },
                     "eu_model": {
                       "description": "The acknowledgement status for the [cross-border data transfer](https://www.akamai.com/legal/compliance/privacy-trust-center/cross-border-data-transfer-statement) agreement.",
                       "example": true,
@@ -7733,7 +7709,7 @@
     },
     "/{apiVersion}/account/availability": {
       "get": {
-        "description": "Returns a paginated list of the services available to you, for all Linode regions.\n\n__Note__. Only authorized Users can run this operation.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli account get-availability\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Returns a paginated list of the services available to you, for all Linode regions.\n\n> 📘\n>\n> Only authorized users can run this operation.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli account get-availability\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-availability"
@@ -8767,7 +8743,7 @@
     },
     "/{apiVersion}/account/cancel": {
       "post": {
-        "description": "Cancels an active account. Akamai attempts to charge the credit card on file for any remaining balance. An error occurs if this charge fails.\n\n> 📘\n>\n> Only account users with _unrestricted_ access can run this operation.\n\n__Parent and child accounts__ In a [parent and child account](https://www.linode.com/docs/guides/parent-child-accounts/) environment, the following apply:\n\n- A child account user can't cancel a child account.\n\n- You can't cancel a parent account if it has an active child account.\n\n- You need to work with your Akamai account team to dissolve any parent-child account relationships before you can fully cancel a child or parent account.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli account cancel \\\n  --comments \"I'm consolidating my accounts\"\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Cancels an active account. Akamai attempts to charge the credit card on file for any remaining balance. An error occurs if this charge fails.\n\n> 📘\n>\n> Only account users with _unrestricted_ access can run this operation.\n\n__Parent and child accounts__\n\nIn a [parent and child account](https://www.linode.com/docs/guides/parent-child-accounts/) environment, the following apply:\n\n- A child account user can't cancel a child account.\n\n- You can't cancel a parent account if it has an active child account.\n\n- You need to work with your Akamai account team to dissolve any parent-child account relationships before you can fully cancel a child or parent account.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli account cancel \\\n  --comments \"I'm consolidating my accounts\"\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/post-cancel-account"
@@ -8956,7 +8932,7 @@
     },
     "/{apiVersion}/account/child-accounts": {
       "get": {
-        "description": "Returns a paginated list of basic information for the child accounts that exist for your parent account. See [Parent and Child Accounts for Akamai Partners](https://www.linode.com/docs/guides/parent-child-accounts/) for details on these accounts.\n\n__Note__. This operation can only be accessed by an unrestricted parent user, or restricted parent user with the `child_account_access` grant.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli child-account list\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    child_account:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Returns a paginated list of basic information for the child accounts that exist for your parent account. See [Parent and Child Accounts for Akamai Partners](https://www.linode.com/docs/guides/parent-child-accounts/) for details on these accounts.\n\n> 📘\n>\n> This operation can only be accessed by an unrestricted parent user, or restricted parent user with the `child_account_access` grant.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli child-account list\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    child_account:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-child-accounts"
@@ -9188,7 +9164,7 @@
                             "x-linode-filterable": true
                           },
                           "state": {
-                            "description": "__Filterable__ The state or province for the billing address (`address_1` and `address_2, if applicable`). If in the United States (US) or Canada (CA), this is the two-letter ISO 3166 State or Province code.\n\n__Note__. If this is a US military address, use state abbreviations (AA, AE, AP).",
+                            "description": "__Filterable__ The state or province for the billing address (`address_1` and `address_2, if applicable`). If in the United States (US) or Canada (CA), this is the two-letter ISO 3166 State or Province code.\n\n> 📘\n>\n> If this is a US military address, use state abbreviations (AA, AE, AP).",
                             "example": "CA",
                             "maxLength": 24,
                             "type": "string",
@@ -9353,7 +9329,7 @@
     },
     "/{apiVersion}/account/child-accounts/{euuid}": {
       "get": {
-        "description": "View a specific child account based on its `euuid`. See [Parent and Child Accounts for Akamai Partners](https://www.linode.com/docs/guides/parent-child-accounts/) for details on these accounts.\n\n__Note__. This operation can only be accessed by an unrestricted user, or restricted user with the `child_account_access` grant.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli child-account view A1BC2DEF-34GH-567I-J890KLMN12O34P56\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    child_account:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "View a specific child account based on its `euuid`. See [Parent and Child Accounts for Akamai Partners](https://www.linode.com/docs/guides/parent-child-accounts/) for details on these accounts.\n\n> 📘\n>\n> This operation can only be accessed by an unrestricted user, or restricted user with the `child_account_access` grant.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli child-account view A1BC2DEF-34GH-567I-J890KLMN12O34P56\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    child_account:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-child-account"
@@ -9547,7 +9523,7 @@
                       "x-linode-filterable": true
                     },
                     "state": {
-                      "description": "__Filterable__ The state or province for the billing address (`address_1` and `address_2, if applicable`). If in the United States (US) or Canada (CA), this is the two-letter ISO 3166 State or Province code.\n\n__Note__. If this is a US military address, use state abbreviations (AA, AE, AP).",
+                      "description": "__Filterable__ The state or province for the billing address (`address_1` and `address_2, if applicable`). If in the United States (US) or Canada (CA), this is the two-letter ISO 3166 State or Province code.\n\n> 📘\n>\n> If this is a US military address, use state abbreviations (AA, AE, AP).",
                       "example": "CA",
                       "maxLength": 24,
                       "type": "string",
@@ -9698,7 +9674,7 @@
     },
     "/{apiVersion}/account/child-accounts/{euuid}/token": {
       "post": {
-        "description": "Create a short-lived bearer token for a parent user on a child account, using the `euuid` of that child account. In the context of the API, a parent user on a child account is referred to as a \"proxy user.\" When Akamai provisions your parent-child account environment, a proxy user is automatically set in the child account. It follows a specific naming convention:\n\n    <Parent account `company` name>_<SHA256 hash of parent `company` name and child account `euuid`>\n\n__Note__. The variables above use only the first 15 and 16 characters of these values, respectively.\n\nThe token lets a parent account run API operations through the proxy user, as if they are a child user in the child account.\n\nThese points apply to the use of this operation:\n\n- To create a token, a parent account user needs the `child_account_access` grant. This lets them use the proxy user on the child account. You can run [List a user's grants](https://techdocs.akamai.com/linode-api/reference/get-user-grants) on a parent account user to check its `child_account_access` setting. To add this access, you can [update](https://techdocs.akamai.com/linode-api/reference/put-user-grants) the parent account user.\n\n- The created token inherits the permissions of the proxy user. It will never have less.\n\n- The API returns the raw token in the response. You can't get it again, so be sure to store it.\n\nExample workflow:\n\n1. [List child accounts](https://techdocs.akamai.com/linode-api/reference/get-child-accounts) and store the `euuid` for the applicable one.\n2. Run this operation and store the `token` that's created for the proxy user.\n3. As a parent account user with access to the proxy user in the child account, use this `token` to authenticate API operations, as if you were a child user.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli child-account create A1BC2DEF-34GH-567I-J890KLMN12O34P56\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    child_account:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Create a short-lived bearer token for a parent user on a child account, using the `euuid` of that child account. In the context of the API, a parent user on a child account is referred to as a \"proxy user.\" When Akamai provisions your parent-child account environment, a proxy user is automatically set in the child account. It follows a specific naming convention:\n\n    <Parent account `company` name>_<SHA256 hash of parent `company` name and child account `euuid`>\n\n> 📘\n>\n> These variables only use the first 15 and 16 characters of these values, respectively.\n\nThe token lets a parent account run API operations through the proxy user, as if they are a child user in the child account.\n\nThese points apply to the use of this operation:\n\n- To create a token, a parent account user needs the `child_account_access` grant. This lets them use the proxy user on the child account. You can run [List a user's grants](https://techdocs.akamai.com/linode-api/reference/get-user-grants) on a parent account user to check its `child_account_access` setting. To add this access, you can [update](https://techdocs.akamai.com/linode-api/reference/put-user-grants) the parent account user.\n\n- The created token inherits the permissions of the proxy user. It will never have less.\n\n- The API returns the raw token in the response. You can't get it again, so be sure to store it.\n\nExample workflow:\n\n1. [List child accounts](https://techdocs.akamai.com/linode-api/reference/get-child-accounts) and store the `euuid` for the applicable one.\n2. Run this operation and store the `token` that's created for the proxy user.\n3. As a parent account user with access to the proxy user in the child account, use this `token` to authenticate API operations, as if you were a child user.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli child-account create A1BC2DEF-34GH-567I-J890KLMN12O34P56\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    child_account:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/post-child-account-token"
@@ -13846,7 +13822,8 @@
                               "ticket_abuse",
                               "notice",
                               "maintenance",
-                              "promotion"
+                              "promotion",
+                              "tax_id_verifying"
                             ],
                             "example": "ticket_important",
                             "readOnly": true,
@@ -19302,7 +19279,7 @@
     },
     "/{apiVersion}/account/users": {
       "post": {
-        "description": "Creates a user on your account. You determine the new user's account access by setting it to restricted or unrestricted and by defining its grants. After completion, the API sends a confirmation message containing password creation and login instructions to the user's `email` address.\n\n__Note__. This operation can only be accessed by account users with _unrestricted_ access.\n\n__Parent and child accounts__\n\nIn a [parent and child account](https://www.linode.com/docs/guides/parent-child-accounts/) environment, the following apply:\n\n- A parent account user can create new parent account users.\n\n- A child account can [update](https://techdocs.akamai.com/linode-api/reference/put-user) the child account parent user (proxy user) to `unrestricted`. This gives the proxy user access to create new child account users.\n\n- A child account user can create new child account users.\n\n- You can't create a proxy user. The proxy user in a child account is predefined when you initially provision the parent-child relationship.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli users create \\\n  --username example_user \\\n  --email example_user@linode.com \\\n  --restricted true\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Creates a user on your account. You determine the new user's account access by setting it to restricted or unrestricted and by defining its grants. After completion, the API sends a confirmation message containing password creation and login instructions to the user's `email` address.\n\n> 📘\n>\n> This operation can only be accessed by account users with _unrestricted_ access.\n\n__Parent and child accounts__\n\nIn a [parent and child account](https://www.linode.com/docs/guides/parent-child-accounts/) environment, the following apply:\n\n- A parent account user can create new parent account users.\n\n- A child account can [update](https://techdocs.akamai.com/linode-api/reference/put-user) the child account parent user (proxy user) to `unrestricted`. This gives the proxy user access to create new child account users.\n\n- A child account user can create new child account users.\n\n- You can't create a proxy user. The proxy user in a child account is predefined when you initially provision the parent-child relationship.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli users create \\\n  --username example_user \\\n  --email example_user@linode.com \\\n  --restricted true\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/post-user"
@@ -19315,10 +19292,10 @@
                 "allOf": [
                   {
                     "additionalProperties": false,
-                    "description": "A User on your Account. Unrestricted users can log in and access information about your Account, while restricted users may only access entities or perform actions they've been granted access to.",
+                    "description": "A user on your account. Unrestricted users can log in and access information about your account, while restricted users may only access entities or perform actions they've been granted access to.",
                     "properties": {
                       "email": {
-                        "description": "The email address for the User. Linode sends emails to this address for account management communications. May be used for other communications as configured.",
+                        "description": "This user's email address. Akamai uses this address for account management communications.",
                         "example": "example_user@linode.com",
                         "format": "email",
                         "type": "string",
@@ -19326,18 +19303,18 @@
                       },
                       "last_login": {
                         "additionalProperties": false,
-                        "description": "__Read-only__ Information for the most recent login attempt for this User.\n\n`null` if no login attempts have been made since creation of this User.\n\nRun the [List user logins](https://techdocs.akamai.com/linode-api/reference/get-account-logins) operation for additional login information.",
+                        "description": "__Read-only__ Details on this user's last login attempt. Returned as `null` if this user hasn't attempted a login since it was created. You can run the [List user logins](https://techdocs.akamai.com/linode-api/reference/get-account-logins) operation for additional login information.",
                         "nullable": true,
                         "properties": {
                           "login_datetime": {
-                            "description": "__Read-only__ The date and time of this User's most recent login attempt.",
+                            "description": "__Read-only__ The date and time of this user's most recent login attempt.",
                             "example": "2018-01-01T01:01:01",
                             "format": "date-time",
                             "readOnly": true,
                             "type": "string"
                           },
                           "status": {
-                            "description": "__Read-only__ The result of the most recent login attempt for this User.",
+                            "description": "__Read-only__ The result of this user's most recent login attempt.",
                             "enum": [
                               "successful",
                               "failed"
@@ -19351,7 +19328,7 @@
                         "type": "object"
                       },
                       "password_created": {
-                        "description": "__Read-only__ The date and time when this User's current password was created.\n\nUser passwords are first created during the Account sign-up process, and updated using the [Reset Password](https://login.linode.com/forgot/password) webpage.\n\n`null` if this User has not created a password yet.",
+                        "description": "__Read-only__ When this user's current password was created. You initially create a password during the account sign-up process, and you can update it using the [Reset Password](https://login.linode.com/forgot/password) webpage. Returned as `null` if this user doesn't have a password set.",
                         "example": "2018-01-01T01:01:01",
                         "format": "date-time",
                         "nullable": true,
@@ -19359,13 +19336,13 @@
                         "type": "string"
                       },
                       "restricted": {
-                        "description": "If `true`, the User must be granted access to perform actions or access entities on this Account. Run [List a user's grants](https://techdocs.akamai.com/linode-api/reference/get-user-grants) for details on how to configure grants for a restricted User.",
+                        "description": "If `true`, this user needs specific access granted to perform actions or access entities on your account. Run [List a user's grants](https://techdocs.akamai.com/linode-api/reference/get-user-grants) for details on how to configure grants for a restricted user.",
                         "example": true,
                         "type": "boolean",
                         "x-linode-cli-display": 3
                       },
                       "ssh_keys": {
-                        "description": "__Read-only__ A list of SSH Key labels added by this User.\n\nUsers can add keys with the [Add an SSH key](https://techdocs.akamai.com/linode-api/reference/post-add-ssh-key) operation.\n\nThese keys are deployed when this User is included in the `authorized_users` field of the following requests:\n\n- [Create a Linode](https://techdocs.akamai.com/linode-api/reference/post-linode-instance)\n- [Rebuild a Linode](https://techdocs.akamai.com/linode-api/reference/post-rebuild-linode-instance)\n- [Create a disk](https://techdocs.akamai.com/linode-api/reference/post-add-linode-disk)",
+                        "description": "__Read-only__ A list of the labels for SSH keys added by this user. Users can add keys with the [Add an SSH key](https://techdocs.akamai.com/linode-api/reference/post-add-ssh-key) operation. These keys are deployed when this user is included in the `authorized_users` field of the following requests:\n\n- [Create a Linode](https://techdocs.akamai.com/linode-api/reference/post-linode-instance)\n\n- [Rebuild a Linode](https://techdocs.akamai.com/linode-api/reference/post-rebuild-linode-instance)\n\n- [Create a disk](https://techdocs.akamai.com/linode-api/reference/post-add-linode-disk)",
                         "example": [
                           "home-pc",
                           "laptop"
@@ -19377,13 +19354,13 @@
                         "type": "array"
                       },
                       "tfa_enabled": {
-                        "description": "__Read-only__ A boolean value indicating if the User has Two Factor Authentication (TFA) enabled. Run the [Create a two factor secret](https://techdocs.akamai.com/linode-api/reference/post-tfa-enable) operation to enable TFA.",
+                        "description": "__Read-only__ Whether this user has Two Factor Authentication (TFA) enabled. Run the [Create a two factor secret](https://techdocs.akamai.com/linode-api/reference/post-tfa-enable) operation to enable TFA.",
                         "example": true,
                         "readOnly": true,
                         "type": "boolean"
                       },
                       "username": {
-                        "description": "__Filterable__ The User's username. This is used for logging in, and may also be displayed alongside actions the User performs (for example, in Events or public StackScripts).",
+                        "description": "__Filterable__ The name of this user. This user needs to use this value to log in. It may also display alongside actions this user performs, including events or public StackScripts.",
                         "example": "example_user",
                         "maxLength": 32,
                         "minLength": 3,
@@ -19398,7 +19375,7 @@
                         "x-linode-filterable": true
                       },
                       "verified_phone_number": {
-                        "description": "__Read-only__ The phone number verified for this User Profile with the [Verify a phone number](https://techdocs.akamai.com/linode-api/reference/post-profile-phone-number-verify) operation.\n\n`null` if this User Profile has no verified phone number.",
+                        "description": "__Read-only__ The [verified](https://techdocs.akamai.com/linode-api/reference/post-profile-phone-number-verify) phone number for this user profile. Returned as `null` if the user doesn't have a verified phone number.",
                         "example": "+5555555555",
                         "format": "phone",
                         "nullable": true,
@@ -19433,10 +19410,10 @@
               "application/json": {
                 "schema": {
                   "additionalProperties": false,
-                  "description": "A User on your Account. Unrestricted users can log in and access information about your Account, while restricted users may only access entities or perform actions they've been granted access to.",
+                  "description": "A user on your account. Unrestricted users can log in and access information about your account, while restricted users may only access entities or perform actions they've been granted access to.",
                   "properties": {
                     "email": {
-                      "description": "The email address for the User. Linode sends emails to this address for account management communications. May be used for other communications as configured.",
+                      "description": "This user's email address. Akamai uses this address for account management communications.",
                       "example": "example_user@linode.com",
                       "format": "email",
                       "type": "string",
@@ -19444,18 +19421,18 @@
                     },
                     "last_login": {
                       "additionalProperties": false,
-                      "description": "__Read-only__ Information for the most recent login attempt for this User.\n\n`null` if no login attempts have been made since creation of this User.\n\nRun the [List user logins](https://techdocs.akamai.com/linode-api/reference/get-account-logins) operation for additional login information.",
+                      "description": "__Read-only__ Details on this user's last login attempt. Returned as `null` if this user hasn't attempted a login since it was created. You can run the [List user logins](https://techdocs.akamai.com/linode-api/reference/get-account-logins) operation for additional login information.",
                       "nullable": true,
                       "properties": {
                         "login_datetime": {
-                          "description": "__Read-only__ The date and time of this User's most recent login attempt.",
+                          "description": "__Read-only__ The date and time of this user's most recent login attempt.",
                           "example": "2018-01-01T01:01:01",
                           "format": "date-time",
                           "readOnly": true,
                           "type": "string"
                         },
                         "status": {
-                          "description": "__Read-only__ The result of the most recent login attempt for this User.",
+                          "description": "__Read-only__ The result of this user's most recent login attempt.",
                           "enum": [
                             "successful",
                             "failed"
@@ -19469,7 +19446,7 @@
                       "type": "object"
                     },
                     "password_created": {
-                      "description": "__Read-only__ The date and time when this User's current password was created.\n\nUser passwords are first created during the Account sign-up process, and updated using the [Reset Password](https://login.linode.com/forgot/password) webpage.\n\n`null` if this User has not created a password yet.",
+                      "description": "__Read-only__ When this user's current password was created. You initially create a password during the account sign-up process, and you can update it using the [Reset Password](https://login.linode.com/forgot/password) webpage. Returned as `null` if this user doesn't have a password set.",
                       "example": "2018-01-01T01:01:01",
                       "format": "date-time",
                       "nullable": true,
@@ -19477,13 +19454,13 @@
                       "type": "string"
                     },
                     "restricted": {
-                      "description": "If `true`, the User must be granted access to perform actions or access entities on this Account. Run [List a user's grants](https://techdocs.akamai.com/linode-api/reference/get-user-grants) for details on how to configure grants for a restricted User.",
+                      "description": "If `true`, this user needs specific access granted to perform actions or access entities on your account. Run [List a user's grants](https://techdocs.akamai.com/linode-api/reference/get-user-grants) for details on how to configure grants for a restricted user.",
                       "example": true,
                       "type": "boolean",
                       "x-linode-cli-display": 3
                     },
                     "ssh_keys": {
-                      "description": "__Read-only__ A list of SSH Key labels added by this User.\n\nUsers can add keys with the [Add an SSH key](https://techdocs.akamai.com/linode-api/reference/post-add-ssh-key) operation.\n\nThese keys are deployed when this User is included in the `authorized_users` field of the following requests:\n\n- [Create a Linode](https://techdocs.akamai.com/linode-api/reference/post-linode-instance)\n- [Rebuild a Linode](https://techdocs.akamai.com/linode-api/reference/post-rebuild-linode-instance)\n- [Create a disk](https://techdocs.akamai.com/linode-api/reference/post-add-linode-disk)",
+                      "description": "__Read-only__ A list of the labels for SSH keys added by this user. Users can add keys with the [Add an SSH key](https://techdocs.akamai.com/linode-api/reference/post-add-ssh-key) operation. These keys are deployed when this user is included in the `authorized_users` field of the following requests:\n\n- [Create a Linode](https://techdocs.akamai.com/linode-api/reference/post-linode-instance)\n\n- [Rebuild a Linode](https://techdocs.akamai.com/linode-api/reference/post-rebuild-linode-instance)\n\n- [Create a disk](https://techdocs.akamai.com/linode-api/reference/post-add-linode-disk)",
                       "example": [
                         "home-pc",
                         "laptop"
@@ -19495,13 +19472,13 @@
                       "type": "array"
                     },
                     "tfa_enabled": {
-                      "description": "__Read-only__ A boolean value indicating if the User has Two Factor Authentication (TFA) enabled. Run the [Create a two factor secret](https://techdocs.akamai.com/linode-api/reference/post-tfa-enable) operation to enable TFA.",
+                      "description": "__Read-only__ Whether this user has Two Factor Authentication (TFA) enabled. Run the [Create a two factor secret](https://techdocs.akamai.com/linode-api/reference/post-tfa-enable) operation to enable TFA.",
                       "example": true,
                       "readOnly": true,
                       "type": "boolean"
                     },
                     "username": {
-                      "description": "__Filterable__ The User's username. This is used for logging in, and may also be displayed alongside actions the User performs (for example, in Events or public StackScripts).",
+                      "description": "__Filterable__ The name of this user. This user needs to use this value to log in. It may also display alongside actions this user performs, including events or public StackScripts.",
                       "example": "example_user",
                       "maxLength": 32,
                       "minLength": 3,
@@ -19516,7 +19493,7 @@
                       "x-linode-filterable": true
                     },
                     "verified_phone_number": {
-                      "description": "__Read-only__ The phone number verified for this User Profile with the [Verify a phone number](https://techdocs.akamai.com/linode-api/reference/post-profile-phone-number-verify) operation.\n\n`null` if this User Profile has no verified phone number.",
+                      "description": "__Read-only__ The [verified](https://techdocs.akamai.com/linode-api/reference/post-profile-phone-number-verify) phone number for this user profile. Returned as `null` if the user doesn't have a verified phone number.",
                       "example": "+5555555555",
                       "format": "phone",
                       "nullable": true,
@@ -19605,7 +19582,7 @@
         "x-linode-grant": "unrestricted only"
       },
       "get": {
-        "description": "Returns a paginated list of all users on your account.\n\n__Note__. This operation can only be accessed by account users with _unrestricted_ access.\n\nA user can access all or part of an account based on their access status and grants:\n\n- __Unrestricted access__. These users can access everything on an account.\n\n- __Restricted access__. These users can only access entities or perform actions they've been given specific grants to.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli users list\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Returns a paginated list of all users on your account.\n\n> 📘\n>\n> This operation can only be accessed by account users with _unrestricted_ access.\n\nA user can access all or part of an account based on their access status and grants:\n\n- __Unrestricted access__. These users can access everything on an account.\n\n- __Restricted access__. These users can only access entities or perform actions they've been given specific grants to.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli users list\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-users"
@@ -19681,10 +19658,10 @@
                         "allOf": [
                           {
                             "additionalProperties": false,
-                            "description": "A User on your Account. Unrestricted users can log in and access information about your Account, while restricted users may only access entities or perform actions they've been granted access to.",
+                            "description": "A user on your account. Unrestricted users can log in and access information about your account, while restricted users may only access entities or perform actions they've been granted access to.",
                             "properties": {
                               "email": {
-                                "description": "The email address for the User. Linode sends emails to this address for account management communications. May be used for other communications as configured.",
+                                "description": "This user's email address. Akamai uses this address for account management communications.",
                                 "example": "example_user@linode.com",
                                 "format": "email",
                                 "type": "string",
@@ -19692,18 +19669,18 @@
                               },
                               "last_login": {
                                 "additionalProperties": false,
-                                "description": "__Read-only__ Information for the most recent login attempt for this User.\n\n`null` if no login attempts have been made since creation of this User.\n\nRun the [List user logins](https://techdocs.akamai.com/linode-api/reference/get-account-logins) operation for additional login information.",
+                                "description": "__Read-only__ Details on this user's last login attempt. Returned as `null` if this user hasn't attempted a login since it was created. You can run the [List user logins](https://techdocs.akamai.com/linode-api/reference/get-account-logins) operation for additional login information.",
                                 "nullable": true,
                                 "properties": {
                                   "login_datetime": {
-                                    "description": "__Read-only__ The date and time of this User's most recent login attempt.",
+                                    "description": "__Read-only__ The date and time of this user's most recent login attempt.",
                                     "example": "2018-01-01T01:01:01",
                                     "format": "date-time",
                                     "readOnly": true,
                                     "type": "string"
                                   },
                                   "status": {
-                                    "description": "__Read-only__ The result of the most recent login attempt for this User.",
+                                    "description": "__Read-only__ The result of this user's most recent login attempt.",
                                     "enum": [
                                       "successful",
                                       "failed"
@@ -19717,7 +19694,7 @@
                                 "type": "object"
                               },
                               "password_created": {
-                                "description": "__Read-only__ The date and time when this User's current password was created.\n\nUser passwords are first created during the Account sign-up process, and updated using the [Reset Password](https://login.linode.com/forgot/password) webpage.\n\n`null` if this User has not created a password yet.",
+                                "description": "__Read-only__ When this user's current password was created. You initially create a password during the account sign-up process, and you can update it using the [Reset Password](https://login.linode.com/forgot/password) webpage. Returned as `null` if this user doesn't have a password set.",
                                 "example": "2018-01-01T01:01:01",
                                 "format": "date-time",
                                 "nullable": true,
@@ -19725,13 +19702,13 @@
                                 "type": "string"
                               },
                               "restricted": {
-                                "description": "If `true`, the User must be granted access to perform actions or access entities on this Account. Run [List a user's grants](https://techdocs.akamai.com/linode-api/reference/get-user-grants) for details on how to configure grants for a restricted User.",
+                                "description": "If `true`, this user needs specific access granted to perform actions or access entities on your account. Run [List a user's grants](https://techdocs.akamai.com/linode-api/reference/get-user-grants) for details on how to configure grants for a restricted user.",
                                 "example": true,
                                 "type": "boolean",
                                 "x-linode-cli-display": 3
                               },
                               "ssh_keys": {
-                                "description": "__Read-only__ A list of SSH Key labels added by this User.\n\nUsers can add keys with the [Add an SSH key](https://techdocs.akamai.com/linode-api/reference/post-add-ssh-key) operation.\n\nThese keys are deployed when this User is included in the `authorized_users` field of the following requests:\n\n- [Create a Linode](https://techdocs.akamai.com/linode-api/reference/post-linode-instance)\n- [Rebuild a Linode](https://techdocs.akamai.com/linode-api/reference/post-rebuild-linode-instance)\n- [Create a disk](https://techdocs.akamai.com/linode-api/reference/post-add-linode-disk)",
+                                "description": "__Read-only__ A list of the labels for SSH keys added by this user. Users can add keys with the [Add an SSH key](https://techdocs.akamai.com/linode-api/reference/post-add-ssh-key) operation. These keys are deployed when this user is included in the `authorized_users` field of the following requests:\n\n- [Create a Linode](https://techdocs.akamai.com/linode-api/reference/post-linode-instance)\n\n- [Rebuild a Linode](https://techdocs.akamai.com/linode-api/reference/post-rebuild-linode-instance)\n\n- [Create a disk](https://techdocs.akamai.com/linode-api/reference/post-add-linode-disk)",
                                 "example": [
                                   "home-pc",
                                   "laptop"
@@ -19743,13 +19720,13 @@
                                 "type": "array"
                               },
                               "tfa_enabled": {
-                                "description": "__Read-only__ A boolean value indicating if the User has Two Factor Authentication (TFA) enabled. Run the [Create a two factor secret](https://techdocs.akamai.com/linode-api/reference/post-tfa-enable) operation to enable TFA.",
+                                "description": "__Read-only__ Whether this user has Two Factor Authentication (TFA) enabled. Run the [Create a two factor secret](https://techdocs.akamai.com/linode-api/reference/post-tfa-enable) operation to enable TFA.",
                                 "example": true,
                                 "readOnly": true,
                                 "type": "boolean"
                               },
                               "username": {
-                                "description": "__Filterable__ The User's username. This is used for logging in, and may also be displayed alongside actions the User performs (for example, in Events or public StackScripts).",
+                                "description": "__Filterable__ The name of this user. This user needs to use this value to log in. It may also display alongside actions this user performs, including events or public StackScripts.",
                                 "example": "example_user",
                                 "maxLength": 32,
                                 "minLength": 3,
@@ -19764,7 +19741,7 @@
                                 "x-linode-filterable": true
                               },
                               "verified_phone_number": {
-                                "description": "__Read-only__ The phone number verified for this User Profile with the [Verify a phone number](https://techdocs.akamai.com/linode-api/reference/post-profile-phone-number-verify) operation.\n\n`null` if this User Profile has no verified phone number.",
+                                "description": "__Read-only__ The [verified](https://techdocs.akamai.com/linode-api/reference/post-profile-phone-number-verify) phone number for this user profile. Returned as `null` if the user doesn't have a verified phone number.",
                                 "example": "+5555555555",
                                 "format": "phone",
                                 "nullable": true,
@@ -19929,7 +19906,7 @@
     },
     "/{apiVersion}/account/users/{username}": {
       "get": {
-        "description": "Returns information about a single user on your account.\n\n__Note__. This operation can only be accessed by account users with _unrestricted_ access.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli users view example_user\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Returns information about a single user on your account.\n\n> 📘\n>\n> This operation can only be accessed by account users with _unrestricted_ access.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli users view example_user\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-user"
@@ -19943,10 +19920,10 @@
                   "allOf": [
                     {
                       "additionalProperties": false,
-                      "description": "A User on your Account. Unrestricted users can log in and access information about your Account, while restricted users may only access entities or perform actions they've been granted access to.",
+                      "description": "A user on your account. Unrestricted users can log in and access information about your account, while restricted users may only access entities or perform actions they've been granted access to.",
                       "properties": {
                         "email": {
-                          "description": "The email address for the User. Linode sends emails to this address for account management communications. May be used for other communications as configured.",
+                          "description": "This user's email address. Akamai uses this address for account management communications.",
                           "example": "example_user@linode.com",
                           "format": "email",
                           "type": "string",
@@ -19954,18 +19931,18 @@
                         },
                         "last_login": {
                           "additionalProperties": false,
-                          "description": "__Read-only__ Information for the most recent login attempt for this User.\n\n`null` if no login attempts have been made since creation of this User.\n\nRun the [List user logins](https://techdocs.akamai.com/linode-api/reference/get-account-logins) operation for additional login information.",
+                          "description": "__Read-only__ Details on this user's last login attempt. Returned as `null` if this user hasn't attempted a login since it was created. You can run the [List user logins](https://techdocs.akamai.com/linode-api/reference/get-account-logins) operation for additional login information.",
                           "nullable": true,
                           "properties": {
                             "login_datetime": {
-                              "description": "__Read-only__ The date and time of this User's most recent login attempt.",
+                              "description": "__Read-only__ The date and time of this user's most recent login attempt.",
                               "example": "2018-01-01T01:01:01",
                               "format": "date-time",
                               "readOnly": true,
                               "type": "string"
                             },
                             "status": {
-                              "description": "__Read-only__ The result of the most recent login attempt for this User.",
+                              "description": "__Read-only__ The result of this user's most recent login attempt.",
                               "enum": [
                                 "successful",
                                 "failed"
@@ -19979,7 +19956,7 @@
                           "type": "object"
                         },
                         "password_created": {
-                          "description": "__Read-only__ The date and time when this User's current password was created.\n\nUser passwords are first created during the Account sign-up process, and updated using the [Reset Password](https://login.linode.com/forgot/password) webpage.\n\n`null` if this User has not created a password yet.",
+                          "description": "__Read-only__ When this user's current password was created. You initially create a password during the account sign-up process, and you can update it using the [Reset Password](https://login.linode.com/forgot/password) webpage. Returned as `null` if this user doesn't have a password set.",
                           "example": "2018-01-01T01:01:01",
                           "format": "date-time",
                           "nullable": true,
@@ -19987,13 +19964,13 @@
                           "type": "string"
                         },
                         "restricted": {
-                          "description": "If `true`, the User must be granted access to perform actions or access entities on this Account. Run [List a user's grants](https://techdocs.akamai.com/linode-api/reference/get-user-grants) for details on how to configure grants for a restricted User.",
+                          "description": "If `true`, this user needs specific access granted to perform actions or access entities on your account. Run [List a user's grants](https://techdocs.akamai.com/linode-api/reference/get-user-grants) for details on how to configure grants for a restricted user.",
                           "example": true,
                           "type": "boolean",
                           "x-linode-cli-display": 3
                         },
                         "ssh_keys": {
-                          "description": "__Read-only__ A list of SSH Key labels added by this User.\n\nUsers can add keys with the [Add an SSH key](https://techdocs.akamai.com/linode-api/reference/post-add-ssh-key) operation.\n\nThese keys are deployed when this User is included in the `authorized_users` field of the following requests:\n\n- [Create a Linode](https://techdocs.akamai.com/linode-api/reference/post-linode-instance)\n- [Rebuild a Linode](https://techdocs.akamai.com/linode-api/reference/post-rebuild-linode-instance)\n- [Create a disk](https://techdocs.akamai.com/linode-api/reference/post-add-linode-disk)",
+                          "description": "__Read-only__ A list of the labels for SSH keys added by this user. Users can add keys with the [Add an SSH key](https://techdocs.akamai.com/linode-api/reference/post-add-ssh-key) operation. These keys are deployed when this user is included in the `authorized_users` field of the following requests:\n\n- [Create a Linode](https://techdocs.akamai.com/linode-api/reference/post-linode-instance)\n\n- [Rebuild a Linode](https://techdocs.akamai.com/linode-api/reference/post-rebuild-linode-instance)\n\n- [Create a disk](https://techdocs.akamai.com/linode-api/reference/post-add-linode-disk)",
                           "example": [
                             "home-pc",
                             "laptop"
@@ -20005,13 +19982,13 @@
                           "type": "array"
                         },
                         "tfa_enabled": {
-                          "description": "__Read-only__ A boolean value indicating if the User has Two Factor Authentication (TFA) enabled. Run the [Create a two factor secret](https://techdocs.akamai.com/linode-api/reference/post-tfa-enable) operation to enable TFA.",
+                          "description": "__Read-only__ Whether this user has Two Factor Authentication (TFA) enabled. Run the [Create a two factor secret](https://techdocs.akamai.com/linode-api/reference/post-tfa-enable) operation to enable TFA.",
                           "example": true,
                           "readOnly": true,
                           "type": "boolean"
                         },
                         "username": {
-                          "description": "__Filterable__ The User's username. This is used for logging in, and may also be displayed alongside actions the User performs (for example, in Events or public StackScripts).",
+                          "description": "__Filterable__ The name of this user. This user needs to use this value to log in. It may also display alongside actions this user performs, including events or public StackScripts.",
                           "example": "example_user",
                           "maxLength": 32,
                           "minLength": 3,
@@ -20026,7 +20003,7 @@
                           "x-linode-filterable": true
                         },
                         "verified_phone_number": {
-                          "description": "__Read-only__ The phone number verified for this User Profile with the [Verify a phone number](https://techdocs.akamai.com/linode-api/reference/post-profile-phone-number-verify) operation.\n\n`null` if this User Profile has no verified phone number.",
+                          "description": "__Read-only__ The [verified](https://techdocs.akamai.com/linode-api/reference/post-profile-phone-number-verify) phone number for this user profile. Returned as `null` if the user doesn't have a verified phone number.",
                           "example": "+5555555555",
                           "format": "phone",
                           "nullable": true,
@@ -20142,7 +20119,7 @@
         "x-linode-grant": "unrestricted only"
       },
       "put": {
-        "description": "Update information about a user on your account, including its restricted status. When setting a user to `restricted`, the API sets no grants for it. You need to set grants so that user can access things on the account.\n\n__Note__. This operation can only be accessed by account users with _unrestricted_ access.\n\n__Parent and child accounts__\n\nIn a [parent and child account](https://www.linode.com/docs/guides/parent-child-accounts/) environment, the following apply:\n\n- You can't edit the `username` or `email` values for the child account parent user (proxy user). These are predefined for the proxy user when you initially provision the parent-child relationship. Only a proxy user's `restricted` status can be modified. This can only be done by an unrestricted child account user.\n\n- A parent account using an unrestricted proxy user in a child account can modify the `username`, `email`, and `restricted` status for an existing child account user.\n\n- A restricted account user--parent or child--can't change their user to `unrestricted`.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli users update example_user \\\n  --username example_user \\\n  --email example@linode.com \\\n  --restricted true\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Update information about a user on your account, including its restricted status. When setting a user to `restricted`, the API sets no grants for it. You need to set grants so that user can access things on the account.\n\n> 📘\n>\n> This operation can only be accessed by account users with _unrestricted_ access.\n\n__Parent and child accounts__\n\nIn a [parent and child account](https://www.linode.com/docs/guides/parent-child-accounts/) environment, the following apply:\n\n- You can't edit the `username` or `email` values for the child account parent user (proxy user). These are predefined for the proxy user when you initially provision the parent-child relationship. Only a proxy user's `restricted` status can be modified. This can only be done by an unrestricted child account user.\n\n- A parent account using an unrestricted proxy user in a child account can modify the `username`, `email`, and `restricted` status for an existing child account user.\n\n- A restricted account user--parent or child--can't change their user to `unrestricted`.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli users update example_user \\\n  --username example_user \\\n  --email example@linode.com \\\n  --restricted true\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/put-user"
@@ -20153,10 +20130,10 @@
             "application/json": {
               "schema": {
                 "additionalProperties": false,
-                "description": "A User on your Account. Unrestricted users can log in and access information about your Account, while restricted users may only access entities or perform actions they've been granted access to.",
+                "description": "A user on your account. Unrestricted users can log in and access information about your account, while restricted users may only access entities or perform actions they've been granted access to.",
                 "properties": {
                   "email": {
-                    "description": "The email address for the User. Linode sends emails to this address for account management communications. May be used for other communications as configured.",
+                    "description": "This user's email address. Akamai uses this address for account management communications.",
                     "example": "{{email}}",
                     "format": "email",
                     "type": "string",
@@ -20164,18 +20141,18 @@
                   },
                   "last_login": {
                     "additionalProperties": false,
-                    "description": "__Read-only__ Information for the most recent login attempt for this User.\n\n`null` if no login attempts have been made since creation of this User.\n\nRun the [List user logins](https://techdocs.akamai.com/linode-api/reference/get-account-logins) operation for additional login information.",
+                    "description": "__Read-only__ Details on this user's last login attempt. Returned as `null` if this user hasn't attempted a login since it was created. You can run the [List user logins](https://techdocs.akamai.com/linode-api/reference/get-account-logins) operation for additional login information.",
                     "nullable": true,
                     "properties": {
                       "login_datetime": {
-                        "description": "__Read-only__ The date and time of this User's most recent login attempt.",
+                        "description": "__Read-only__ The date and time of this user's most recent login attempt.",
                         "example": "2018-01-01T01:01:01",
                         "format": "date-time",
                         "readOnly": true,
                         "type": "string"
                       },
                       "status": {
-                        "description": "__Read-only__ The result of the most recent login attempt for this User.",
+                        "description": "__Read-only__ The result of this user's most recent login attempt.",
                         "enum": [
                           "successful",
                           "failed"
@@ -20189,7 +20166,7 @@
                     "type": "object"
                   },
                   "password_created": {
-                    "description": "__Read-only__ The date and time when this User's current password was created.\n\nUser passwords are first created during the Account sign-up process, and updated using the [Reset Password](https://login.linode.com/forgot/password) webpage.\n\n`null` if this User has not created a password yet.",
+                    "description": "__Read-only__ When this user's current password was created. You initially create a password during the account sign-up process, and you can update it using the [Reset Password](https://login.linode.com/forgot/password) webpage. Returned as `null` if this user doesn't have a password set.",
                     "example": "{{password_created}}",
                     "format": "date-time",
                     "nullable": true,
@@ -20197,13 +20174,13 @@
                     "type": "string"
                   },
                   "restricted": {
-                    "description": "If `true`, the User must be granted access to perform actions or access entities on this Account. Run [List a user's grants](https://techdocs.akamai.com/linode-api/reference/get-user-grants) for details on how to configure grants for a restricted User.",
+                    "description": "If `true`, this user needs specific access granted to perform actions or access entities on your account. Run [List a user's grants](https://techdocs.akamai.com/linode-api/reference/get-user-grants) for details on how to configure grants for a restricted user.",
                     "example": "{{restricted}}",
                     "type": "boolean",
                     "x-linode-cli-display": 3
                   },
                   "ssh_keys": {
-                    "description": "__Read-only__ A list of SSH Key labels added by this User.\n\nUsers can add keys with the [Add an SSH key](https://techdocs.akamai.com/linode-api/reference/post-add-ssh-key) operation.\n\nThese keys are deployed when this User is included in the `authorized_users` field of the following requests:\n\n- [Create a Linode](https://techdocs.akamai.com/linode-api/reference/post-linode-instance)\n- [Rebuild a Linode](https://techdocs.akamai.com/linode-api/reference/post-rebuild-linode-instance)\n- [Create a disk](https://techdocs.akamai.com/linode-api/reference/post-add-linode-disk)",
+                    "description": "__Read-only__ A list of the labels for SSH keys added by this user. Users can add keys with the [Add an SSH key](https://techdocs.akamai.com/linode-api/reference/post-add-ssh-key) operation. These keys are deployed when this user is included in the `authorized_users` field of the following requests:\n\n- [Create a Linode](https://techdocs.akamai.com/linode-api/reference/post-linode-instance)\n\n- [Rebuild a Linode](https://techdocs.akamai.com/linode-api/reference/post-rebuild-linode-instance)\n\n- [Create a disk](https://techdocs.akamai.com/linode-api/reference/post-add-linode-disk)",
                     "example": [
                       "home-pc",
                       "laptop"
@@ -20215,13 +20192,13 @@
                     "type": "array"
                   },
                   "tfa_enabled": {
-                    "description": "__Read-only__ A boolean value indicating if the User has Two Factor Authentication (TFA) enabled. Run the [Create a two factor secret](https://techdocs.akamai.com/linode-api/reference/post-tfa-enable) operation to enable TFA.",
+                    "description": "__Read-only__ Whether this user has Two Factor Authentication (TFA) enabled. Run the [Create a two factor secret](https://techdocs.akamai.com/linode-api/reference/post-tfa-enable) operation to enable TFA.",
                     "example": "{{tfa_enabled}}",
                     "readOnly": true,
                     "type": "boolean"
                   },
                   "username": {
-                    "description": "__Filterable__ The User's username. This is used for logging in, and may also be displayed alongside actions the User performs (for example, in Events or public StackScripts).",
+                    "description": "__Filterable__ The name of this user. This user needs to use this value to log in. It may also display alongside actions this user performs, including events or public StackScripts.",
                     "example": "{{username}}",
                     "maxLength": 32,
                     "minLength": 3,
@@ -20236,7 +20213,7 @@
                     "x-linode-filterable": true
                   },
                   "verified_phone_number": {
-                    "description": "__Read-only__ The phone number verified for this User Profile with the [Verify a phone number](https://techdocs.akamai.com/linode-api/reference/post-profile-phone-number-verify) operation.\n\n`null` if this User Profile has no verified phone number.",
+                    "description": "__Read-only__ The [verified](https://techdocs.akamai.com/linode-api/reference/post-profile-phone-number-verify) phone number for this user profile. Returned as `null` if the user doesn't have a verified phone number.",
                     "example": "{{verified_phone_number}}",
                     "format": "phone",
                     "nullable": true,
@@ -20281,10 +20258,10 @@
                   "allOf": [
                     {
                       "additionalProperties": false,
-                      "description": "A User on your Account. Unrestricted users can log in and access information about your Account, while restricted users may only access entities or perform actions they've been granted access to.",
+                      "description": "A user on your account. Unrestricted users can log in and access information about your account, while restricted users may only access entities or perform actions they've been granted access to.",
                       "properties": {
                         "email": {
-                          "description": "The email address for the User. Linode sends emails to this address for account management communications. May be used for other communications as configured.",
+                          "description": "This user's email address. Akamai uses this address for account management communications.",
                           "example": "example_user@linode.com",
                           "format": "email",
                           "type": "string",
@@ -20292,18 +20269,18 @@
                         },
                         "last_login": {
                           "additionalProperties": false,
-                          "description": "__Read-only__ Information for the most recent login attempt for this User.\n\n`null` if no login attempts have been made since creation of this User.\n\nRun the [List user logins](https://techdocs.akamai.com/linode-api/reference/get-account-logins) operation for additional login information.",
+                          "description": "__Read-only__ Details on this user's last login attempt. Returned as `null` if this user hasn't attempted a login since it was created. You can run the [List user logins](https://techdocs.akamai.com/linode-api/reference/get-account-logins) operation for additional login information.",
                           "nullable": true,
                           "properties": {
                             "login_datetime": {
-                              "description": "__Read-only__ The date and time of this User's most recent login attempt.",
+                              "description": "__Read-only__ The date and time of this user's most recent login attempt.",
                               "example": "2018-01-01T01:01:01",
                               "format": "date-time",
                               "readOnly": true,
                               "type": "string"
                             },
                             "status": {
-                              "description": "__Read-only__ The result of the most recent login attempt for this User.",
+                              "description": "__Read-only__ The result of this user's most recent login attempt.",
                               "enum": [
                                 "successful",
                                 "failed"
@@ -20317,7 +20294,7 @@
                           "type": "object"
                         },
                         "password_created": {
-                          "description": "__Read-only__ The date and time when this User's current password was created.\n\nUser passwords are first created during the Account sign-up process, and updated using the [Reset Password](https://login.linode.com/forgot/password) webpage.\n\n`null` if this User has not created a password yet.",
+                          "description": "__Read-only__ When this user's current password was created. You initially create a password during the account sign-up process, and you can update it using the [Reset Password](https://login.linode.com/forgot/password) webpage. Returned as `null` if this user doesn't have a password set.",
                           "example": "2018-01-01T01:01:01",
                           "format": "date-time",
                           "nullable": true,
@@ -20325,13 +20302,13 @@
                           "type": "string"
                         },
                         "restricted": {
-                          "description": "If `true`, the User must be granted access to perform actions or access entities on this Account. Run [List a user's grants](https://techdocs.akamai.com/linode-api/reference/get-user-grants) for details on how to configure grants for a restricted User.",
+                          "description": "If `true`, this user needs specific access granted to perform actions or access entities on your account. Run [List a user's grants](https://techdocs.akamai.com/linode-api/reference/get-user-grants) for details on how to configure grants for a restricted user.",
                           "example": true,
                           "type": "boolean",
                           "x-linode-cli-display": 3
                         },
                         "ssh_keys": {
-                          "description": "__Read-only__ A list of SSH Key labels added by this User.\n\nUsers can add keys with the [Add an SSH key](https://techdocs.akamai.com/linode-api/reference/post-add-ssh-key) operation.\n\nThese keys are deployed when this User is included in the `authorized_users` field of the following requests:\n\n- [Create a Linode](https://techdocs.akamai.com/linode-api/reference/post-linode-instance)\n- [Rebuild a Linode](https://techdocs.akamai.com/linode-api/reference/post-rebuild-linode-instance)\n- [Create a disk](https://techdocs.akamai.com/linode-api/reference/post-add-linode-disk)",
+                          "description": "__Read-only__ A list of the labels for SSH keys added by this user. Users can add keys with the [Add an SSH key](https://techdocs.akamai.com/linode-api/reference/post-add-ssh-key) operation. These keys are deployed when this user is included in the `authorized_users` field of the following requests:\n\n- [Create a Linode](https://techdocs.akamai.com/linode-api/reference/post-linode-instance)\n\n- [Rebuild a Linode](https://techdocs.akamai.com/linode-api/reference/post-rebuild-linode-instance)\n\n- [Create a disk](https://techdocs.akamai.com/linode-api/reference/post-add-linode-disk)",
                           "example": [
                             "home-pc",
                             "laptop"
@@ -20343,13 +20320,13 @@
                           "type": "array"
                         },
                         "tfa_enabled": {
-                          "description": "__Read-only__ A boolean value indicating if the User has Two Factor Authentication (TFA) enabled. Run the [Create a two factor secret](https://techdocs.akamai.com/linode-api/reference/post-tfa-enable) operation to enable TFA.",
+                          "description": "__Read-only__ Whether this user has Two Factor Authentication (TFA) enabled. Run the [Create a two factor secret](https://techdocs.akamai.com/linode-api/reference/post-tfa-enable) operation to enable TFA.",
                           "example": true,
                           "readOnly": true,
                           "type": "boolean"
                         },
                         "username": {
-                          "description": "__Filterable__ The User's username. This is used for logging in, and may also be displayed alongside actions the User performs (for example, in Events or public StackScripts).",
+                          "description": "__Filterable__ The name of this user. This user needs to use this value to log in. It may also display alongside actions this user performs, including events or public StackScripts.",
                           "example": "example_user",
                           "maxLength": 32,
                           "minLength": 3,
@@ -20364,7 +20341,7 @@
                           "x-linode-filterable": true
                         },
                         "verified_phone_number": {
-                          "description": "__Read-only__ The phone number verified for this User Profile with the [Verify a phone number](https://techdocs.akamai.com/linode-api/reference/post-profile-phone-number-verify) operation.\n\n`null` if this User Profile has no verified phone number.",
+                          "description": "__Read-only__ The [verified](https://techdocs.akamai.com/linode-api/reference/post-profile-phone-number-verify) phone number for this user profile. Returned as `null` if the user doesn't have a verified phone number.",
                           "example": "+5555555555",
                           "format": "phone",
                           "nullable": true,
@@ -20477,7 +20454,7 @@
         "x-linode-grant": "unrestricted only"
       },
       "delete": {
-        "description": "Deletes a user. The API immediately logs the user out and removes all of its `grants`.\n\n__Note__. This operation can only be accessed by account users with _unrestricted_ access.\n\n__Parent and child accounts__\n\nIn a [parent and child account](https://www.linode.com/docs/guides/parent-child-accounts/) environment, the following apply:\n\n- You can't delete a child account parent user (proxy user). The API returns a 403 error if you target a proxy user with this operation.\n\n- A parent account using an unrestricted proxy user can use this operation to delete a child account user.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli users delete example_user\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Deletes a user. The API immediately logs the user out and removes all of its `grants`.\n\n> 📘\n>\n> This operation can only be accessed by account users with _unrestricted_ access.\n\n__Parent and child accounts__\n\nIn a [parent and child account](https://www.linode.com/docs/guides/parent-child-accounts/) environment, the following apply:\n\n- You can't delete a child account parent user (proxy user). The API returns a 403 error if you target a proxy user with this operation.\n\n- A parent account using an unrestricted proxy user can use this operation to delete a child account user.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli users delete example_user\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/delete-user"
@@ -20613,7 +20590,7 @@
     },
     "/{apiVersion}/account/users/{username}/grants": {
       "get": {
-        "description": "Returns the full grants structure for an account username you specify. This includes all entities on the account, and the level of access this user has to each of them.\n\nThis doesn't apply to the account owner or the current authenticated user. You can run the [List grants](https://techdocs.akamai.com/linode-api/reference/get-profile-grants) operation to view those grants. However, this doesn't show the entities that they _don't_ have access to.\n\n__Note__. This operation can only be accessed by account users with _unrestricted_ access.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    account:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Returns the full grants structure for an account username you specify. This includes all entities on the account, and the level of access this user has to each of them.\n\nThis doesn't apply to the account owner or the current authenticated user. You can run the [List grants](https://techdocs.akamai.com/linode-api/reference/get-profile-grants) operation to view those grants. However, this doesn't show the entities that they _don't_ have access to.\n\n> 📘\n>\n> This operation can only be accessed by account users with _unrestricted_ access.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    account:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-user-grants"
@@ -20781,10 +20758,6 @@
                           "example": true,
                           "type": "boolean"
                         },
-                        "add_placement_groups": {
-                          "description": "If `true`, this User may add Placement Groups.",
-                          "type": "boolean"
-                        },
                         "add_stackscripts": {
                           "description": "If `true`, this User may add StackScripts.",
                           "example": true,
@@ -20926,41 +20899,6 @@
                     },
                     "nodebalancer": {
                       "description": "The grants this User has for each NodeBalancer that is owned by this Account.",
-                      "items": {
-                        "additionalProperties": false,
-                        "description": "Represents the level of access a restricted User has to a specific resource on the Account.",
-                        "properties": {
-                          "id": {
-                            "description": "The ID of the entity this grant applies to.",
-                            "example": 123,
-                            "type": "integer"
-                          },
-                          "label": {
-                            "description": "__Read-only__ The current label of the entity this grant applies to, for display purposes.",
-                            "example": "example-entity",
-                            "readOnly": true,
-                            "type": "string"
-                          },
-                          "permissions": {
-                            "description": "The level of access this User has to this entity.  If `null`, this User has no access.",
-                            "enum": [
-                              "read_only",
-                              "read_write"
-                            ],
-                            "example": "read_only",
-                            "nullable": true,
-                            "type": "string"
-                          }
-                        },
-                        "type": "object",
-                        "x-akamai": {
-                          "file-path": "schemas/grant.yaml"
-                        }
-                      },
-                      "type": "array"
-                    },
-                    "placement_group": {
-                      "description": "The grants this User has for each Placement Group that is owned by this Account.",
                       "items": {
                         "additionalProperties": false,
                         "description": "Represents the level of access a restricted User has to a specific resource on the Account.",
@@ -21181,7 +21119,7 @@
         "x-linode-grant": "unrestricted only"
       },
       "put": {
-        "description": "Update the grants a user has. This can be used to give a user access to new entities or actions, or take access away.  You don't need to include the grant for every entity on the account in this request. Any that are not included remain unchanged.\n\n__Note__. This operation can only be accessed by account users with _unrestricted_ access.\n\n__Parent and child accounts__\n\nIn a [parent and child account](https://www.linode.com/docs/guides/parent-child-accounts/) environment, the following apply:\n\n- No child account user can modify the `account_access` grant for the child account parent user (proxy user).\n\n- An unrestricted child account user can configure all other grants for the proxy user, via `global` object.\n\n- An unrestricted child account user can enable the `account_access` grant for other child account users. However, enabled child users are still subject to child user restrictions--they can't perform write operations for any billing or account information.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    account:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Update the grants a user has. This can be used to give a user access to new entities or actions, or take access away.  You don't need to include the grant for every entity on the account in this request. Any that are not included remain unchanged.\n\n> 📘\n>\n> This operation can only be accessed by account users with _unrestricted_ access.\n\n__Parent and child accounts__\n\nIn a [parent and child account](https://www.linode.com/docs/guides/parent-child-accounts/) environment, the following apply:\n\n- No child account user can modify the `account_access` grant for the child account parent user (proxy user).\n\n- An unrestricted child account user can configure all other grants for the proxy user, via `global` object.\n\n- An unrestricted child account user can enable the `account_access` grant for other child account users. However, enabled child users are still subject to child user restrictions--they can't perform write operations for any billing or account information.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    account:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/put-user-grants"
@@ -21348,10 +21286,6 @@
                         "example": true,
                         "type": "boolean"
                       },
-                      "add_placement_groups": {
-                        "description": "If `true`, this User may add Placement Groups.",
-                        "type": "boolean"
-                      },
                       "add_stackscripts": {
                         "description": "If `true`, this User may add StackScripts.",
                         "example": true,
@@ -21493,41 +21427,6 @@
                   },
                   "nodebalancer": {
                     "description": "The grants this User has for each NodeBalancer that is owned by this Account.",
-                    "items": {
-                      "additionalProperties": false,
-                      "description": "Represents the level of access a restricted User has to a specific resource on the Account.",
-                      "properties": {
-                        "id": {
-                          "description": "The ID of the entity this grant applies to.",
-                          "example": 123,
-                          "type": "integer"
-                        },
-                        "label": {
-                          "description": "__Read-only__ The current label of the entity this grant applies to, for display purposes.",
-                          "example": "example-entity",
-                          "readOnly": true,
-                          "type": "string"
-                        },
-                        "permissions": {
-                          "description": "The level of access this User has to this entity.  If `null`, this User has no access.",
-                          "enum": [
-                            "read_only",
-                            "read_write"
-                          ],
-                          "example": "read_only",
-                          "nullable": true,
-                          "type": "string"
-                        }
-                      },
-                      "type": "object",
-                      "x-akamai": {
-                        "file-path": "schemas/grant.yaml"
-                      }
-                    },
-                    "type": "array"
-                  },
-                  "placement_group": {
-                    "description": "The grants this User has for each Placement Group that is owned by this Account.",
                     "items": {
                       "additionalProperties": false,
                       "description": "Represents the level of access a restricted User has to a specific resource on the Account.",
@@ -21842,10 +21741,6 @@
                           "example": true,
                           "type": "boolean"
                         },
-                        "add_placement_groups": {
-                          "description": "If `true`, this User may add Placement Groups.",
-                          "type": "boolean"
-                        },
                         "add_stackscripts": {
                           "description": "If `true`, this User may add StackScripts.",
                           "example": true,
@@ -21987,41 +21882,6 @@
                     },
                     "nodebalancer": {
                       "description": "The grants this User has for each NodeBalancer that is owned by this Account.",
-                      "items": {
-                        "additionalProperties": false,
-                        "description": "Represents the level of access a restricted User has to a specific resource on the Account.",
-                        "properties": {
-                          "id": {
-                            "description": "The ID of the entity this grant applies to.",
-                            "example": 123,
-                            "type": "integer"
-                          },
-                          "label": {
-                            "description": "__Read-only__ The current label of the entity this grant applies to, for display purposes.",
-                            "example": "example-entity",
-                            "readOnly": true,
-                            "type": "string"
-                          },
-                          "permissions": {
-                            "description": "The level of access this User has to this entity.  If `null`, this User has no access.",
-                            "enum": [
-                              "read_only",
-                              "read_write"
-                            ],
-                            "example": "read_only",
-                            "nullable": true,
-                            "type": "string"
-                          }
-                        },
-                        "type": "object",
-                        "x-akamai": {
-                          "file-path": "schemas/grant.yaml"
-                        }
-                      },
-                      "type": "array"
-                    },
-                    "placement_group": {
-                      "description": "The grants this User has for each Placement Group that is owned by this Account.",
                       "items": {
                         "additionalProperties": false,
                         "description": "Represents the level of access a restricted User has to a specific resource on the Account.",
@@ -23316,8 +23176,8 @@
                               "allow_list": {
                                 "description": "Controls access to the Managed Database.\n\n- Individually included IP addresses or CIDR ranges can access the Managed Database while all other sources are blocked.\n\n- A standalone value of `0.0.0.0/0` allows all IP addresses access to the Managed Database.\n\n- An empty array (`[]`) blocks all public and private connections to the Managed Database.",
                                 "example": [
-                                  "192.0.2.123/24",
-                                  "192.0.2.236/24"
+                                  "192.0.2.6/24",
+                                  "192.0.2.248/24"
                                 ],
                                 "items": {
                                   "format": "ipv4/prefix_length",
@@ -23398,7 +23258,7 @@
                                     "type": "string"
                                   },
                                   "secondary": {
-                                    "description": "The secondary/private network host for the Managed Database.\n\nA private network host and a private IP can only be used to access a database cluster from Linodes in the same data center and will not incur transfer costs.\n\n__Note__. The secondary hostname is publicly visible and accessible.",
+                                    "description": "The secondary/private network host for the Managed Database. A private network host and a private IP can only be used to access a database cluster from Linodes in the same data center and will not incur transfer costs.\n\n> 📘\n>\n> The secondary hostname is publicly visible and accessible.",
                                     "example": "lin-123-456-mysql-primary-private.servers.linodedb.net",
                                     "nullable": true,
                                     "type": "string"
@@ -23764,8 +23624,8 @@
                   "allow_list": {
                     "description": "Controls access to the Managed Database.\n\n- Individually included IP addresses or CIDR ranges can access the Managed Database while all other sources are blocked.\n\n- A standalone value of `0.0.0.0/0` allows all IP addresses access to the Managed Database.\n\n- An empty array (`[]`) blocks all public and private connections to the Managed Database.",
                     "example": [
-                      "192.0.2.27/24",
-                      "192.0.2.36/24"
+                      "192.0.2.73/24",
+                      "192.0.2.129/24"
                     ],
                     "items": {
                       "format": "ipv4/prefix_length",
@@ -23902,8 +23762,8 @@
                     "allow_list": {
                       "description": "Controls access to the Managed Database.\n\n- Individually included IP addresses or CIDR ranges can access the Managed Database while all other sources are blocked.\n\n- A standalone value of `0.0.0.0/0` allows all IP addresses access to the Managed Database.\n\n- An empty array (`[]`) blocks all public and private connections to the Managed Database.",
                       "example": [
-                        "192.0.2.174/24",
-                        "192.0.2.208/24"
+                        "192.0.2.160/24",
+                        "192.0.2.115/24"
                       ],
                       "items": {
                         "format": "ipv4/prefix_length",
@@ -23980,7 +23840,7 @@
                           "type": "string"
                         },
                         "secondary": {
-                          "description": "The secondary/private network host for the Managed Database.\n\nA private network host and a private IP can only be used to access a database cluster from Linodes in the same data center and will not incur transfer costs.\n\n__Note__. The secondary hostname is publicly visible and accessible.",
+                          "description": "The secondary/private network host for the Managed Database. A private network host and a private IP can only be used to access a database cluster from Linodes in the same data center and will not incur transfer costs.\n\n> 📘\n>\n> The secondary hostname is publicly visible and accessible.",
                           "example": "lin-123-456-mysql-primary-private.servers.linodedb.net",
                           "nullable": true,
                           "type": "string"
@@ -24427,8 +24287,8 @@
                               "allow_list": {
                                 "description": "Controls access to the Managed Database.\n\n- Individually included IP addresses or CIDR ranges can access the Managed Database while all other sources are blocked.\n\n- A standalone value of `0.0.0.0/0` allows all IP addresses access to the Managed Database.\n\n- An empty array (`[]`) blocks all public and private connections to the Managed Database.",
                                 "example": [
-                                  "192.0.2.90/24",
-                                  "192.0.2.89/24"
+                                  "192.0.2.193/24",
+                                  "192.0.2.140/24"
                                 ],
                                 "items": {
                                   "format": "ipv4/prefix_length",
@@ -24505,7 +24365,7 @@
                                     "type": "string"
                                   },
                                   "secondary": {
-                                    "description": "The secondary/private network host for the Managed Database.\n\nA private network host and a private IP can only be used to access a database cluster from Linodes in the same data center and will not incur transfer costs.\n\n__Note__. The secondary hostname is publicly visible and accessible.",
+                                    "description": "The secondary/private network host for the Managed Database. A private network host and a private IP can only be used to access a database cluster from Linodes in the same data center and will not incur transfer costs.\n\n> 📘\n>\n> The secondary hostname is publicly visible and accessible.",
                                     "example": "lin-123-456-mysql-primary-private.servers.linodedb.net",
                                     "nullable": true,
                                     "type": "string"
@@ -24868,8 +24728,8 @@
                     "allow_list": {
                       "description": "Controls access to the Managed Database.\n\n- Individually included IP addresses or CIDR ranges can access the Managed Database while all other sources are blocked.\n\n- A standalone value of `0.0.0.0/0` allows all IP addresses access to the Managed Database.\n\n- An empty array (`[]`) blocks all public and private connections to the Managed Database.",
                       "example": [
-                        "192.0.2.231/24",
-                        "192.0.2.182/24"
+                        "192.0.2.158/24",
+                        "192.0.2.165/24"
                       ],
                       "items": {
                         "format": "ipv4/prefix_length",
@@ -24946,7 +24806,7 @@
                           "type": "string"
                         },
                         "secondary": {
-                          "description": "The secondary/private network host for the Managed Database.\n\nA private network host and a private IP can only be used to access a database cluster from Linodes in the same data center and will not incur transfer costs.\n\n__Note__. The secondary hostname is publicly visible and accessible.",
+                          "description": "The secondary/private network host for the Managed Database. A private network host and a private IP can only be used to access a database cluster from Linodes in the same data center and will not incur transfer costs.\n\n> 📘\n>\n> The secondary hostname is publicly visible and accessible.",
                           "example": "lin-123-456-mysql-primary-private.servers.linodedb.net",
                           "nullable": true,
                           "type": "string"
@@ -25275,8 +25135,8 @@
                   "allow_list": {
                     "description": "Controls access to the Managed Database.\n\n- Individually included IP addresses or CIDR ranges can access the Managed Database while all other sources are blocked.\n\n- A standalone value of `0.0.0.0/0` allows all IP addresses access to the Managed Database.\n\n- An empty array (`[]`) blocks all public and private connections to the Managed Database.",
                     "example": [
-                      "192.0.2.124/24",
-                      "192.0.2.218/24"
+                      "192.0.2.254/24",
+                      "192.0.2.127/24"
                     ],
                     "items": {
                       "format": "ipv4/prefix_length",
@@ -25408,8 +25268,8 @@
                     "allow_list": {
                       "description": "Controls access to the Managed Database.\n\n- Individually included IP addresses or CIDR ranges can access the Managed Database while all other sources are blocked.\n\n- A standalone value of `0.0.0.0/0` allows all IP addresses access to the Managed Database.\n\n- An empty array (`[]`) blocks all public and private connections to the Managed Database.",
                       "example": [
-                        "192.0.2.124/24",
-                        "192.0.2.126/24"
+                        "192.0.2.186/24",
+                        "192.0.2.205/24"
                       ],
                       "items": {
                         "format": "ipv4/prefix_length",
@@ -25486,7 +25346,7 @@
                           "type": "string"
                         },
                         "secondary": {
-                          "description": "The secondary/private network host for the Managed Database.\n\nA private network host and a private IP can only be used to access a database cluster from Linodes in the same data center and will not incur transfer costs.\n\n__Note__. The secondary hostname is publicly visible and accessible.",
+                          "description": "The secondary/private network host for the Managed Database. A private network host and a private IP can only be used to access a database cluster from Linodes in the same data center and will not incur transfer costs.\n\n> 📘\n>\n> The secondary hostname is publicly visible and accessible.",
                           "example": "lin-123-456-mysql-primary-private.servers.linodedb.net",
                           "nullable": true,
                           "type": "string"
@@ -26766,8 +26626,8 @@
                   "allow_list": {
                     "description": "Controls access to the Managed Database.\n\n- Individually included IP addresses or CIDR ranges can access the Managed Database while all other sources are blocked.\n\n- A standalone value of `0.0.0.0/0` allows all IP addresses access to the Managed Database.\n\n- An empty array (`[]`) blocks all public and private connections to the Managed Database.",
                     "example": [
-                      "192.0.2.209/24",
-                      "192.0.2.149/24"
+                      "192.0.2.58/24",
+                      "192.0.2.24/24"
                     ],
                     "items": {
                       "format": "ipv4/prefix_length",
@@ -26904,8 +26764,8 @@
                     "allow_list": {
                       "description": "Controls access to the Managed Database.\n\n- Individually included IP addresses or CIDR ranges can access the Managed Database while all other sources are blocked.\n\n- A standalone value of `0.0.0.0/0` allows all IP addresses access to the Managed Database.\n\n- An empty array (`[]`) blocks all public and private connections to the Managed Database.",
                       "example": [
-                        "192.0.2.211/24",
-                        "192.0.2.44/24"
+                        "192.0.2.46/24",
+                        "192.0.2.1/24"
                       ],
                       "items": {
                         "format": "ipv4/prefix_length",
@@ -26982,7 +26842,7 @@
                           "type": "string"
                         },
                         "secondary": {
-                          "description": "The secondary/private network host for the Managed Database.\n\nA private network host and a private IP can only be used to access a database cluster from Linodes in the same data center and will not incur transfer costs.\n\n__Note__. The secondary hostname is publicly viewable and accessible.",
+                          "description": "The secondary/private network host for the Managed Database. A private network host and a private IP can only be used to access a database cluster from Linodes in the same data center and will not incur transfer costs.\n\n> 📘\n>\n> The secondary hostname is publicly viewable and accessible.",
                           "example": "lin-0000-000-pgsql-primary-private.servers.linodedb.net",
                           "nullable": true,
                           "type": "string"
@@ -27422,8 +27282,8 @@
                               "allow_list": {
                                 "description": "Controls access to the Managed Database.\n\n- Individually included IP addresses or CIDR ranges can access the Managed Database while all other sources are blocked.\n\n- A standalone value of `0.0.0.0/0` allows all IP addresses access to the Managed Database.\n\n- An empty array (`[]`) blocks all public and private connections to the Managed Database.",
                                 "example": [
-                                  "192.0.2.136/24",
-                                  "192.0.2.248/24"
+                                  "192.0.2.241/24",
+                                  "192.0.2.171/24"
                                 ],
                                 "items": {
                                   "format": "ipv4/prefix_length",
@@ -27500,7 +27360,7 @@
                                     "type": "string"
                                   },
                                   "secondary": {
-                                    "description": "The secondary/private network host for the Managed Database.\n\nA private network host and a private IP can only be used to access a database cluster from Linodes in the same data center and will not incur transfer costs.\n\n__Note__. The secondary hostname is publicly visible and accessible.",
+                                    "description": "The secondary/private network host for the Managed Database. A private network host and a private IP can only be used to access a database cluster from Linodes in the same data center and will not incur transfer costs.\n\n> 📘\n>\n> The secondary hostname is publicly visible and accessible.",
                                     "example": "lin-0000-000-pgsql-primary-private.servers.linodedb.net",
                                     "nullable": true,
                                     "type": "string"
@@ -27863,8 +27723,8 @@
                     "allow_list": {
                       "description": "Controls access to the Managed Database.\n\n- Individually included IP addresses or CIDR ranges can access the Managed Database while all other sources are blocked.\n\n- A standalone value of `0.0.0.0/0` allows all IP addresses access to the Managed Database.\n\n- An empty array (`[]`) blocks all public and private connections to the Managed Database.",
                       "example": [
-                        "192.0.2.56/24",
-                        "192.0.2.6/24"
+                        "192.0.2.51/24",
+                        "192.0.2.121/24"
                       ],
                       "items": {
                         "format": "ipv4/prefix_length",
@@ -27941,7 +27801,7 @@
                           "type": "string"
                         },
                         "secondary": {
-                          "description": "The secondary/private network host for the Managed Database.\n\nA private network host and a private IP can only be used to access a database cluster from Linodes in the same data center and will not incur transfer costs.\n\n__Note__. The secondary hostname is publicly visible and accessible.",
+                          "description": "The secondary/private network host for the Managed Database. A private network host and a private IP can only be used to access a database cluster from Linodes in the same data center and will not incur transfer costs.\n\n> 📘\n>\n> The secondary hostname is publicly visible and accessible.",
                           "example": "lin-0000-000-pgsql-primary-private.servers.linodedb.net",
                           "nullable": true,
                           "type": "string"
@@ -28270,8 +28130,8 @@
                   "allow_list": {
                     "description": "Controls access to the Managed Database.\n\n- Individually included IP addresses or CIDR ranges can access the Managed Database while all other sources are blocked.\n\n- A standalone value of `0.0.0.0/0` allows all IP addresses access to the Managed Database.\n\n- An empty array (`[]`) blocks all public and private connections to the Managed Database.",
                     "example": [
-                      "192.0.2.254/24",
-                      "192.0.2.102/24"
+                      "192.0.2.54/24",
+                      "192.0.2.112/24"
                     ],
                     "items": {
                       "format": "ipv4/prefix_length",
@@ -28403,8 +28263,8 @@
                     "allow_list": {
                       "description": "Controls access to the Managed Database.\n\n- Individually included IP addresses or CIDR ranges can access the Managed Database while all other sources are blocked.\n\n- A standalone value of `0.0.0.0/0` allows all IP addresses access to the Managed Database.\n\n- An empty array (`[]`) blocks all public and private connections to the Managed Database.",
                       "example": [
-                        "192.0.2.47/24",
-                        "192.0.2.246/24"
+                        "192.0.2.72/24",
+                        "192.0.2.237/24"
                       ],
                       "items": {
                         "format": "ipv4/prefix_length",
@@ -28481,7 +28341,7 @@
                           "type": "string"
                         },
                         "secondary": {
-                          "description": "The secondary/private network host for the Managed Database.\n\nA private network host and a private IP can only be used to access a database cluster from Linodes in the same data center and will not incur transfer costs.\n\n__Note__. The secondary hostname is publicly visible and accessible.",
+                          "description": "The secondary/private network host for the Managed Database. A private network host and a private IP can only be used to access a database cluster from Linodes in the same data center and will not incur transfer costs.\n\n> 📘\n>\n> The secondary hostname is publicly visible and accessible.",
                           "example": "lin-0000-000-pgsql-primary-private.servers.linodedb.net",
                           "nullable": true,
                           "type": "string"
@@ -29078,7 +28938,7 @@
     },
     "/{apiVersion}/databases/postgresql/instances/{instanceId}/credentials/reset": {
       "post": {
-        "description": "Reset the root password for a PostgreSQL Managed Database. A new root password is randomly generated and accessible with the [Get PostgreSQL Managed Database credentials](https://techdocs.akamai.com/linode-api/reference/get-databases-postrge-sql-instance-credentials) operation.\n\n- The database's status needs to be `active`.\n\n- Only unrestricted users can access this operation. These users have access regardless of the acting token's OAuth scopes.\n\n- It may take several seconds for credentials to reset.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli databases postgresql-creds-reset 123\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    databases:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Reset the root password for a PostgreSQL Managed Database. A new root password is randomly generated and accessible with the [Get PostgreSQL Managed Database credentials](https://techdocs.akamai.com/linode-api/reference/get-databases-postgre-sql-instance-credentials) operation.\n\n- The database's status needs to be `active`.\n\n- Only unrestricted users can access this operation. These users have access regardless of the acting token's OAuth scopes.\n\n- It may take several seconds for credentials to reset.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli databases postgresql-creds-reset 123\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    databases:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/post-databases-postgre-sql-instance-credentials-reset"
@@ -30456,7 +30316,7 @@
                     "description": "A domain zonefile in our DNS system.  You must own the domain name and tell your registrar to use Linode's nameservers in order for a domain in our system to be treated as authoritative.",
                     "properties": {
                       "axfr_ips": {
-                        "description": "The list of IPs that may perform a zone transfer for this Domain. The total combined length of all data within this array cannot exceed 1000 characters.\n\n__Note__. This is potentially dangerous, and should be set to an empty list unless you intend to use it.",
+                        "description": "The list of IPs that may perform a zone transfer for this domain. The total combined length of all data within this array cannot exceed 1000 characters.\n\n> 📘\n>\n> This is potentially dangerous, and should be set to an empty list unless you intend to use it.",
                         "example": [],
                         "items": {
                           "format": "ip",
@@ -30465,7 +30325,7 @@
                         "type": "array"
                       },
                       "description": {
-                        "description": "A description for this Domain. This is for display purposes only.",
+                        "description": "A description for this domain. This is for display purposes only.",
                         "example": null,
                         "maxLength": 253,
                         "minLength": 1,
@@ -30473,7 +30333,7 @@
                         "type": "string"
                       },
                       "domain": {
-                        "description": "__Filterable__ The domain this Domain represents. Domain labels cannot be longer than 63 characters and must conform to [RFC1035](https://tools.ietf.org/html/rfc1035). Domains must be unique on Linode's platform, including across different Linode accounts; there cannot be two Domains representing the same domain.",
+                        "description": "__Filterable__ The domain this domain represents. domain labels cannot be longer than 63 characters and must conform to [RFC1035](https://tools.ietf.org/html/rfc1035). domains must be unique on Linode's platform, including across different Linode accounts; there cannot be two domains representing the same domain.",
                         "example": "example.org",
                         "maxLength": 253,
                         "minLength": 1,
@@ -30489,13 +30349,13 @@
                       },
                       "expire_sec": {
                         "default": 0,
-                        "description": "The amount of time in seconds that may pass before this Domain is no longer authoritative.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 1209600.",
+                        "description": "The amount of time in seconds that may pass before this domain is no longer authoritative.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 1209600.",
                         "example": 300,
                         "type": "integer"
                       },
                       "group": {
                         "deprecated": true,
-                        "description": "__Filterable__ The group this Domain belongs to.  This is for display purposes only.",
+                        "description": "__Filterable__ The group this domain belongs to.  This is for display purposes only.",
                         "example": null,
                         "maxLength": 50,
                         "minLength": 1,
@@ -30509,14 +30369,14 @@
                         "x-linode-filterable": true
                       },
                       "id": {
-                        "description": "__Read-only__ This Domain's unique ID.",
+                        "description": "__Read-only__ This domain's unique ID.",
                         "example": 1234,
                         "readOnly": true,
                         "type": "integer",
                         "x-linode-cli-display": 1
                       },
                       "master_ips": {
-                        "description": "The IP addresses representing the master DNS for this Domain. At least one value is required for `type` slave Domains. The total combined length of all data within this array cannot exceed 1000 characters.",
+                        "description": "The IP addresses representing the master DNS for this domain. At least one value is required for `type` slave domains. The total combined length of all data within this array cannot exceed 1000 characters.",
                         "example": [],
                         "items": {
                           "format": "ip",
@@ -30526,7 +30386,7 @@
                       },
                       "refresh_sec": {
                         "default": 0,
-                        "description": "The amount of time in seconds before this Domain should be refreshed.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 14400.",
+                        "description": "The amount of time in seconds before this domain should be refreshed.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 14400.",
                         "example": 300,
                         "type": "integer"
                       },
@@ -30537,7 +30397,7 @@
                         "type": "integer"
                       },
                       "soa_email": {
-                        "description": "Start of Authority email address. This is required for `type` master Domains.",
+                        "description": "Start of Authority email address. This is required for `type` master domains.",
                         "example": "admin@example.org",
                         "format": "email",
                         "type": "string",
@@ -30545,7 +30405,7 @@
                       },
                       "status": {
                         "default": "active",
-                        "description": "Used to control whether this Domain is currently being rendered.",
+                        "description": "Used to control whether this domain is currently being rendered.",
                         "enum": [
                           "disabled",
                           "active"
@@ -30579,12 +30439,12 @@
                       },
                       "ttl_sec": {
                         "default": 0,
-                        "description": "\"Time to Live\" - the amount of time in seconds that this Domain's records may be cached by resolvers or other domain servers.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n- Any other value is rounded up to the nearest valid value.\n- A value of 0 is equivalent to the default value of 86400.",
+                        "description": "\"Time to Live\" - the amount of time in seconds that this domain's records may be cached by resolvers or other domain servers.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 86400.",
                         "example": 300,
                         "type": "integer"
                       },
                       "type": {
-                        "description": "Whether this Domain represents the authoritative source of information for the domain it describes (`master`), or whether it is a read-only copy of a master (`slave`).",
+                        "description": "Whether this domain represents the authoritative source of information for the domain it describes (`master`), or whether it is a read-only copy of a master (`slave`).",
                         "enum": [
                           "master",
                           "slave"
@@ -30626,7 +30486,7 @@
                   "description": "A domain zonefile in our DNS system.  You must own the domain name and tell your registrar to use Linode's nameservers in order for a domain in our system to be treated as authoritative.",
                   "properties": {
                     "axfr_ips": {
-                      "description": "The list of IPs that may perform a zone transfer for this Domain. The total combined length of all data within this array cannot exceed 1000 characters.\n\n__Note__. This is potentially dangerous, and should be set to an empty list unless you intend to use it.",
+                      "description": "The list of IPs that may perform a zone transfer for this domain. The total combined length of all data within this array cannot exceed 1000 characters.\n\n> 📘\n>\n> This is potentially dangerous, and should be set to an empty list unless you intend to use it.",
                       "example": [],
                       "items": {
                         "format": "ip",
@@ -30635,7 +30495,7 @@
                       "type": "array"
                     },
                     "description": {
-                      "description": "A description for this Domain. This is for display purposes only.",
+                      "description": "A description for this domain. This is for display purposes only.",
                       "example": null,
                       "maxLength": 253,
                       "minLength": 1,
@@ -30643,7 +30503,7 @@
                       "type": "string"
                     },
                     "domain": {
-                      "description": "__Filterable__ The domain this Domain represents. Domain labels cannot be longer than 63 characters and must conform to [RFC1035](https://tools.ietf.org/html/rfc1035). Domains must be unique on Linode's platform, including across different Linode accounts; there cannot be two Domains representing the same domain.",
+                      "description": "__Filterable__ The domain this domain represents. domain labels cannot be longer than 63 characters and must conform to [RFC1035](https://tools.ietf.org/html/rfc1035). domains must be unique on Linode's platform, including across different Linode accounts; there cannot be two domains representing the same domain.",
                       "example": "example.org",
                       "maxLength": 253,
                       "minLength": 1,
@@ -30659,13 +30519,13 @@
                     },
                     "expire_sec": {
                       "default": 0,
-                      "description": "The amount of time in seconds that may pass before this Domain is no longer authoritative.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 1209600.",
+                      "description": "The amount of time in seconds that may pass before this domain is no longer authoritative.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 1209600.",
                       "example": 300,
                       "type": "integer"
                     },
                     "group": {
                       "deprecated": true,
-                      "description": "__Filterable__ The group this Domain belongs to.  This is for display purposes only.",
+                      "description": "__Filterable__ The group this domain belongs to.  This is for display purposes only.",
                       "example": null,
                       "maxLength": 50,
                       "minLength": 1,
@@ -30679,14 +30539,14 @@
                       "x-linode-filterable": true
                     },
                     "id": {
-                      "description": "__Read-only__ This Domain's unique ID.",
+                      "description": "__Read-only__ This domain's unique ID.",
                       "example": 1234,
                       "readOnly": true,
                       "type": "integer",
                       "x-linode-cli-display": 1
                     },
                     "master_ips": {
-                      "description": "The IP addresses representing the master DNS for this Domain. At least one value is required for `type` slave Domains. The total combined length of all data within this array cannot exceed 1000 characters.",
+                      "description": "The IP addresses representing the master DNS for this domain. At least one value is required for `type` slave domains. The total combined length of all data within this array cannot exceed 1000 characters.",
                       "example": [],
                       "items": {
                         "format": "ip",
@@ -30696,7 +30556,7 @@
                     },
                     "refresh_sec": {
                       "default": 0,
-                      "description": "The amount of time in seconds before this Domain should be refreshed.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 14400.",
+                      "description": "The amount of time in seconds before this domain should be refreshed.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 14400.",
                       "example": 300,
                       "type": "integer"
                     },
@@ -30707,7 +30567,7 @@
                       "type": "integer"
                     },
                     "soa_email": {
-                      "description": "Start of Authority email address. This is required for `type` master Domains.",
+                      "description": "Start of Authority email address. This is required for `type` master domains.",
                       "example": "admin@example.org",
                       "format": "email",
                       "type": "string",
@@ -30715,7 +30575,7 @@
                     },
                     "status": {
                       "default": "active",
-                      "description": "Used to control whether this Domain is currently being rendered.",
+                      "description": "Used to control whether this domain is currently being rendered.",
                       "enum": [
                         "disabled",
                         "active"
@@ -30749,12 +30609,12 @@
                     },
                     "ttl_sec": {
                       "default": 0,
-                      "description": "\"Time to Live\" - the amount of time in seconds that this Domain's records may be cached by resolvers or other domain servers.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n- Any other value is rounded up to the nearest valid value.\n- A value of 0 is equivalent to the default value of 86400.",
+                      "description": "\"Time to Live\" - the amount of time in seconds that this domain's records may be cached by resolvers or other domain servers.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 86400.",
                       "example": 300,
                       "type": "integer"
                     },
                     "type": {
-                      "description": "Whether this Domain represents the authoritative source of information for the domain it describes (`master`), or whether it is a read-only copy of a master (`slave`).",
+                      "description": "Whether this domain represents the authoritative source of information for the domain it describes (`master`), or whether it is a read-only copy of a master (`slave`).",
                       "enum": [
                         "master",
                         "slave"
@@ -30899,7 +30759,7 @@
                         "description": "A domain zonefile in our DNS system.  You must own the domain name and tell your registrar to use Linode's nameservers in order for a domain in our system to be treated as authoritative.",
                         "properties": {
                           "axfr_ips": {
-                            "description": "The list of IPs that may perform a zone transfer for this Domain. The total combined length of all data within this array cannot exceed 1000 characters.\n\n__Note__. This is potentially dangerous, and should be set to an empty list unless you intend to use it.",
+                            "description": "The list of IPs that may perform a zone transfer for this domain. The total combined length of all data within this array cannot exceed 1000 characters.\n\n> 📘\n>\n> This is potentially dangerous, and should be set to an empty list unless you intend to use it.",
                             "example": [],
                             "items": {
                               "format": "ip",
@@ -30908,7 +30768,7 @@
                             "type": "array"
                           },
                           "description": {
-                            "description": "A description for this Domain. This is for display purposes only.",
+                            "description": "A description for this domain. This is for display purposes only.",
                             "example": null,
                             "maxLength": 253,
                             "minLength": 1,
@@ -30916,7 +30776,7 @@
                             "type": "string"
                           },
                           "domain": {
-                            "description": "__Filterable__ The domain this Domain represents. Domain labels cannot be longer than 63 characters and must conform to [RFC1035](https://tools.ietf.org/html/rfc1035). Domains must be unique on Linode's platform, including across different Linode accounts; there cannot be two Domains representing the same domain.",
+                            "description": "__Filterable__ The domain this domain represents. domain labels cannot be longer than 63 characters and must conform to [RFC1035](https://tools.ietf.org/html/rfc1035). domains must be unique on Linode's platform, including across different Linode accounts; there cannot be two domains representing the same domain.",
                             "example": "example.org",
                             "maxLength": 253,
                             "minLength": 1,
@@ -30932,13 +30792,13 @@
                           },
                           "expire_sec": {
                             "default": 0,
-                            "description": "The amount of time in seconds that may pass before this Domain is no longer authoritative.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 1209600.",
+                            "description": "The amount of time in seconds that may pass before this domain is no longer authoritative.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 1209600.",
                             "example": 300,
                             "type": "integer"
                           },
                           "group": {
                             "deprecated": true,
-                            "description": "__Filterable__ The group this Domain belongs to.  This is for display purposes only.",
+                            "description": "__Filterable__ The group this domain belongs to.  This is for display purposes only.",
                             "example": null,
                             "maxLength": 50,
                             "minLength": 1,
@@ -30952,14 +30812,14 @@
                             "x-linode-filterable": true
                           },
                           "id": {
-                            "description": "__Read-only__ This Domain's unique ID.",
+                            "description": "__Read-only__ This domain's unique ID.",
                             "example": 1234,
                             "readOnly": true,
                             "type": "integer",
                             "x-linode-cli-display": 1
                           },
                           "master_ips": {
-                            "description": "The IP addresses representing the master DNS for this Domain. At least one value is required for `type` slave Domains. The total combined length of all data within this array cannot exceed 1000 characters.",
+                            "description": "The IP addresses representing the master DNS for this domain. At least one value is required for `type` slave domains. The total combined length of all data within this array cannot exceed 1000 characters.",
                             "example": [],
                             "items": {
                               "format": "ip",
@@ -30969,7 +30829,7 @@
                           },
                           "refresh_sec": {
                             "default": 0,
-                            "description": "The amount of time in seconds before this Domain should be refreshed.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 14400.",
+                            "description": "The amount of time in seconds before this domain should be refreshed.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 14400.",
                             "example": 300,
                             "type": "integer"
                           },
@@ -30980,7 +30840,7 @@
                             "type": "integer"
                           },
                           "soa_email": {
-                            "description": "Start of Authority email address. This is required for `type` master Domains.",
+                            "description": "Start of Authority email address. This is required for `type` master domains.",
                             "example": "admin@example.org",
                             "format": "email",
                             "type": "string",
@@ -30988,7 +30848,7 @@
                           },
                           "status": {
                             "default": "active",
-                            "description": "Used to control whether this Domain is currently being rendered.",
+                            "description": "Used to control whether this domain is currently being rendered.",
                             "enum": [
                               "disabled",
                               "active"
@@ -31022,12 +30882,12 @@
                           },
                           "ttl_sec": {
                             "default": 0,
-                            "description": "\"Time to Live\" - the amount of time in seconds that this Domain's records may be cached by resolvers or other domain servers.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n- Any other value is rounded up to the nearest valid value.\n- A value of 0 is equivalent to the default value of 86400.",
+                            "description": "\"Time to Live\" - the amount of time in seconds that this domain's records may be cached by resolvers or other domain servers.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 86400.",
                             "example": 300,
                             "type": "integer"
                           },
                           "type": {
-                            "description": "Whether this Domain represents the authoritative source of information for the domain it describes (`master`), or whether it is a read-only copy of a master (`slave`).",
+                            "description": "Whether this domain represents the authoritative source of information for the domain it describes (`master`), or whether it is a read-only copy of a master (`slave`).",
                             "enum": [
                               "master",
                               "slave"
@@ -31222,7 +31082,7 @@
                   "description": "A domain zonefile in our DNS system.  You must own the domain name and tell your registrar to use Linode's nameservers in order for a domain in our system to be treated as authoritative.",
                   "properties": {
                     "axfr_ips": {
-                      "description": "The list of IPs that may perform a zone transfer for this Domain. The total combined length of all data within this array cannot exceed 1000 characters.\n\n__Note__. This is potentially dangerous, and should be set to an empty list unless you intend to use it.",
+                      "description": "The list of IPs that may perform a zone transfer for this domain. The total combined length of all data within this array cannot exceed 1000 characters.\n\n> 📘\n>\n> This is potentially dangerous, and should be set to an empty list unless you intend to use it.",
                       "example": [],
                       "items": {
                         "format": "ip",
@@ -31231,7 +31091,7 @@
                       "type": "array"
                     },
                     "description": {
-                      "description": "A description for this Domain. This is for display purposes only.",
+                      "description": "A description for this domain. This is for display purposes only.",
                       "example": null,
                       "maxLength": 253,
                       "minLength": 1,
@@ -31239,7 +31099,7 @@
                       "type": "string"
                     },
                     "domain": {
-                      "description": "__Filterable__ The domain this Domain represents. Domain labels cannot be longer than 63 characters and must conform to [RFC1035](https://tools.ietf.org/html/rfc1035). Domains must be unique on Linode's platform, including across different Linode accounts; there cannot be two Domains representing the same domain.",
+                      "description": "__Filterable__ The domain this domain represents. domain labels cannot be longer than 63 characters and must conform to [RFC1035](https://tools.ietf.org/html/rfc1035). domains must be unique on Linode's platform, including across different Linode accounts; there cannot be two domains representing the same domain.",
                       "example": "example.org",
                       "maxLength": 253,
                       "minLength": 1,
@@ -31255,13 +31115,13 @@
                     },
                     "expire_sec": {
                       "default": 0,
-                      "description": "The amount of time in seconds that may pass before this Domain is no longer authoritative.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 1209600.",
+                      "description": "The amount of time in seconds that may pass before this domain is no longer authoritative.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 1209600.",
                       "example": 300,
                       "type": "integer"
                     },
                     "group": {
                       "deprecated": true,
-                      "description": "__Filterable__ The group this Domain belongs to.  This is for display purposes only.",
+                      "description": "__Filterable__ The group this domain belongs to.  This is for display purposes only.",
                       "example": null,
                       "maxLength": 50,
                       "minLength": 1,
@@ -31275,14 +31135,14 @@
                       "x-linode-filterable": true
                     },
                     "id": {
-                      "description": "__Read-only__ This Domain's unique ID.",
+                      "description": "__Read-only__ This domain's unique ID.",
                       "example": 1234,
                       "readOnly": true,
                       "type": "integer",
                       "x-linode-cli-display": 1
                     },
                     "master_ips": {
-                      "description": "The IP addresses representing the master DNS for this Domain. At least one value is required for `type` slave Domains. The total combined length of all data within this array cannot exceed 1000 characters.",
+                      "description": "The IP addresses representing the master DNS for this domain. At least one value is required for `type` slave domains. The total combined length of all data within this array cannot exceed 1000 characters.",
                       "example": [],
                       "items": {
                         "format": "ip",
@@ -31292,7 +31152,7 @@
                     },
                     "refresh_sec": {
                       "default": 0,
-                      "description": "The amount of time in seconds before this Domain should be refreshed.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 14400.",
+                      "description": "The amount of time in seconds before this domain should be refreshed.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 14400.",
                       "example": 300,
                       "type": "integer"
                     },
@@ -31303,7 +31163,7 @@
                       "type": "integer"
                     },
                     "soa_email": {
-                      "description": "Start of Authority email address. This is required for `type` master Domains.",
+                      "description": "Start of Authority email address. This is required for `type` master domains.",
                       "example": "admin@example.org",
                       "format": "email",
                       "type": "string",
@@ -31311,7 +31171,7 @@
                     },
                     "status": {
                       "default": "active",
-                      "description": "Used to control whether this Domain is currently being rendered.",
+                      "description": "Used to control whether this domain is currently being rendered.",
                       "enum": [
                         "disabled",
                         "active"
@@ -31345,12 +31205,12 @@
                     },
                     "ttl_sec": {
                       "default": 0,
-                      "description": "\"Time to Live\" - the amount of time in seconds that this Domain's records may be cached by resolvers or other domain servers.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n- Any other value is rounded up to the nearest valid value.\n- A value of 0 is equivalent to the default value of 86400.",
+                      "description": "\"Time to Live\" - the amount of time in seconds that this domain's records may be cached by resolvers or other domain servers.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 86400.",
                       "example": 300,
                       "type": "integer"
                     },
                     "type": {
-                      "description": "Whether this Domain represents the authoritative source of information for the domain it describes (`master`), or whether it is a read-only copy of a master (`slave`).",
+                      "description": "Whether this domain represents the authoritative source of information for the domain it describes (`master`), or whether it is a read-only copy of a master (`slave`).",
                       "enum": [
                         "master",
                         "slave"
@@ -31484,7 +31344,7 @@
                   "description": "A domain zonefile in our DNS system.  You must own the domain name and tell your registrar to use Linode's nameservers in order for a domain in our system to be treated as authoritative.",
                   "properties": {
                     "axfr_ips": {
-                      "description": "The list of IPs that may perform a zone transfer for this Domain. The total combined length of all data within this array cannot exceed 1000 characters.\n\n__Note__. This is potentially dangerous, and should be set to an empty list unless you intend to use it.",
+                      "description": "The list of IPs that may perform a zone transfer for this domain. The total combined length of all data within this array cannot exceed 1000 characters.\n\n> 📘\n>\n> This is potentially dangerous, and should be set to an empty list unless you intend to use it.",
                       "example": [],
                       "items": {
                         "format": "ip",
@@ -31493,7 +31353,7 @@
                       "type": "array"
                     },
                     "description": {
-                      "description": "A description for this Domain. This is for display purposes only.",
+                      "description": "A description for this domain. This is for display purposes only.",
                       "example": null,
                       "maxLength": 253,
                       "minLength": 1,
@@ -31501,7 +31361,7 @@
                       "type": "string"
                     },
                     "domain": {
-                      "description": "__Filterable__ The domain this Domain represents. Domain labels cannot be longer than 63 characters and must conform to [RFC1035](https://tools.ietf.org/html/rfc1035). Domains must be unique on Linode's platform, including across different Linode accounts; there cannot be two Domains representing the same domain.",
+                      "description": "__Filterable__ The domain this domain represents. domain labels cannot be longer than 63 characters and must conform to [RFC1035](https://tools.ietf.org/html/rfc1035). domains must be unique on Linode's platform, including across different Linode accounts; there cannot be two domains representing the same domain.",
                       "example": "example.org",
                       "maxLength": 253,
                       "minLength": 1,
@@ -31517,13 +31377,13 @@
                     },
                     "expire_sec": {
                       "default": 0,
-                      "description": "The amount of time in seconds that may pass before this Domain is no longer authoritative.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 1209600.",
+                      "description": "The amount of time in seconds that may pass before this domain is no longer authoritative.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 1209600.",
                       "example": 300,
                       "type": "integer"
                     },
                     "group": {
                       "deprecated": true,
-                      "description": "__Filterable__ The group this Domain belongs to.  This is for display purposes only.",
+                      "description": "__Filterable__ The group this domain belongs to.  This is for display purposes only.",
                       "example": null,
                       "maxLength": 50,
                       "minLength": 1,
@@ -31537,14 +31397,14 @@
                       "x-linode-filterable": true
                     },
                     "id": {
-                      "description": "__Read-only__ This Domain's unique ID.",
+                      "description": "__Read-only__ This domain's unique ID.",
                       "example": 1234,
                       "readOnly": true,
                       "type": "integer",
                       "x-linode-cli-display": 1
                     },
                     "master_ips": {
-                      "description": "The IP addresses representing the master DNS for this Domain. At least one value is required for `type` slave Domains. The total combined length of all data within this array cannot exceed 1000 characters.",
+                      "description": "The IP addresses representing the master DNS for this domain. At least one value is required for `type` slave domains. The total combined length of all data within this array cannot exceed 1000 characters.",
                       "example": [],
                       "items": {
                         "format": "ip",
@@ -31554,7 +31414,7 @@
                     },
                     "refresh_sec": {
                       "default": 0,
-                      "description": "The amount of time in seconds before this Domain should be refreshed.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 14400.",
+                      "description": "The amount of time in seconds before this domain should be refreshed.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 14400.",
                       "example": 300,
                       "type": "integer"
                     },
@@ -31565,7 +31425,7 @@
                       "type": "integer"
                     },
                     "soa_email": {
-                      "description": "Start of Authority email address. This is required for `type` master Domains.",
+                      "description": "Start of Authority email address. This is required for `type` master domains.",
                       "example": "admin@example.org",
                       "format": "email",
                       "type": "string",
@@ -31573,7 +31433,7 @@
                     },
                     "status": {
                       "default": "active",
-                      "description": "Used to control whether this Domain is currently being rendered.",
+                      "description": "Used to control whether this domain is currently being rendered.",
                       "enum": [
                         "disabled",
                         "active"
@@ -31607,12 +31467,12 @@
                     },
                     "ttl_sec": {
                       "default": 0,
-                      "description": "\"Time to Live\" - the amount of time in seconds that this Domain's records may be cached by resolvers or other domain servers.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n- Any other value is rounded up to the nearest valid value.\n- A value of 0 is equivalent to the default value of 86400.",
+                      "description": "\"Time to Live\" - the amount of time in seconds that this domain's records may be cached by resolvers or other domain servers.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 86400.",
                       "example": 300,
                       "type": "integer"
                     },
                     "type": {
-                      "description": "Whether this Domain represents the authoritative source of information for the domain it describes (`master`), or whether it is a read-only copy of a master (`slave`).",
+                      "description": "Whether this domain represents the authoritative source of information for the domain it describes (`master`), or whether it is a read-only copy of a master (`slave`).",
                       "enum": [
                         "master",
                         "slave"
@@ -31718,7 +31578,7 @@
                 "description": "A domain zonefile in our DNS system.  You must own the domain name and tell your registrar to use Linode's nameservers in order for a domain in our system to be treated as authoritative.",
                 "properties": {
                   "axfr_ips": {
-                    "description": "The list of IPs that may perform a zone transfer for this Domain. The total combined length of all data within this array cannot exceed 1000 characters.\n\n__Note__. This is potentially dangerous, and should be set to an empty list unless you intend to use it.",
+                    "description": "The list of IPs that may perform a zone transfer for this domain. The total combined length of all data within this array cannot exceed 1000 characters.\n\n> 📘\n>\n> This is potentially dangerous, and should be set to an empty list unless you intend to use it.",
                     "example": [],
                     "items": {
                       "format": "ip",
@@ -31727,7 +31587,7 @@
                     "type": "array"
                   },
                   "description": {
-                    "description": "A description for this Domain. This is for display purposes only.",
+                    "description": "A description for this domain. This is for display purposes only.",
                     "example": "{{description}}",
                     "maxLength": 253,
                     "minLength": 1,
@@ -31735,7 +31595,7 @@
                     "type": "string"
                   },
                   "domain": {
-                    "description": "__Filterable__ The domain this Domain represents. Domain labels cannot be longer than 63 characters and must conform to [RFC1035](https://tools.ietf.org/html/rfc1035). Domains must be unique on Linode's platform, including across different Linode accounts; there cannot be two Domains representing the same domain.",
+                    "description": "__Filterable__ The domain this domain represents. domain labels cannot be longer than 63 characters and must conform to [RFC1035](https://tools.ietf.org/html/rfc1035). domains must be unique on Linode's platform, including across different Linode accounts; there cannot be two domains representing the same domain.",
                     "example": "{{domain}}",
                     "maxLength": 253,
                     "minLength": 1,
@@ -31751,13 +31611,13 @@
                   },
                   "expire_sec": {
                     "default": 0,
-                    "description": "The amount of time in seconds that may pass before this Domain is no longer authoritative.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 1209600.",
+                    "description": "The amount of time in seconds that may pass before this domain is no longer authoritative.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 1209600.",
                     "example": "{{expire_sec}}",
                     "type": "integer"
                   },
                   "group": {
                     "deprecated": true,
-                    "description": "__Filterable__ The group this Domain belongs to.  This is for display purposes only.",
+                    "description": "__Filterable__ The group this domain belongs to.  This is for display purposes only.",
                     "example": "{{group}}",
                     "maxLength": 50,
                     "minLength": 1,
@@ -31771,14 +31631,14 @@
                     "x-linode-filterable": true
                   },
                   "id": {
-                    "description": "__Read-only__ This Domain's unique ID.",
+                    "description": "__Read-only__ This domain's unique ID.",
                     "example": "{{id}}",
                     "readOnly": true,
                     "type": "integer",
                     "x-linode-cli-display": 1
                   },
                   "master_ips": {
-                    "description": "The IP addresses representing the master DNS for this Domain. At least one value is required for `type` slave Domains. The total combined length of all data within this array cannot exceed 1000 characters.",
+                    "description": "The IP addresses representing the master DNS for this domain. At least one value is required for `type` slave domains. The total combined length of all data within this array cannot exceed 1000 characters.",
                     "example": [],
                     "items": {
                       "format": "ip",
@@ -31788,7 +31648,7 @@
                   },
                   "refresh_sec": {
                     "default": 0,
-                    "description": "The amount of time in seconds before this Domain should be refreshed.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 14400.",
+                    "description": "The amount of time in seconds before this domain should be refreshed.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 14400.",
                     "example": "{{refresh_sec}}",
                     "type": "integer"
                   },
@@ -31799,7 +31659,7 @@
                     "type": "integer"
                   },
                   "soa_email": {
-                    "description": "Start of Authority email address. This is required for `type` master Domains.",
+                    "description": "Start of Authority email address. This is required for `type` master domains.",
                     "example": "{{soa_email}}",
                     "format": "email",
                     "type": "string",
@@ -31807,7 +31667,7 @@
                   },
                   "status": {
                     "default": "active",
-                    "description": "Used to control whether this Domain is currently being rendered.",
+                    "description": "Used to control whether this domain is currently being rendered.",
                     "enum": [
                       "disabled",
                       "active"
@@ -31841,12 +31701,12 @@
                   },
                   "ttl_sec": {
                     "default": 0,
-                    "description": "\"Time to Live\" - the amount of time in seconds that this Domain's records may be cached by resolvers or other domain servers.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n- Any other value is rounded up to the nearest valid value.\n- A value of 0 is equivalent to the default value of 86400.",
+                    "description": "\"Time to Live\" - the amount of time in seconds that this domain's records may be cached by resolvers or other domain servers.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 86400.",
                     "example": "{{ttl_sec}}",
                     "type": "integer"
                   },
                   "type": {
-                    "description": "Whether this Domain represents the authoritative source of information for the domain it describes (`master`), or whether it is a read-only copy of a master (`slave`).",
+                    "description": "Whether this domain represents the authoritative source of information for the domain it describes (`master`), or whether it is a read-only copy of a master (`slave`).",
                     "enum": [
                       "master",
                       "slave"
@@ -31879,7 +31739,7 @@
                   "description": "A domain zonefile in our DNS system.  You must own the domain name and tell your registrar to use Linode's nameservers in order for a domain in our system to be treated as authoritative.",
                   "properties": {
                     "axfr_ips": {
-                      "description": "The list of IPs that may perform a zone transfer for this Domain. The total combined length of all data within this array cannot exceed 1000 characters.\n\n__Note__. This is potentially dangerous, and should be set to an empty list unless you intend to use it.",
+                      "description": "The list of IPs that may perform a zone transfer for this domain. The total combined length of all data within this array cannot exceed 1000 characters.\n\n> 📘\n>\n> This is potentially dangerous, and should be set to an empty list unless you intend to use it.",
                       "example": [],
                       "items": {
                         "format": "ip",
@@ -31888,7 +31748,7 @@
                       "type": "array"
                     },
                     "description": {
-                      "description": "A description for this Domain. This is for display purposes only.",
+                      "description": "A description for this domain. This is for display purposes only.",
                       "example": null,
                       "maxLength": 253,
                       "minLength": 1,
@@ -31896,7 +31756,7 @@
                       "type": "string"
                     },
                     "domain": {
-                      "description": "__Filterable__ The domain this Domain represents. Domain labels cannot be longer than 63 characters and must conform to [RFC1035](https://tools.ietf.org/html/rfc1035). Domains must be unique on Linode's platform, including across different Linode accounts; there cannot be two Domains representing the same domain.",
+                      "description": "__Filterable__ The domain this domain represents. domain labels cannot be longer than 63 characters and must conform to [RFC1035](https://tools.ietf.org/html/rfc1035). domains must be unique on Linode's platform, including across different Linode accounts; there cannot be two domains representing the same domain.",
                       "example": "example.org",
                       "maxLength": 253,
                       "minLength": 1,
@@ -31912,13 +31772,13 @@
                     },
                     "expire_sec": {
                       "default": 0,
-                      "description": "The amount of time in seconds that may pass before this Domain is no longer authoritative.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 1209600.",
+                      "description": "The amount of time in seconds that may pass before this domain is no longer authoritative.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 1209600.",
                       "example": 300,
                       "type": "integer"
                     },
                     "group": {
                       "deprecated": true,
-                      "description": "__Filterable__ The group this Domain belongs to.  This is for display purposes only.",
+                      "description": "__Filterable__ The group this domain belongs to.  This is for display purposes only.",
                       "example": null,
                       "maxLength": 50,
                       "minLength": 1,
@@ -31932,14 +31792,14 @@
                       "x-linode-filterable": true
                     },
                     "id": {
-                      "description": "__Read-only__ This Domain's unique ID.",
+                      "description": "__Read-only__ This domain's unique ID.",
                       "example": 1234,
                       "readOnly": true,
                       "type": "integer",
                       "x-linode-cli-display": 1
                     },
                     "master_ips": {
-                      "description": "The IP addresses representing the master DNS for this Domain. At least one value is required for `type` slave Domains. The total combined length of all data within this array cannot exceed 1000 characters.",
+                      "description": "The IP addresses representing the master DNS for this domain. At least one value is required for `type` slave domains. The total combined length of all data within this array cannot exceed 1000 characters.",
                       "example": [],
                       "items": {
                         "format": "ip",
@@ -31949,7 +31809,7 @@
                     },
                     "refresh_sec": {
                       "default": 0,
-                      "description": "The amount of time in seconds before this Domain should be refreshed.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 14400.",
+                      "description": "The amount of time in seconds before this domain should be refreshed.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 14400.",
                       "example": 300,
                       "type": "integer"
                     },
@@ -31960,7 +31820,7 @@
                       "type": "integer"
                     },
                     "soa_email": {
-                      "description": "Start of Authority email address. This is required for `type` master Domains.",
+                      "description": "Start of Authority email address. This is required for `type` master domains.",
                       "example": "admin@example.org",
                       "format": "email",
                       "type": "string",
@@ -31968,7 +31828,7 @@
                     },
                     "status": {
                       "default": "active",
-                      "description": "Used to control whether this Domain is currently being rendered.",
+                      "description": "Used to control whether this domain is currently being rendered.",
                       "enum": [
                         "disabled",
                         "active"
@@ -32002,12 +31862,12 @@
                     },
                     "ttl_sec": {
                       "default": 0,
-                      "description": "\"Time to Live\" - the amount of time in seconds that this Domain's records may be cached by resolvers or other domain servers.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n- Any other value is rounded up to the nearest valid value.\n- A value of 0 is equivalent to the default value of 86400.",
+                      "description": "\"Time to Live\" - the amount of time in seconds that this domain's records may be cached by resolvers or other domain servers.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 86400.",
                       "example": 300,
                       "type": "integer"
                     },
                     "type": {
-                      "description": "Whether this Domain represents the authoritative source of information for the domain it describes (`master`), or whether it is a read-only copy of a master (`slave`).",
+                      "description": "Whether this domain represents the authoritative source of information for the domain it describes (`master`), or whether it is a read-only copy of a master (`slave`).",
                       "enum": [
                         "master",
                         "slave"
@@ -32287,7 +32147,7 @@
                   "description": "A domain zonefile in our DNS system.  You must own the domain name and tell your registrar to use Linode's nameservers in order for a domain in our system to be treated as authoritative.",
                   "properties": {
                     "axfr_ips": {
-                      "description": "The list of IPs that may perform a zone transfer for this Domain. The total combined length of all data within this array cannot exceed 1000 characters.\n\n__Note__. This is potentially dangerous, and should be set to an empty list unless you intend to use it.",
+                      "description": "The list of IPs that may perform a zone transfer for this domain. The total combined length of all data within this array cannot exceed 1000 characters.\n\n> 📘\n>\n> This is potentially dangerous, and should be set to an empty list unless you intend to use it.",
                       "example": [],
                       "items": {
                         "format": "ip",
@@ -32296,7 +32156,7 @@
                       "type": "array"
                     },
                     "description": {
-                      "description": "A description for this Domain. This is for display purposes only.",
+                      "description": "A description for this domain. This is for display purposes only.",
                       "example": null,
                       "maxLength": 253,
                       "minLength": 1,
@@ -32304,7 +32164,7 @@
                       "type": "string"
                     },
                     "domain": {
-                      "description": "__Filterable__ The domain this Domain represents. Domain labels cannot be longer than 63 characters and must conform to [RFC1035](https://tools.ietf.org/html/rfc1035). Domains must be unique on Linode's platform, including across different Linode accounts; there cannot be two Domains representing the same domain.",
+                      "description": "__Filterable__ The domain this domain represents. domain labels cannot be longer than 63 characters and must conform to [RFC1035](https://tools.ietf.org/html/rfc1035). domains must be unique on Linode's platform, including across different Linode accounts; there cannot be two domains representing the same domain.",
                       "example": "example.org",
                       "maxLength": 253,
                       "minLength": 1,
@@ -32320,13 +32180,13 @@
                     },
                     "expire_sec": {
                       "default": 0,
-                      "description": "The amount of time in seconds that may pass before this Domain is no longer authoritative.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 1209600.",
+                      "description": "The amount of time in seconds that may pass before this domain is no longer authoritative.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 1209600.",
                       "example": 300,
                       "type": "integer"
                     },
                     "group": {
                       "deprecated": true,
-                      "description": "__Filterable__ The group this Domain belongs to.  This is for display purposes only.",
+                      "description": "__Filterable__ The group this domain belongs to.  This is for display purposes only.",
                       "example": null,
                       "maxLength": 50,
                       "minLength": 1,
@@ -32340,14 +32200,14 @@
                       "x-linode-filterable": true
                     },
                     "id": {
-                      "description": "__Read-only__ This Domain's unique ID.",
+                      "description": "__Read-only__ This domain's unique ID.",
                       "example": 1234,
                       "readOnly": true,
                       "type": "integer",
                       "x-linode-cli-display": 1
                     },
                     "master_ips": {
-                      "description": "The IP addresses representing the master DNS for this Domain. At least one value is required for `type` slave Domains. The total combined length of all data within this array cannot exceed 1000 characters.",
+                      "description": "The IP addresses representing the master DNS for this domain. At least one value is required for `type` slave domains. The total combined length of all data within this array cannot exceed 1000 characters.",
                       "example": [],
                       "items": {
                         "format": "ip",
@@ -32357,7 +32217,7 @@
                     },
                     "refresh_sec": {
                       "default": 0,
-                      "description": "The amount of time in seconds before this Domain should be refreshed.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 14400.",
+                      "description": "The amount of time in seconds before this domain should be refreshed.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 14400.",
                       "example": 300,
                       "type": "integer"
                     },
@@ -32368,7 +32228,7 @@
                       "type": "integer"
                     },
                     "soa_email": {
-                      "description": "Start of Authority email address. This is required for `type` master Domains.",
+                      "description": "Start of Authority email address. This is required for `type` master domains.",
                       "example": "admin@example.org",
                       "format": "email",
                       "type": "string",
@@ -32376,7 +32236,7 @@
                     },
                     "status": {
                       "default": "active",
-                      "description": "Used to control whether this Domain is currently being rendered.",
+                      "description": "Used to control whether this domain is currently being rendered.",
                       "enum": [
                         "disabled",
                         "active"
@@ -32410,12 +32270,12 @@
                     },
                     "ttl_sec": {
                       "default": 0,
-                      "description": "\"Time to Live\" - the amount of time in seconds that this Domain's records may be cached by resolvers or other domain servers.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n- Any other value is rounded up to the nearest valid value.\n- A value of 0 is equivalent to the default value of 86400.",
+                      "description": "\"Time to Live\" - the amount of time in seconds that this domain's records may be cached by resolvers or other domain servers.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 86400.",
                       "example": 300,
                       "type": "integer"
                     },
                     "type": {
-                      "description": "Whether this Domain represents the authoritative source of information for the domain it describes (`master`), or whether it is a read-only copy of a master (`slave`).",
+                      "description": "Whether this domain represents the authoritative source of information for the domain it describes (`master`), or whether it is a read-only copy of a master (`slave`).",
                       "enum": [
                         "master",
                         "slave"
@@ -36887,7 +36747,7 @@
                         "x-linode-filterable": true
                       },
                       "interfaces": {
-                        "description": "An array of Network Interfaces to add to this Linode's Configuration Profile. At least one and up to three Interface objects can exist in this array. The position in the array determines which of the Linode's network Interfaces is configured:\n\n- First [0]:  eth0\n- Second [1]: eth1\n- Third [2]:  eth2\n\nWhen updating a Linode's Interfaces, _each Interface must be redefined_. An empty `interfaces` array results in a default `public` type Interface configuration only.\n\nIf no public Interface is configured, public IP addresses are still assigned to the Linode but will not be usable without manual configuration.\n\n__Note__. Changes to Linode Interface configurations can be enabled by rebooting the Linode.\n\n`vpc` details\n\nSee the [VPC documentation](https://www.linode.com/docs/products/networking/vpc/#technical-specifications) guide for its specifications and limitations.\n\n`vlan` details\n\n- Only Next Generation Network (NGN) data centers support VLANs. Run the [List regions](https://techdocs.akamai.com/linode-api/reference/get-regions) operation to view the capabilities of data center regions. If a VLAN is attached to your Linode and you attempt to migrate or clone it to a non-NGN data center, the migration or cloning will not initiate. If a Linode cannot be migrated or cloned because of an incompatibility, you will be prompted to select a different data center or contact support.\n- See the [VLANs Overview](https://www.linode.com/docs/products/networking/vlans/#technical-specifications) guide to view additional specifications and limitations.",
+                        "description": "An array of Network interfaces to add to this Linode's Configuration Profile. At least one and up to three Interface objects can exist in this array. The position in the array determines which of the Linode's network interfaces is configured:\n\n- First [0]:  eth0\n- Second [1]: eth1\n- Third [2]:  eth2\n\nWhen updating a Linode's interfaces, _each Interface must be redefined_. An empty `interfaces` array results in a default `public` type Interface configuration only.\n\nIf no public Interface is configured, public IP addresses are still assigned to the Linode but will not be usable without manual configuration.\n\n> 📘\n>\n> Changes to Linode Interface configurations can be enabled by rebooting the Linode.\n\n`vpc` details\n\nSee the [VPC documentation](https://www.linode.com/docs/products/networking/vpc/#technical-specifications) guide for its specifications and limitations.\n\n`vlan` details\n\n- Only Next Generation Network (NGN) data centers support VLANs. Run the [List regions](https://techdocs.akamai.com/linode-api/reference/get-regions) operation to view the capabilities of data center regions. If a VLAN is attached to your Linode and you attempt to migrate or clone it to a non-NGN data center, the migration or cloning will not initiate. If a Linode cannot be migrated or cloned because of an incompatibility, you will be prompted to select a different data center or contact support.\n- See the [VLANs Overview](https://www.linode.com/docs/products/networking/vlans/#technical-specifications) guide to view additional specifications and limitations.",
                         "example": [
                           {
                             "id": 101,
@@ -36904,7 +36764,7 @@
                             "ipam_address": "10.0.0.1/24",
                             "ipv4": {
                               "nat_1_1": null,
-                              "vpc": "192.0.2.134"
+                              "vpc": "192.0.2.12"
                             },
                             "label": "vlan-1",
                             "primary": false,
@@ -36916,8 +36776,8 @@
                             "id": 103,
                             "ipam_address": null,
                             "ipv4": {
-                              "nat_1_1": "192.0.2.136",
-                              "vpc": "192.0.2.235"
+                              "nat_1_1": "192.0.2.121",
+                              "vpc": "192.0.2.241"
                             },
                             "label": null,
                             "primary": true,
@@ -36946,8 +36806,8 @@
                             "ip_ranges": {
                               "description": "IPv4 CIDR VPC subnet ranges that are routed to this interface.\n\nWhen included in a request:\n\n- A range can't include any addresses that are assigned to an active Linode or another VPC subnet.\n\n- When updating, you need to include any existing ranges to maintain them. If a range is left out, it will be removed.\n\n- Submit this as an empty array removes all existing values.\n\n- Omit this object to leave existing values as is.\n\n<<LB>>\n\n> 📘\n>\n> This is only supported for interfaces with a `purpose` of `vpc`.",
                               "example": [
-                                "192.0.2.34/24",
-                                "2001:db8:7eac:78b6:7ff1:8e56:ebc1:8ddc/32"
+                                "192.0.2.90/24",
+                                "2001:db8:e4a6:4266:5d21:d95f:1810:2794/32"
                               ],
                               "items": {
                                 "format": "ip",
@@ -36985,13 +36845,13 @@
                                     }
                                   ],
                                   "description": "The 1:1 NAT IPv4 address, used to associate a public IPv4 address with the interface's VPC subnet IPv4 address.\n\n- Only supported for interfaces with a `purpose` of `vpc`.\n\n- Returned as `null` if no 1:1 NAT is set for a `vpc` type interface.\n\n- Returned as an empty string (`\"\"`) for non-`vpc` type interfaces.\n\nWhen included in a request:\n\n- You can set this to a specific, public IPv4 address that's available on the Linode. You can also use the `any` keyword to enable the Linode's assigned public IPv4 address.\n\n- A specified address can't be shared with another Linode.\n\n- Omit this object or include it and set it to `null` or an empty string (`\"\"`) to block creation of a 1:1 NAT.\n\n<<LB>>\n\n> 📘\n>\n> You can't set this to a specific IPv4 address when creating a new Linode. During the creation process, the network automatically establishes a public IPv4 address for the Linode. Since this address doesn't exist yet, you can't include a custom IPv4 address to change it. After your Linode is created, you can [update your configuration profile interface](https://www.linode.com/docs/api/linode-instances/#configuration-profile-interface-update) to change the `nat_1_1` address.",
-                                  "example": "192.0.2.24",
+                                  "example": "192.0.2.166",
                                   "nullable": true,
                                   "type": "string"
                                 },
                                 "vpc": {
                                   "description": "The VPC subnet IPv4 address for this interface.\n\n- This only applies to interfaces with a `purpose` of `vpc`.\n\n- Returned as an empty string (`\"\"`) for non-`vpc` type interfaces.\n\nWhen included in a request:\n\n- The `vpc` can't be assigned to an existing Linode as an address or in a range.\n\n- The target address can't be the first two or last two addresses in the subnet IPv4 range.\n\n- If omitted, a valid address within the Subnet IPv4 range is automatically assigned.",
-                                  "example": "192.0.2.188",
+                                  "example": "192.0.2.203",
                                   "format": "ip",
                                   "nullable": true,
                                   "type": "string"
@@ -37364,7 +37224,7 @@
                     "ipv4": {
                       "description": "__Filterable__, __Read-only__ This Linode's IPv4 Addresses. Each Linode is assigned a single public IPv4 address upon creation, and may get a single private IPv4 address if needed. You may need to [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) to get additional IPv4 addresses.\n\nIPv4 addresses may be reassigned between your Linodes, or shared with other Linodes. See the [networking](https://techdocs.akamai.com/linode-api/reference/post-firewalls) operations for details.",
                       "example": [
-                        "192.0.2.217",
+                        "192.0.2.63",
                         "192.0.2.1"
                       ],
                       "format": "ipv4",
@@ -37383,7 +37243,7 @@
                     },
                     "ipv6": {
                       "description": "__Read-only__ This Linode's IPv6 SLAAC address. This address is specific to a Linode, and may not be shared. If the Linode has not been assigned an IPv6 address, the return value will be `null`.",
-                      "example": "2001:db8:6166:61ba:24c9:9121:2ddb:e3d2/32",
+                      "example": "2001:db8:7c77:ade7:fe1a:f375:7321:fa32/32",
                       "format": "ipv6/128",
                       "nullable": true,
                       "readOnly": true,
@@ -38018,7 +37878,7 @@
                           "ipv4": {
                             "description": "__Filterable__, __Read-only__ This Linode's IPv4 Addresses. Each Linode is assigned a single public IPv4 address upon creation, and may get a single private IPv4 address if needed. You may need to [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) to get additional IPv4 addresses.\n\nIPv4 addresses may be reassigned between your Linodes, or shared with other Linodes. See the [networking](https://techdocs.akamai.com/linode-api/reference/post-firewalls) operations for details.",
                             "example": [
-                              "192.0.2.112",
+                              "192.0.2.242",
                               "192.0.2.1"
                             ],
                             "format": "ipv4",
@@ -38037,7 +37897,7 @@
                           },
                           "ipv6": {
                             "description": "__Read-only__ This Linode's IPv6 SLAAC address. This address is specific to a Linode, and may not be shared. If the Linode has not been assigned an IPv6 address, the return value will be `null`.",
-                            "example": "2001:db8:c311:486d:dd2b:e8c9:4c1b:1e3d/32",
+                            "example": "2001:db8:8363:97bc:552d:ef40:f31e:de7f/32",
                             "format": "ipv6/128",
                             "nullable": true,
                             "readOnly": true,
@@ -38600,7 +38460,7 @@
                     "ipv4": {
                       "description": "__Filterable__, __Read-only__ This Linode's IPv4 Addresses. Each Linode is assigned a single public IPv4 address upon creation, and may get a single private IPv4 address if needed. You may need to [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) to get additional IPv4 addresses.\n\nIPv4 addresses may be reassigned between your Linodes, or shared with other Linodes. See the [networking](https://techdocs.akamai.com/linode-api/reference/post-firewalls) operations for details.",
                       "example": [
-                        "192.0.2.82",
+                        "192.0.2.134",
                         "192.0.2.1"
                       ],
                       "format": "ipv4",
@@ -38619,7 +38479,7 @@
                     },
                     "ipv6": {
                       "description": "__Read-only__ This Linode's IPv6 SLAAC address. This address is specific to a Linode, and may not be shared. If the Linode has not been assigned an IPv6 address, the return value will be `null`.",
-                      "example": "2001:db8:2df0:9d83:78e2:c1d9:4705:3f0a/32",
+                      "example": "2001:db8:37be:62dc:8cad:d837:5502:8cb5/32",
                       "format": "ipv6/128",
                       "nullable": true,
                       "readOnly": true,
@@ -39184,7 +39044,7 @@
                   "ipv4": {
                     "description": "__Filterable__, __Read-only__ This Linode's IPv4 Addresses. Each Linode is assigned a single public IPv4 address upon creation, and may get a single private IPv4 address if needed. You may need to [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) to get additional IPv4 addresses.\n\nIPv4 addresses may be reassigned between your Linodes, or shared with other Linodes. See the [networking](https://techdocs.akamai.com/linode-api/reference/post-firewalls) operations for details.",
                     "example": [
-                      "192.0.2.195",
+                      "192.0.2.138",
                       "192.0.2.1"
                     ],
                     "format": "ipv4",
@@ -39627,7 +39487,7 @@
                     "ipv4": {
                       "description": "__Filterable__, __Read-only__ This Linode's IPv4 Addresses. Each Linode is assigned a single public IPv4 address upon creation, and may get a single private IPv4 address if needed. You may need to [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) to get additional IPv4 addresses.\n\nIPv4 addresses may be reassigned between your Linodes, or shared with other Linodes. See the [networking](https://techdocs.akamai.com/linode-api/reference/post-firewalls) operations for details.",
                       "example": [
-                        "192.0.2.208",
+                        "192.0.2.230",
                         "192.0.2.1"
                       ],
                       "format": "ipv4",
@@ -39646,7 +39506,7 @@
                     },
                     "ipv6": {
                       "description": "__Read-only__ This Linode's IPv6 SLAAC address. This address is specific to a Linode, and may not be shared. If the Linode has not been assigned an IPv6 address, the return value will be `null`.",
-                      "example": "2001:db8:d60c:bcf1:a616:d014:cf97:4835/32",
+                      "example": "2001:db8:cc7e:b838:b680:d4b3:aa62:c74c/32",
                       "format": "ipv6/128",
                       "nullable": true,
                       "readOnly": true,
@@ -40065,7 +39925,7 @@
     },
     "/{apiVersion}/linode/instances/{linodeId}/backups": {
       "post": {
-        "description": "Creates a snapshot backup of a Linode.\n\n__Note__. Backups are not encrypted even when they are taken from an encrypted disk. When a backup is restored, and if encryption is enabled, the data stored on the disk is encrypted again.\n\n__Important__. If you already have a snapshot of this Linode, this is a destructive action. The previous snapshot will be deleted.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli linodes snapshot 123\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    linodes:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Creates a snapshot backup of a Linode.\n\n> 📘\n>\n> - Backups aren't encrypted even when they're taken from an encrypted disk. When a backup is restored, and if encryption is enabled, the data stored on the disk is encrypted again.\n>\n> - If you already have a snapshot of this Linode, the previous snapshot will be deleted.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli linodes snapshot 123\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    linodes:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/post-snapshot"
@@ -41110,7 +40970,7 @@
     },
     "/{apiVersion}/linode/instances/{linodeId}/backups/enable": {
       "post": {
-        "description": "Enables backups for the specified Linode.\n\n__Note__. Backups are not encrypted even when they are taken from an encrypted disk. When a backup is restored, and if encryption is enabled, the data stored on the disk is encrypted again.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli linodes backups-enable 123\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    linodes:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Enables backups for the specified Linode.\n\n> 📘\n>\n> Backups aren't encrypted even when they're taken from an encrypted disk. When a backup is restored, and if encryption is enabled, the data stored on the disk is encrypted again.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli linodes backups-enable 123\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    linodes:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/post-enable-backups"
@@ -41511,7 +41371,7 @@
     },
     "/{apiVersion}/linode/instances/{linodeId}/backups/{backupId}/restore": {
       "post": {
-        "description": "Restores a Linode's Backup to the specified Linode.\n\nThe following conditions apply:\n\n  - Backups may not be restored across Regions.\n  - Only successfully completed Backups that are not undergoing maintenance can be restored.\n  - The Linode that the Backup is being restored to must not itself be in the process of creating a Backup.\n\n__Note__. When you restore a backup, the restored disk is assigned the same [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier) as the original disk. In most cases, this is acceptable and does not cause issues. However, if you attempt to mount both the original disk and the corresponding restore disk at the same time (by assigning them both to devices in your Configuration Profile's __Block Device Assignment__), you will encounter a UUID \"collision\".\n\nWhen this happens, the system selects, and mounts, only one of the disks at random. This is due to both disks sharing the same UUID, and your instance _may fail to boot_ since it will not be clear which disk is root. If your system does boot, you will not see any immediate indication if you are booted into the restored disk or the original disk, and you will be unable to access both disks at the same time.\n\nTo avoid this, we recommend only restoring a backup to the same Compute Instance if you do not intend on mounting them at the same time or are comfortable modifying UUIDs. If you need access to files on both the original disk and the restored disk simultaneously (such as needing to copy files between them), we suggest either restoring the backup to a separate Compute Instance or [creating](https://techdocs.akamai.com/linode-api/reference/post-linode-instance) a new Compute Instance with the desired `backup_id`.\n\nTo learn more about block device assignments and viewing your disks' UUIDs, see our guide on [Configuration Profiles](https://www.linode.com/docs/products/compute/compute-instances/guides/configuration-profiles/#block-device-assignment).\n\n__Note__. Backups are not encrypted even when they are taken from an encrypted disk. When a backup is restored, and if encryption is enabled, the data stored on the disk is encrypted again.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli linodes backup-restore 123 123456 \\\n  --linode_id 234 \\\n  --overwrite true\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    linodes:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Restores a Linode's backup to the specified Linode.\n\n- Backups may not be restored across regions.\n- Only successfully completed backups that are not undergoing maintenance can be restored.\n- The Linode that the backup is being restored to can't be the target of a current backup.\n\nWhen you restore a backup, the restored disk is assigned the same [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier) as the original disk. In most cases, this is acceptable and doesn't cause issues. However, if you try to mount both the original disk and the corresponding restore disk at the same time (by assigning them both to devices in your Configuration Profile's __Block Device Assignment__), you'll encounter a UUID \"collision\".\n\nWhen this happens, the system selects, and mounts, only one of the disks at random. This is because both disks are sharing the same UUID. Your instance _may fail to boot_ because the API can't tell which disk is root. If your system boots in this scenario, you won't see an immediate indication if you're booted into the restored disk or the original disk, and you'll be unable to access both disks at the same time.\n\nTo avoid this, only restore a backup to the same Linode if you don't intend to mount them at the same time, or you're comfortable modifying UUIDs. If you need access to files on both the original disk and the restored disk simultaneously -- for example, if you need to copy files between them -- you should restore the backup to a separate Linode or [create](https://techdocs.akamai.com/linode-api/reference/post-linode-instance) a new Linode using the desired `backup_id`.\n\nTo learn more about block device assignments and viewing your disks' UUIDs, see our guide on [Configuration Profiles](https://www.linode.com/docs/products/compute/compute-instances/guides/configuration-profiles/#block-device-assignment).\n\n> 📘\n>\n> Backups aren't encrypted even when they're taken from an encrypted disk. When a backup is restored, and if encryption is enabled, the data stored on the disk is encrypted again.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli linodes backup-restore 123 123456 \\\n  --linode_id 234 \\\n  --overwrite true\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    linodes:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/post-restore-backup"
@@ -42177,7 +42037,7 @@
                     "ipv4": {
                       "description": "__Filterable__, __Read-only__ This Linode's IPv4 Addresses. Each Linode is assigned a single public IPv4 address upon creation, and may get a single private IPv4 address if needed. You may need to [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) to get additional IPv4 addresses.\n\nIPv4 addresses may be reassigned between your Linodes, or shared with other Linodes. See the [networking](https://techdocs.akamai.com/linode-api/reference/post-firewalls) operations for details.",
                       "example": [
-                        "192.0.2.160",
+                        "192.0.2.215",
                         "192.0.2.1"
                       ],
                       "format": "ipv4",
@@ -42196,7 +42056,7 @@
                     },
                     "ipv6": {
                       "description": "__Read-only__ This Linode's IPv6 SLAAC address. This address is specific to a Linode, and may not be shared. If the Linode has not been assigned an IPv6 address, the return value will be `null`.",
-                      "example": "2001:db8:97fd:d47:c563:f339:58bd:662e/32",
+                      "example": "2001:db8:5695:701:c985:f8eb:329f:5e98/32",
                       "format": "ipv6/128",
                       "nullable": true,
                       "readOnly": true,
@@ -42758,7 +42618,7 @@
                         "x-linode-cli-display": 1
                       },
                       "interfaces": {
-                        "description": "An array of Network Interfaces to add to this Linode's Configuration Profile. At least one and up to three Interface objects can exist in this array. The position in the array determines which of the Linode's network Interfaces is configured:\n\n- First [0]:  eth0\n- Second [1]: eth1\n- Third [2]:  eth2\n\nWhen updating a Linode's Interfaces, _each Interface must be redefined_. An empty `interfaces` array results in a default `public` type Interface configuration only.\n\nIf no public Interface is configured, public IP addresses are still assigned to the Linode but will not be usable without manual configuration.\n\n__Note__. Changes to Linode Interface configurations can be enabled by rebooting the Linode.\n\n`vpc` details\n\nSee the [VPC documentation](https://www.linode.com/docs/products/networking/vpc/#technical-specifications) guide for its specifications and limitations.\n\n`vlan` details\n\n- Only Next Generation Network (NGN) data centers support VLANs. Run the [List regions](https://techdocs.akamai.com/linode-api/reference/get-regions) operation to view the capabilities of data center regions. If a VLAN is attached to your Linode and you attempt to migrate or clone it to a non-NGN data center, the migration or cloning will not initiate. If a Linode cannot be migrated or cloned because of an incompatibility, you will be prompted to select a different data center or contact support.\n- See the [VLANs Overview](https://www.linode.com/docs/products/networking/vlans/#technical-specifications) guide to view additional specifications and limitations.",
+                        "description": "An array of Network interfaces to add to this Linode's Configuration Profile. At least one and up to three Interface objects can exist in this array. The position in the array determines which of the Linode's network interfaces is configured:\n\n- First [0]:  eth0\n- Second [1]: eth1\n- Third [2]:  eth2\n\nWhen updating a Linode's interfaces, _each Interface must be redefined_. An empty `interfaces` array results in a default `public` type Interface configuration only.\n\nIf no public Interface is configured, public IP addresses are still assigned to the Linode but will not be usable without manual configuration.\n\n> 📘\n>\n> Changes to Linode Interface configurations can be enabled by rebooting the Linode.\n\n`vpc` details\n\nSee the [VPC documentation](https://www.linode.com/docs/products/networking/vpc/#technical-specifications) guide for its specifications and limitations.\n\n`vlan` details\n\n- Only Next Generation Network (NGN) data centers support VLANs. Run the [List regions](https://techdocs.akamai.com/linode-api/reference/get-regions) operation to view the capabilities of data center regions. If a VLAN is attached to your Linode and you attempt to migrate or clone it to a non-NGN data center, the migration or cloning will not initiate. If a Linode cannot be migrated or cloned because of an incompatibility, you will be prompted to select a different data center or contact support.\n- See the [VLANs Overview](https://www.linode.com/docs/products/networking/vlans/#technical-specifications) guide to view additional specifications and limitations.",
                         "example": [
                           {
                             "id": 101,
@@ -42775,7 +42635,7 @@
                             "ipam_address": "10.0.0.1/24",
                             "ipv4": {
                               "nat_1_1": null,
-                              "vpc": "192.0.2.100"
+                              "vpc": "192.0.2.203"
                             },
                             "label": "vlan-1",
                             "primary": false,
@@ -42787,8 +42647,8 @@
                             "id": 103,
                             "ipam_address": null,
                             "ipv4": {
-                              "nat_1_1": "192.0.2.158",
-                              "vpc": "192.0.2.215"
+                              "nat_1_1": "192.0.2.147",
+                              "vpc": "192.0.2.244"
                             },
                             "label": null,
                             "primary": true,
@@ -42817,8 +42677,8 @@
                             "ip_ranges": {
                               "description": "IPv4 CIDR VPC subnet ranges that are routed to this interface.\n\nWhen included in a request:\n\n- A range can't include any addresses that are assigned to an active Linode or another VPC subnet.\n\n- When updating, you need to include any existing ranges to maintain them. If a range is left out, it will be removed.\n\n- Submit this as an empty array removes all existing values.\n\n- Omit this object to leave existing values as is.\n\n<<LB>>\n\n> 📘\n>\n> This is only supported for interfaces with a `purpose` of `vpc`.",
                               "example": [
-                                "192.0.2.228/24",
-                                "2001:db8:6455:99ce:bd56:87cd:1f7b:29b5/32"
+                                "192.0.2.236/24",
+                                "2001:db8:c9cb:43ef:eb48:2a94:ddc0:7732/32"
                               ],
                               "items": {
                                 "format": "ip",
@@ -42856,13 +42716,13 @@
                                     }
                                   ],
                                   "description": "The 1:1 NAT IPv4 address, used to associate a public IPv4 address with the interface's VPC subnet IPv4 address.\n\n- Only supported for interfaces with a `purpose` of `vpc`.\n\n- Returned as `null` if no 1:1 NAT is set for a `vpc` type interface.\n\n- Returned as an empty string (`\"\"`) for non-`vpc` type interfaces.\n\nWhen included in a request:\n\n- You can set this to a specific, public IPv4 address that's available on the Linode. You can also use the `any` keyword to enable the Linode's assigned public IPv4 address.\n\n- A specified address can't be shared with another Linode.\n\n- Omit this object or include it and set it to `null` or an empty string (`\"\"`) to block creation of a 1:1 NAT.\n\n<<LB>>\n\n> 📘\n>\n> You can't set this to a specific IPv4 address when creating a new Linode. During the creation process, the network automatically establishes a public IPv4 address for the Linode. Since this address doesn't exist yet, you can't include a custom IPv4 address to change it. After your Linode is created, you can [update your configuration profile interface](https://www.linode.com/docs/api/linode-instances/#configuration-profile-interface-update) to change the `nat_1_1` address.",
-                                  "example": "192.0.2.18",
+                                  "example": "192.0.2.208",
                                   "nullable": true,
                                   "type": "string"
                                 },
                                 "vpc": {
                                   "description": "The VPC subnet IPv4 address for this interface.\n\n- This only applies to interfaces with a `purpose` of `vpc`.\n\n- Returned as an empty string (`\"\"`) for non-`vpc` type interfaces.\n\nWhen included in a request:\n\n- The `vpc` can't be assigned to an existing Linode as an address or in a range.\n\n- The target address can't be the first two or last two addresses in the subnet IPv4 range.\n\n- If omitted, a valid address within the Subnet IPv4 range is automatically assigned.",
-                                  "example": "192.0.2.103",
+                                  "example": "192.0.2.36",
                                   "format": "ip",
                                   "nullable": true,
                                   "type": "string"
@@ -43238,7 +43098,7 @@
                       "x-linode-cli-display": 1
                     },
                     "interfaces": {
-                      "description": "An array of Network Interfaces to add to this Linode's Configuration Profile. At least one and up to three Interface objects can exist in this array. The position in the array determines which of the Linode's network Interfaces is configured:\n\n- First [0]:  eth0\n- Second [1]: eth1\n- Third [2]:  eth2\n\nWhen updating a Linode's Interfaces, _each Interface must be redefined_. An empty `interfaces` array results in a default `public` type Interface configuration only.\n\nIf no public Interface is configured, public IP addresses are still assigned to the Linode but will not be usable without manual configuration.\n\n__Note__. Changes to Linode Interface configurations can be enabled by rebooting the Linode.\n\n`vpc` details\n\nSee the [VPC documentation](https://www.linode.com/docs/products/networking/vpc/#technical-specifications) guide for its specifications and limitations.\n\n`vlan` details\n\n- Only Next Generation Network (NGN) data centers support VLANs. Run the [List regions](https://techdocs.akamai.com/linode-api/reference/get-regions) operation to view the capabilities of data center regions. If a VLAN is attached to your Linode and you attempt to migrate or clone it to a non-NGN data center, the migration or cloning will not initiate. If a Linode cannot be migrated or cloned because of an incompatibility, you will be prompted to select a different data center or contact support.\n- See the [VLANs Overview](https://www.linode.com/docs/products/networking/vlans/#technical-specifications) guide to view additional specifications and limitations.",
+                      "description": "An array of Network interfaces to add to this Linode's Configuration Profile. At least one and up to three Interface objects can exist in this array. The position in the array determines which of the Linode's network interfaces is configured:\n\n- First [0]:  eth0\n- Second [1]: eth1\n- Third [2]:  eth2\n\nWhen updating a Linode's interfaces, _each Interface must be redefined_. An empty `interfaces` array results in a default `public` type Interface configuration only.\n\nIf no public Interface is configured, public IP addresses are still assigned to the Linode but will not be usable without manual configuration.\n\n> 📘\n>\n> Changes to Linode Interface configurations can be enabled by rebooting the Linode.\n\n`vpc` details\n\nSee the [VPC documentation](https://www.linode.com/docs/products/networking/vpc/#technical-specifications) guide for its specifications and limitations.\n\n`vlan` details\n\n- Only Next Generation Network (NGN) data centers support VLANs. Run the [List regions](https://techdocs.akamai.com/linode-api/reference/get-regions) operation to view the capabilities of data center regions. If a VLAN is attached to your Linode and you attempt to migrate or clone it to a non-NGN data center, the migration or cloning will not initiate. If a Linode cannot be migrated or cloned because of an incompatibility, you will be prompted to select a different data center or contact support.\n- See the [VLANs Overview](https://www.linode.com/docs/products/networking/vlans/#technical-specifications) guide to view additional specifications and limitations.",
                       "example": [
                         {
                           "id": 101,
@@ -43255,7 +43115,7 @@
                           "ipam_address": "10.0.0.1/24",
                           "ipv4": {
                             "nat_1_1": null,
-                            "vpc": "192.0.2.65"
+                            "vpc": "192.0.2.119"
                           },
                           "label": "vlan-1",
                           "primary": false,
@@ -43267,8 +43127,8 @@
                           "id": 103,
                           "ipam_address": null,
                           "ipv4": {
-                            "nat_1_1": "192.0.2.112",
-                            "vpc": "192.0.2.80"
+                            "nat_1_1": "192.0.2.63",
+                            "vpc": "192.0.2.166"
                           },
                           "label": null,
                           "primary": true,
@@ -43297,8 +43157,8 @@
                           "ip_ranges": {
                             "description": "IPv4 CIDR VPC subnet ranges that are routed to this interface.\n\nWhen included in a request:\n\n- A range can't include any addresses that are assigned to an active Linode or another VPC subnet.\n\n- When updating, you need to include any existing ranges to maintain them. If a range is left out, it will be removed.\n\n- Submit this as an empty array removes all existing values.\n\n- Omit this object to leave existing values as is.\n\n<<LB>>\n\n> 📘\n>\n> This is only supported for interfaces with a `purpose` of `vpc`.",
                             "example": [
-                              "192.0.2.241/24",
-                              "2001:db8:8572:977f:d436:6610:dbd8:88d0/32"
+                              "192.0.2.184/24",
+                              "2001:db8:2144:19ef:cc8:6daa:d86c:80f8/32"
                             ],
                             "items": {
                               "format": "ip",
@@ -43336,13 +43196,13 @@
                                   }
                                 ],
                                 "description": "The 1:1 NAT IPv4 address, used to associate a public IPv4 address with the interface's VPC subnet IPv4 address.\n\n- Only supported for interfaces with a `purpose` of `vpc`.\n\n- Returned as `null` if no 1:1 NAT is set for a `vpc` type interface.\n\n- Returned as an empty string (`\"\"`) for non-`vpc` type interfaces.\n\nWhen included in a request:\n\n- You can set this to a specific, public IPv4 address that's available on the Linode. You can also use the `any` keyword to enable the Linode's assigned public IPv4 address.\n\n- A specified address can't be shared with another Linode.\n\n- Omit this object or include it and set it to `null` or an empty string (`\"\"`) to block creation of a 1:1 NAT.\n\n<<LB>>\n\n> 📘\n>\n> You can't set this to a specific IPv4 address when creating a new Linode. During the creation process, the network automatically establishes a public IPv4 address for the Linode. Since this address doesn't exist yet, you can't include a custom IPv4 address to change it. After your Linode is created, you can [update your configuration profile interface](https://www.linode.com/docs/api/linode-instances/#configuration-profile-interface-update) to change the `nat_1_1` address.",
-                                "example": "192.0.2.90",
+                                "example": "192.0.2.39",
                                 "nullable": true,
                                 "type": "string"
                               },
                               "vpc": {
                                 "description": "The VPC subnet IPv4 address for this interface.\n\n- This only applies to interfaces with a `purpose` of `vpc`.\n\n- Returned as an empty string (`\"\"`) for non-`vpc` type interfaces.\n\nWhen included in a request:\n\n- The `vpc` can't be assigned to an existing Linode as an address or in a range.\n\n- The target address can't be the first two or last two addresses in the subnet IPv4 range.\n\n- If omitted, a valid address within the Subnet IPv4 range is automatically assigned.",
-                                "example": "192.0.2.108",
+                                "example": "192.0.2.213",
                                 "format": "ip",
                                 "nullable": true,
                                 "type": "string"
@@ -43820,7 +43680,7 @@
                             "x-linode-cli-display": 1
                           },
                           "interfaces": {
-                            "description": "An array of Network Interfaces to add to this Linode's Configuration Profile. At least one and up to three Interface objects can exist in this array. The position in the array determines which of the Linode's network Interfaces is configured:\n\n- First [0]:  eth0\n- Second [1]: eth1\n- Third [2]:  eth2\n\nWhen updating a Linode's Interfaces, _each Interface must be redefined_. An empty `interfaces` array results in a default `public` type Interface configuration only.\n\nIf no public Interface is configured, public IP addresses are still assigned to the Linode but will not be usable without manual configuration.\n\n__Note__. Changes to Linode Interface configurations can be enabled by rebooting the Linode.\n\n`vpc` details\n\nSee the [VPC documentation](https://www.linode.com/docs/products/networking/vpc/#technical-specifications) guide for its specifications and limitations.\n\n`vlan` details\n\n- Only Next Generation Network (NGN) data centers support VLANs. Run the [List regions](https://techdocs.akamai.com/linode-api/reference/get-regions) operation to view the capabilities of data center regions. If a VLAN is attached to your Linode and you attempt to migrate or clone it to a non-NGN data center, the migration or cloning will not initiate. If a Linode cannot be migrated or cloned because of an incompatibility, you will be prompted to select a different data center or contact support.\n- See the [VLANs Overview](https://www.linode.com/docs/products/networking/vlans/#technical-specifications) guide to view additional specifications and limitations.",
+                            "description": "An array of Network interfaces to add to this Linode's Configuration Profile. At least one and up to three Interface objects can exist in this array. The position in the array determines which of the Linode's network interfaces is configured:\n\n- First [0]:  eth0\n- Second [1]: eth1\n- Third [2]:  eth2\n\nWhen updating a Linode's interfaces, _each Interface must be redefined_. An empty `interfaces` array results in a default `public` type Interface configuration only.\n\nIf no public Interface is configured, public IP addresses are still assigned to the Linode but will not be usable without manual configuration.\n\n> 📘\n>\n> Changes to Linode Interface configurations can be enabled by rebooting the Linode.\n\n`vpc` details\n\nSee the [VPC documentation](https://www.linode.com/docs/products/networking/vpc/#technical-specifications) guide for its specifications and limitations.\n\n`vlan` details\n\n- Only Next Generation Network (NGN) data centers support VLANs. Run the [List regions](https://techdocs.akamai.com/linode-api/reference/get-regions) operation to view the capabilities of data center regions. If a VLAN is attached to your Linode and you attempt to migrate or clone it to a non-NGN data center, the migration or cloning will not initiate. If a Linode cannot be migrated or cloned because of an incompatibility, you will be prompted to select a different data center or contact support.\n- See the [VLANs Overview](https://www.linode.com/docs/products/networking/vlans/#technical-specifications) guide to view additional specifications and limitations.",
                             "example": [
                               {
                                 "id": 101,
@@ -43837,7 +43697,7 @@
                                 "ipam_address": "10.0.0.1/24",
                                 "ipv4": {
                                   "nat_1_1": null,
-                                  "vpc": "192.0.2.177"
+                                  "vpc": "192.0.2.110"
                                 },
                                 "label": "vlan-1",
                                 "primary": false,
@@ -43849,8 +43709,8 @@
                                 "id": 103,
                                 "ipam_address": null,
                                 "ipv4": {
-                                  "nat_1_1": "192.0.2.16",
-                                  "vpc": "192.0.2.230"
+                                  "nat_1_1": "192.0.2.73",
+                                  "vpc": "192.0.2.185"
                                 },
                                 "label": null,
                                 "primary": true,
@@ -43879,8 +43739,8 @@
                                 "ip_ranges": {
                                   "description": "IPv4 CIDR VPC subnet ranges that are routed to this interface.\n\nWhen included in a request:\n\n- A range can't include any addresses that are assigned to an active Linode or another VPC subnet.\n\n- When updating, you need to include any existing ranges to maintain them. If a range is left out, it will be removed.\n\n- Submit this as an empty array removes all existing values.\n\n- Omit this object to leave existing values as is.\n\n<<LB>>\n\n> 📘\n>\n> This is only supported for interfaces with a `purpose` of `vpc`.",
                                   "example": [
-                                    "192.0.2.113/24",
-                                    "2001:db8:1fca:1de1:9f2e:80af:ade4:2ed1/32"
+                                    "192.0.2.248/24",
+                                    "2001:db8:e1bf:5720:d4a3:3e21:f4da:aefc/32"
                                   ],
                                   "items": {
                                     "format": "ip",
@@ -43918,13 +43778,13 @@
                                         }
                                       ],
                                       "description": "The 1:1 NAT IPv4 address, used to associate a public IPv4 address with the interface's VPC subnet IPv4 address.\n\n- Only supported for interfaces with a `purpose` of `vpc`.\n\n- Returned as `null` if no 1:1 NAT is set for a `vpc` type interface.\n\n- Returned as an empty string (`\"\"`) for non-`vpc` type interfaces.\n\nWhen included in a request:\n\n- You can set this to a specific, public IPv4 address that's available on the Linode. You can also use the `any` keyword to enable the Linode's assigned public IPv4 address.\n\n- A specified address can't be shared with another Linode.\n\n- Omit this object or include it and set it to `null` or an empty string (`\"\"`) to block creation of a 1:1 NAT.\n\n<<LB>>\n\n> 📘\n>\n> You can't set this to a specific IPv4 address when creating a new Linode. During the creation process, the network automatically establishes a public IPv4 address for the Linode. Since this address doesn't exist yet, you can't include a custom IPv4 address to change it. After your Linode is created, you can [update your configuration profile interface](https://www.linode.com/docs/api/linode-instances/#configuration-profile-interface-update) to change the `nat_1_1` address.",
-                                      "example": "192.0.2.239",
+                                      "example": "192.0.2.166",
                                       "nullable": true,
                                       "type": "string"
                                     },
                                     "vpc": {
                                       "description": "The VPC subnet IPv4 address for this interface.\n\n- This only applies to interfaces with a `purpose` of `vpc`.\n\n- Returned as an empty string (`\"\"`) for non-`vpc` type interfaces.\n\nWhen included in a request:\n\n- The `vpc` can't be assigned to an existing Linode as an address or in a range.\n\n- The target address can't be the first two or last two addresses in the subnet IPv4 range.\n\n- If omitted, a valid address within the Subnet IPv4 range is automatically assigned.",
-                                      "example": "192.0.2.146",
+                                      "example": "192.0.2.124",
                                       "format": "ip",
                                       "nullable": true,
                                       "type": "string"
@@ -44394,7 +44254,7 @@
                       "x-linode-cli-display": 1
                     },
                     "interfaces": {
-                      "description": "An array of Network Interfaces to add to this Linode's Configuration Profile. At least one and up to three Interface objects can exist in this array. The position in the array determines which of the Linode's network Interfaces is configured:\n\n- First [0]:  eth0\n- Second [1]: eth1\n- Third [2]:  eth2\n\nWhen updating a Linode's Interfaces, _each Interface must be redefined_. An empty `interfaces` array results in a default `public` type Interface configuration only.\n\nIf no public Interface is configured, public IP addresses are still assigned to the Linode but will not be usable without manual configuration.\n\n__Note__. Changes to Linode Interface configurations can be enabled by rebooting the Linode.\n\n`vpc` details\n\nSee the [VPC documentation](https://www.linode.com/docs/products/networking/vpc/#technical-specifications) guide for its specifications and limitations.\n\n`vlan` details\n\n- Only Next Generation Network (NGN) data centers support VLANs. Run the [List regions](https://techdocs.akamai.com/linode-api/reference/get-regions) operation to view the capabilities of data center regions. If a VLAN is attached to your Linode and you attempt to migrate or clone it to a non-NGN data center, the migration or cloning will not initiate. If a Linode cannot be migrated or cloned because of an incompatibility, you will be prompted to select a different data center or contact support.\n- See the [VLANs Overview](https://www.linode.com/docs/products/networking/vlans/#technical-specifications) guide to view additional specifications and limitations.",
+                      "description": "An array of Network interfaces to add to this Linode's Configuration Profile. At least one and up to three Interface objects can exist in this array. The position in the array determines which of the Linode's network interfaces is configured:\n\n- First [0]:  eth0\n- Second [1]: eth1\n- Third [2]:  eth2\n\nWhen updating a Linode's interfaces, _each Interface must be redefined_. An empty `interfaces` array results in a default `public` type Interface configuration only.\n\nIf no public Interface is configured, public IP addresses are still assigned to the Linode but will not be usable without manual configuration.\n\n> 📘\n>\n> Changes to Linode Interface configurations can be enabled by rebooting the Linode.\n\n`vpc` details\n\nSee the [VPC documentation](https://www.linode.com/docs/products/networking/vpc/#technical-specifications) guide for its specifications and limitations.\n\n`vlan` details\n\n- Only Next Generation Network (NGN) data centers support VLANs. Run the [List regions](https://techdocs.akamai.com/linode-api/reference/get-regions) operation to view the capabilities of data center regions. If a VLAN is attached to your Linode and you attempt to migrate or clone it to a non-NGN data center, the migration or cloning will not initiate. If a Linode cannot be migrated or cloned because of an incompatibility, you will be prompted to select a different data center or contact support.\n- See the [VLANs Overview](https://www.linode.com/docs/products/networking/vlans/#technical-specifications) guide to view additional specifications and limitations.",
                       "example": [
                         {
                           "id": 101,
@@ -44411,7 +44271,7 @@
                           "ipam_address": "10.0.0.1/24",
                           "ipv4": {
                             "nat_1_1": null,
-                            "vpc": "192.0.2.20"
+                            "vpc": "192.0.2.224"
                           },
                           "label": "vlan-1",
                           "primary": false,
@@ -44423,8 +44283,8 @@
                           "id": 103,
                           "ipam_address": null,
                           "ipv4": {
-                            "nat_1_1": "192.0.2.90",
-                            "vpc": "192.0.2.34"
+                            "nat_1_1": "192.0.2.242",
+                            "vpc": "192.0.2.32"
                           },
                           "label": null,
                           "primary": true,
@@ -44453,8 +44313,8 @@
                           "ip_ranges": {
                             "description": "IPv4 CIDR VPC subnet ranges that are routed to this interface.\n\nWhen included in a request:\n\n- A range can't include any addresses that are assigned to an active Linode or another VPC subnet.\n\n- When updating, you need to include any existing ranges to maintain them. If a range is left out, it will be removed.\n\n- Submit this as an empty array removes all existing values.\n\n- Omit this object to leave existing values as is.\n\n<<LB>>\n\n> 📘\n>\n> This is only supported for interfaces with a `purpose` of `vpc`.",
                             "example": [
-                              "192.0.2.233/24",
-                              "2001:db8:18e2:e4b:7ca3:fd83:45ba:9073/32"
+                              "192.0.2.201/24",
+                              "2001:db8:c2a3:eb66:479:dcea:ac7f:2ee1/32"
                             ],
                             "items": {
                               "format": "ip",
@@ -44492,13 +44352,13 @@
                                   }
                                 ],
                                 "description": "The 1:1 NAT IPv4 address, used to associate a public IPv4 address with the interface's VPC subnet IPv4 address.\n\n- Only supported for interfaces with a `purpose` of `vpc`.\n\n- Returned as `null` if no 1:1 NAT is set for a `vpc` type interface.\n\n- Returned as an empty string (`\"\"`) for non-`vpc` type interfaces.\n\nWhen included in a request:\n\n- You can set this to a specific, public IPv4 address that's available on the Linode. You can also use the `any` keyword to enable the Linode's assigned public IPv4 address.\n\n- A specified address can't be shared with another Linode.\n\n- Omit this object or include it and set it to `null` or an empty string (`\"\"`) to block creation of a 1:1 NAT.\n\n<<LB>>\n\n> 📘\n>\n> You can't set this to a specific IPv4 address when creating a new Linode. During the creation process, the network automatically establishes a public IPv4 address for the Linode. Since this address doesn't exist yet, you can't include a custom IPv4 address to change it. After your Linode is created, you can [update your configuration profile interface](https://www.linode.com/docs/api/linode-instances/#configuration-profile-interface-update) to change the `nat_1_1` address.",
-                                "example": "192.0.2.25",
+                                "example": "192.0.2.31",
                                 "nullable": true,
                                 "type": "string"
                               },
                               "vpc": {
                                 "description": "The VPC subnet IPv4 address for this interface.\n\n- This only applies to interfaces with a `purpose` of `vpc`.\n\n- Returned as an empty string (`\"\"`) for non-`vpc` type interfaces.\n\nWhen included in a request:\n\n- The `vpc` can't be assigned to an existing Linode as an address or in a range.\n\n- The target address can't be the first two or last two addresses in the subnet IPv4 range.\n\n- If omitted, a valid address within the Subnet IPv4 range is automatically assigned.",
-                                "example": "192.0.2.110",
+                                "example": "192.0.2.156",
                                 "format": "ip",
                                 "nullable": true,
                                 "type": "string"
@@ -44938,7 +44798,7 @@
                     "x-linode-cli-display": 1
                   },
                   "interfaces": {
-                    "description": "An array of Network Interfaces to add to this Linode's Configuration Profile. At least one and up to three Interface objects can exist in this array. The position in the array determines which of the Linode's network Interfaces is configured:\n\n- First [0]:  eth0\n- Second [1]: eth1\n- Third [2]:  eth2\n\nWhen updating a Linode's Interfaces, _each Interface must be redefined_. An empty `interfaces` array results in a default `public` type Interface configuration only.\n\nIf no public Interface is configured, public IP addresses are still assigned to the Linode but will not be usable without manual configuration.\n\n__Note__. Changes to Linode Interface configurations can be enabled by rebooting the Linode.\n\n`vpc` details\n\nSee the [VPC documentation](https://www.linode.com/docs/products/networking/vpc/#technical-specifications) guide for its specifications and limitations.\n\n`vlan` details\n\n- Only Next Generation Network (NGN) data centers support VLANs. Run the [List regions](https://techdocs.akamai.com/linode-api/reference/get-regions) operation to view the capabilities of data center regions. If a VLAN is attached to your Linode and you attempt to migrate or clone it to a non-NGN data center, the migration or cloning will not initiate. If a Linode cannot be migrated or cloned because of an incompatibility, you will be prompted to select a different data center or contact support.\n- See the [VLANs Overview](https://www.linode.com/docs/products/networking/vlans/#technical-specifications) guide to view additional specifications and limitations.",
+                    "description": "An array of Network interfaces to add to this Linode's Configuration Profile. At least one and up to three Interface objects can exist in this array. The position in the array determines which of the Linode's network interfaces is configured:\n\n- First [0]:  eth0\n- Second [1]: eth1\n- Third [2]:  eth2\n\nWhen updating a Linode's interfaces, _each Interface must be redefined_. An empty `interfaces` array results in a default `public` type Interface configuration only.\n\nIf no public Interface is configured, public IP addresses are still assigned to the Linode but will not be usable without manual configuration.\n\n> 📘\n>\n> Changes to Linode Interface configurations can be enabled by rebooting the Linode.\n\n`vpc` details\n\nSee the [VPC documentation](https://www.linode.com/docs/products/networking/vpc/#technical-specifications) guide for its specifications and limitations.\n\n`vlan` details\n\n- Only Next Generation Network (NGN) data centers support VLANs. Run the [List regions](https://techdocs.akamai.com/linode-api/reference/get-regions) operation to view the capabilities of data center regions. If a VLAN is attached to your Linode and you attempt to migrate or clone it to a non-NGN data center, the migration or cloning will not initiate. If a Linode cannot be migrated or cloned because of an incompatibility, you will be prompted to select a different data center or contact support.\n- See the [VLANs Overview](https://www.linode.com/docs/products/networking/vlans/#technical-specifications) guide to view additional specifications and limitations.",
                     "example": [
                       {
                         "id": 101,
@@ -44955,7 +44815,7 @@
                         "ipam_address": "10.0.0.1/24",
                         "ipv4": {
                           "nat_1_1": null,
-                          "vpc": "192.0.2.57"
+                          "vpc": "192.0.2.195"
                         },
                         "label": "vlan-1",
                         "primary": false,
@@ -44967,8 +44827,8 @@
                         "id": 103,
                         "ipam_address": null,
                         "ipv4": {
-                          "nat_1_1": "192.0.2.119",
-                          "vpc": "192.0.2.42"
+                          "nat_1_1": "192.0.2.214",
+                          "vpc": "192.0.2.175"
                         },
                         "label": null,
                         "primary": true,
@@ -44997,8 +44857,8 @@
                         "ip_ranges": {
                           "description": "IPv4 CIDR VPC subnet ranges that are routed to this interface.\n\nWhen included in a request:\n\n- A range can't include any addresses that are assigned to an active Linode or another VPC subnet.\n\n- When updating, you need to include any existing ranges to maintain them. If a range is left out, it will be removed.\n\n- Submit this as an empty array removes all existing values.\n\n- Omit this object to leave existing values as is.\n\n<<LB>>\n\n> 📘\n>\n> This is only supported for interfaces with a `purpose` of `vpc`.",
                           "example": [
-                            "192.0.2.100/24",
-                            "2001:db8:4c4a:37cf:2a3b:2cc6:dc10:84e8/32"
+                            "192.0.2.76/24",
+                            "2001:db8:3172:839:ba2c:f95e:d66b:3da6/32"
                           ],
                           "items": {
                             "format": "ip",
@@ -45036,13 +44896,13 @@
                                 }
                               ],
                               "description": "The 1:1 NAT IPv4 address, used to associate a public IPv4 address with the interface's VPC subnet IPv4 address.\n\n- Only supported for interfaces with a `purpose` of `vpc`.\n\n- Returned as `null` if no 1:1 NAT is set for a `vpc` type interface.\n\n- Returned as an empty string (`\"\"`) for non-`vpc` type interfaces.\n\nWhen included in a request:\n\n- You can set this to a specific, public IPv4 address that's available on the Linode. You can also use the `any` keyword to enable the Linode's assigned public IPv4 address.\n\n- A specified address can't be shared with another Linode.\n\n- Omit this object or include it and set it to `null` or an empty string (`\"\"`) to block creation of a 1:1 NAT.\n\n<<LB>>\n\n> 📘\n>\n> You can't set this to a specific IPv4 address when creating a new Linode. During the creation process, the network automatically establishes a public IPv4 address for the Linode. Since this address doesn't exist yet, you can't include a custom IPv4 address to change it. After your Linode is created, you can [update your configuration profile interface](https://www.linode.com/docs/api/linode-instances/#configuration-profile-interface-update) to change the `nat_1_1` address.",
-                              "example": "192.0.2.186",
+                              "example": "192.0.2.144",
                               "nullable": true,
                               "type": "string"
                             },
                             "vpc": {
                               "description": "The VPC subnet IPv4 address for this interface.\n\n- This only applies to interfaces with a `purpose` of `vpc`.\n\n- Returned as an empty string (`\"\"`) for non-`vpc` type interfaces.\n\nWhen included in a request:\n\n- The `vpc` can't be assigned to an existing Linode as an address or in a range.\n\n- The target address can't be the first two or last two addresses in the subnet IPv4 range.\n\n- If omitted, a valid address within the Subnet IPv4 range is automatically assigned.",
-                              "example": "192.0.2.153",
+                              "example": "192.0.2.93",
                               "format": "ip",
                               "nullable": true,
                               "type": "string"
@@ -45408,7 +45268,7 @@
                       "x-linode-cli-display": 1
                     },
                     "interfaces": {
-                      "description": "An array of Network Interfaces to add to this Linode's Configuration Profile. At least one and up to three Interface objects can exist in this array. The position in the array determines which of the Linode's network Interfaces is configured:\n\n- First [0]:  eth0\n- Second [1]: eth1\n- Third [2]:  eth2\n\nWhen updating a Linode's Interfaces, _each Interface must be redefined_. An empty `interfaces` array results in a default `public` type Interface configuration only.\n\nIf no public Interface is configured, public IP addresses are still assigned to the Linode but will not be usable without manual configuration.\n\n__Note__. Changes to Linode Interface configurations can be enabled by rebooting the Linode.\n\n`vpc` details\n\nSee the [VPC documentation](https://www.linode.com/docs/products/networking/vpc/#technical-specifications) guide for its specifications and limitations.\n\n`vlan` details\n\n- Only Next Generation Network (NGN) data centers support VLANs. Run the [List regions](https://techdocs.akamai.com/linode-api/reference/get-regions) operation to view the capabilities of data center regions. If a VLAN is attached to your Linode and you attempt to migrate or clone it to a non-NGN data center, the migration or cloning will not initiate. If a Linode cannot be migrated or cloned because of an incompatibility, you will be prompted to select a different data center or contact support.\n- See the [VLANs Overview](https://www.linode.com/docs/products/networking/vlans/#technical-specifications) guide to view additional specifications and limitations.",
+                      "description": "An array of Network interfaces to add to this Linode's Configuration Profile. At least one and up to three Interface objects can exist in this array. The position in the array determines which of the Linode's network interfaces is configured:\n\n- First [0]:  eth0\n- Second [1]: eth1\n- Third [2]:  eth2\n\nWhen updating a Linode's interfaces, _each Interface must be redefined_. An empty `interfaces` array results in a default `public` type Interface configuration only.\n\nIf no public Interface is configured, public IP addresses are still assigned to the Linode but will not be usable without manual configuration.\n\n> 📘\n>\n> Changes to Linode Interface configurations can be enabled by rebooting the Linode.\n\n`vpc` details\n\nSee the [VPC documentation](https://www.linode.com/docs/products/networking/vpc/#technical-specifications) guide for its specifications and limitations.\n\n`vlan` details\n\n- Only Next Generation Network (NGN) data centers support VLANs. Run the [List regions](https://techdocs.akamai.com/linode-api/reference/get-regions) operation to view the capabilities of data center regions. If a VLAN is attached to your Linode and you attempt to migrate or clone it to a non-NGN data center, the migration or cloning will not initiate. If a Linode cannot be migrated or cloned because of an incompatibility, you will be prompted to select a different data center or contact support.\n- See the [VLANs Overview](https://www.linode.com/docs/products/networking/vlans/#technical-specifications) guide to view additional specifications and limitations.",
                       "example": [
                         {
                           "id": 101,
@@ -45425,7 +45285,7 @@
                           "ipam_address": "10.0.0.1/24",
                           "ipv4": {
                             "nat_1_1": null,
-                            "vpc": "192.0.2.13"
+                            "vpc": "192.0.2.146"
                           },
                           "label": "vlan-1",
                           "primary": false,
@@ -45437,8 +45297,8 @@
                           "id": 103,
                           "ipam_address": null,
                           "ipv4": {
-                            "nat_1_1": "192.0.2.168",
-                            "vpc": "192.0.2.234"
+                            "nat_1_1": "192.0.2.183",
+                            "vpc": "192.0.2.113"
                           },
                           "label": null,
                           "primary": true,
@@ -45467,8 +45327,8 @@
                           "ip_ranges": {
                             "description": "IPv4 CIDR VPC subnet ranges that are routed to this interface.\n\nWhen included in a request:\n\n- A range can't include any addresses that are assigned to an active Linode or another VPC subnet.\n\n- When updating, you need to include any existing ranges to maintain them. If a range is left out, it will be removed.\n\n- Submit this as an empty array removes all existing values.\n\n- Omit this object to leave existing values as is.\n\n<<LB>>\n\n> 📘\n>\n> This is only supported for interfaces with a `purpose` of `vpc`.",
                             "example": [
-                              "192.0.2.121/24",
-                              "2001:db8:c163:9c9:b588:43aa:e6e:9530/32"
+                              "192.0.2.161/24",
+                              "2001:db8:240:1b07:f8f2:5760:9f6:a632/32"
                             ],
                             "items": {
                               "format": "ip",
@@ -45506,13 +45366,13 @@
                                   }
                                 ],
                                 "description": "The 1:1 NAT IPv4 address, used to associate a public IPv4 address with the interface's VPC subnet IPv4 address.\n\n- Only supported for interfaces with a `purpose` of `vpc`.\n\n- Returned as `null` if no 1:1 NAT is set for a `vpc` type interface.\n\n- Returned as an empty string (`\"\"`) for non-`vpc` type interfaces.\n\nWhen included in a request:\n\n- You can set this to a specific, public IPv4 address that's available on the Linode. You can also use the `any` keyword to enable the Linode's assigned public IPv4 address.\n\n- A specified address can't be shared with another Linode.\n\n- Omit this object or include it and set it to `null` or an empty string (`\"\"`) to block creation of a 1:1 NAT.\n\n<<LB>>\n\n> 📘\n>\n> You can't set this to a specific IPv4 address when creating a new Linode. During the creation process, the network automatically establishes a public IPv4 address for the Linode. Since this address doesn't exist yet, you can't include a custom IPv4 address to change it. After your Linode is created, you can [update your configuration profile interface](https://www.linode.com/docs/api/linode-instances/#configuration-profile-interface-update) to change the `nat_1_1` address.",
-                                "example": "192.0.2.49",
+                                "example": "192.0.2.106",
                                 "nullable": true,
                                 "type": "string"
                               },
                               "vpc": {
                                 "description": "The VPC subnet IPv4 address for this interface.\n\n- This only applies to interfaces with a `purpose` of `vpc`.\n\n- Returned as an empty string (`\"\"`) for non-`vpc` type interfaces.\n\nWhen included in a request:\n\n- The `vpc` can't be assigned to an existing Linode as an address or in a range.\n\n- The target address can't be the first two or last two addresses in the subnet IPv4 range.\n\n- If omitted, a valid address within the Subnet IPv4 range is automatically assigned.",
-                                "example": "192.0.2.200",
+                                "example": "192.0.2.125",
                                 "format": "ip",
                                 "nullable": true,
                                 "type": "string"
@@ -45899,8 +45759,8 @@
                       "ip_ranges": {
                         "description": "IPv4 CIDR VPC subnet ranges that are routed to this interface.\n\nWhen included in a request:\n\n- A range can't include any addresses that are assigned to an active Linode or another VPC subnet.\n\n- When updating, you need to include any existing ranges to maintain them. If a range is left out, it will be removed.\n\n- Submit this as an empty array removes all existing values.\n\n- Omit this object to leave existing values as is.\n\n<<LB>>\n\n> 📘\n>\n> This is only supported for interfaces with a `purpose` of `vpc`.",
                         "example": [
-                          "192.0.2.204/24",
-                          "2001:db8:bd67:7e6a:52fc:35b9:85ad:9c7f/32"
+                          "192.0.2.213/24",
+                          "2001:db8:2d62:563:6bd0:763d:2607:2fad/32"
                         ],
                         "items": {
                           "format": "ip",
@@ -45938,13 +45798,13 @@
                               }
                             ],
                             "description": "The 1:1 NAT IPv4 address, used to associate a public IPv4 address with the interface's VPC subnet IPv4 address.\n\n- Only supported for interfaces with a `purpose` of `vpc`.\n\n- Returned as `null` if no 1:1 NAT is set for a `vpc` type interface.\n\n- Returned as an empty string (`\"\"`) for non-`vpc` type interfaces.\n\nWhen included in a request:\n\n- You can set this to a specific, public IPv4 address that's available on the Linode. You can also use the `any` keyword to enable the Linode's assigned public IPv4 address.\n\n- A specified address can't be shared with another Linode.\n\n- Omit this object or include it and set it to `null` or an empty string (`\"\"`) to block creation of a 1:1 NAT.\n\n<<LB>>\n\n> 📘\n>\n> You can't set this to a specific IPv4 address when creating a new Linode. During the creation process, the network automatically establishes a public IPv4 address for the Linode. Since this address doesn't exist yet, you can't include a custom IPv4 address to change it. After your Linode is created, you can [update your configuration profile interface](https://www.linode.com/docs/api/linode-instances/#configuration-profile-interface-update) to change the `nat_1_1` address.",
-                            "example": "192.0.2.225",
+                            "example": "192.0.2.22",
                             "nullable": true,
                             "type": "string"
                           },
                           "vpc": {
                             "description": "The VPC subnet IPv4 address for this interface.\n\n- This only applies to interfaces with a `purpose` of `vpc`.\n\n- Returned as an empty string (`\"\"`) for non-`vpc` type interfaces.\n\nWhen included in a request:\n\n- The `vpc` can't be assigned to an existing Linode as an address or in a range.\n\n- The target address can't be the first two or last two addresses in the subnet IPv4 range.\n\n- If omitted, a valid address within the Subnet IPv4 range is automatically assigned.",
-                            "example": "192.0.2.213",
+                            "example": "192.0.2.208",
                             "format": "ip",
                             "nullable": true,
                             "type": "string"
@@ -46042,8 +45902,8 @@
                     "ip_ranges": {
                       "description": "IPv4 CIDR VPC subnet ranges that are routed to this interface.\n\nWhen included in a request:\n\n- A range can't include any addresses that are assigned to an active Linode or another VPC subnet.\n\n- When updating, you need to include any existing ranges to maintain them. If a range is left out, it will be removed.\n\n- Submit this as an empty array removes all existing values.\n\n- Omit this object to leave existing values as is.\n\n<<LB>>\n\n> 📘\n>\n> This is only supported for interfaces with a `purpose` of `vpc`.",
                       "example": [
-                        "192.0.2.96/24",
-                        "2001:db8:2751:b6d1:20b9:1dfc:978f:4ca5/32"
+                        "192.0.2.97/24",
+                        "2001:db8:a94:5b6c:6f30:14d7:3c6d:512c/32"
                       ],
                       "items": {
                         "format": "ip",
@@ -46081,13 +45941,13 @@
                             }
                           ],
                           "description": "The 1:1 NAT IPv4 address, used to associate a public IPv4 address with the interface's VPC subnet IPv4 address.\n\n- Only supported for interfaces with a `purpose` of `vpc`.\n\n- Returned as `null` if no 1:1 NAT is set for a `vpc` type interface.\n\n- Returned as an empty string (`\"\"`) for non-`vpc` type interfaces.\n\nWhen included in a request:\n\n- You can set this to a specific, public IPv4 address that's available on the Linode. You can also use the `any` keyword to enable the Linode's assigned public IPv4 address.\n\n- A specified address can't be shared with another Linode.\n\n- Omit this object or include it and set it to `null` or an empty string (`\"\"`) to block creation of a 1:1 NAT.\n\n<<LB>>\n\n> 📘\n>\n> You can't set this to a specific IPv4 address when creating a new Linode. During the creation process, the network automatically establishes a public IPv4 address for the Linode. Since this address doesn't exist yet, you can't include a custom IPv4 address to change it. After your Linode is created, you can [update your configuration profile interface](https://www.linode.com/docs/api/linode-instances/#configuration-profile-interface-update) to change the `nat_1_1` address.",
-                          "example": "192.0.2.251",
+                          "example": "192.0.2.233",
                           "nullable": true,
                           "type": "string"
                         },
                         "vpc": {
                           "description": "The VPC subnet IPv4 address for this interface.\n\n- This only applies to interfaces with a `purpose` of `vpc`.\n\n- Returned as an empty string (`\"\"`) for non-`vpc` type interfaces.\n\nWhen included in a request:\n\n- The `vpc` can't be assigned to an existing Linode as an address or in a range.\n\n- The target address can't be the first two or last two addresses in the subnet IPv4 range.\n\n- If omitted, a valid address within the Subnet IPv4 range is automatically assigned.",
-                          "example": "192.0.2.98",
+                          "example": "192.0.2.227",
                           "format": "ip",
                           "nullable": true,
                           "type": "string"
@@ -46241,7 +46101,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "description": "An array of Network Interfaces to add to this Linode's Configuration Profile. At least one and up to three Interface objects can exist in this array. The position in the array determines which of the Linode's network Interfaces is configured:\n\n- First [0]:  eth0\n- Second [1]: eth1\n- Third [2]:  eth2\n\nWhen updating a Linode's Interfaces, _each Interface must be redefined_. An empty `interfaces` array results in a default `public` type Interface configuration only.\n\nIf no public Interface is configured, public IP addresses are still assigned to the Linode but will not be usable without manual configuration.\n\n__Note__. Changes to Linode Interface configurations can be enabled by rebooting the Linode.\n\n`vpc` details\n\nSee the [VPC documentation](https://www.linode.com/docs/products/networking/vpc/#technical-specifications) guide for its specifications and limitations.\n\n`vlan` details\n\n- Only Next Generation Network (NGN) data centers support VLANs. Run the [List regions](https://techdocs.akamai.com/linode-api/reference/get-regions) operation to view the capabilities of data center regions. If a VLAN is attached to your Linode and you attempt to migrate or clone it to a non-NGN data center, the migration or cloning will not initiate. If a Linode cannot be migrated or cloned because of an incompatibility, you will be prompted to select a different data center or contact support.\n- See the [VLANs Overview](https://www.linode.com/docs/products/networking/vlans/#technical-specifications) guide to view additional specifications and limitations.",
+                  "description": "An array of Network interfaces to add to this Linode's Configuration Profile. At least one and up to three Interface objects can exist in this array. The position in the array determines which of the Linode's network interfaces is configured:\n\n- First [0]:  eth0\n- Second [1]: eth1\n- Third [2]:  eth2\n\nWhen updating a Linode's interfaces, _each Interface must be redefined_. An empty `interfaces` array results in a default `public` type Interface configuration only.\n\nIf no public Interface is configured, public IP addresses are still assigned to the Linode but will not be usable without manual configuration.\n\n> 📘\n>\n> Changes to Linode Interface configurations can be enabled by rebooting the Linode.\n\n`vpc` details\n\nSee the [VPC documentation](https://www.linode.com/docs/products/networking/vpc/#technical-specifications) guide for its specifications and limitations.\n\n`vlan` details\n\n- Only Next Generation Network (NGN) data centers support VLANs. Run the [List regions](https://techdocs.akamai.com/linode-api/reference/get-regions) operation to view the capabilities of data center regions. If a VLAN is attached to your Linode and you attempt to migrate or clone it to a non-NGN data center, the migration or cloning will not initiate. If a Linode cannot be migrated or cloned because of an incompatibility, you will be prompted to select a different data center or contact support.\n- See the [VLANs Overview](https://www.linode.com/docs/products/networking/vlans/#technical-specifications) guide to view additional specifications and limitations.",
                   "example": [
                     {
                       "id": 101,
@@ -46258,7 +46118,7 @@
                       "ipam_address": "10.0.0.1/24",
                       "ipv4": {
                         "nat_1_1": null,
-                        "vpc": "192.0.2.170"
+                        "vpc": "192.0.2.83"
                       },
                       "label": "vlan-1",
                       "primary": false,
@@ -46270,8 +46130,8 @@
                       "id": 103,
                       "ipam_address": null,
                       "ipv4": {
-                        "nat_1_1": "192.0.2.251",
-                        "vpc": "192.0.2.20"
+                        "nat_1_1": "192.0.2.91",
+                        "vpc": "192.0.2.208"
                       },
                       "label": null,
                       "primary": true,
@@ -46300,8 +46160,8 @@
                       "ip_ranges": {
                         "description": "IPv4 CIDR VPC subnet ranges that are routed to this interface.\n\nWhen included in a request:\n\n- A range can't include any addresses that are assigned to an active Linode or another VPC subnet.\n\n- When updating, you need to include any existing ranges to maintain them. If a range is left out, it will be removed.\n\n- Submit this as an empty array removes all existing values.\n\n- Omit this object to leave existing values as is.\n\n<<LB>>\n\n> 📘\n>\n> This is only supported for interfaces with a `purpose` of `vpc`.",
                         "example": [
-                          "192.0.2.248/24",
-                          "2001:db8:2c87:614b:cd55:2413:9488:564c/32"
+                          "192.0.2.10/24",
+                          "2001:db8:55c1:4688:150:bd5:7e2d:7a77/32"
                         ],
                         "items": {
                           "format": "ip",
@@ -46339,13 +46199,13 @@
                               }
                             ],
                             "description": "The 1:1 NAT IPv4 address, used to associate a public IPv4 address with the interface's VPC subnet IPv4 address.\n\n- Only supported for interfaces with a `purpose` of `vpc`.\n\n- Returned as `null` if no 1:1 NAT is set for a `vpc` type interface.\n\n- Returned as an empty string (`\"\"`) for non-`vpc` type interfaces.\n\nWhen included in a request:\n\n- You can set this to a specific, public IPv4 address that's available on the Linode. You can also use the `any` keyword to enable the Linode's assigned public IPv4 address.\n\n- A specified address can't be shared with another Linode.\n\n- Omit this object or include it and set it to `null` or an empty string (`\"\"`) to block creation of a 1:1 NAT.\n\n<<LB>>\n\n> 📘\n>\n> You can't set this to a specific IPv4 address when creating a new Linode. During the creation process, the network automatically establishes a public IPv4 address for the Linode. Since this address doesn't exist yet, you can't include a custom IPv4 address to change it. After your Linode is created, you can [update your configuration profile interface](https://www.linode.com/docs/api/linode-instances/#configuration-profile-interface-update) to change the `nat_1_1` address.",
-                            "example": "192.0.2.14",
+                            "example": "192.0.2.182",
                             "nullable": true,
                             "type": "string"
                           },
                           "vpc": {
                             "description": "The VPC subnet IPv4 address for this interface.\n\n- This only applies to interfaces with a `purpose` of `vpc`.\n\n- Returned as an empty string (`\"\"`) for non-`vpc` type interfaces.\n\nWhen included in a request:\n\n- The `vpc` can't be assigned to an existing Linode as an address or in a range.\n\n- The target address can't be the first two or last two addresses in the subnet IPv4 range.\n\n- If omitted, a valid address within the Subnet IPv4 range is automatically assigned.",
-                            "example": "192.0.2.225",
+                            "example": "192.0.2.228",
                             "format": "ip",
                             "nullable": true,
                             "type": "string"
@@ -46771,8 +46631,8 @@
                     "ip_ranges": {
                       "description": "IPv4 CIDR VPC subnet ranges that are routed to this interface.\n\nWhen included in a request:\n\n- A range can't include any addresses that are assigned to an active Linode or another VPC subnet.\n\n- When updating, you need to include any existing ranges to maintain them. If a range is left out, it will be removed.\n\n- Submit this as an empty array removes all existing values.\n\n- Omit this object to leave existing values as is.\n\n<<LB>>\n\n> 📘\n>\n> This is only supported for interfaces with a `purpose` of `vpc`.",
                       "example": [
-                        "192.0.2.153/24",
-                        "2001:db8:cf23:b8da:f2cf:3ed1:bc4:8c53/32"
+                        "192.0.2.79/24",
+                        "2001:db8:2fa4:b21d:a1a7:a0ff:decd:b44/32"
                       ],
                       "items": {
                         "format": "ip",
@@ -46810,13 +46670,13 @@
                             }
                           ],
                           "description": "The 1:1 NAT IPv4 address, used to associate a public IPv4 address with the interface's VPC subnet IPv4 address.\n\n- Only supported for interfaces with a `purpose` of `vpc`.\n\n- Returned as `null` if no 1:1 NAT is set for a `vpc` type interface.\n\n- Returned as an empty string (`\"\"`) for non-`vpc` type interfaces.\n\nWhen included in a request:\n\n- You can set this to a specific, public IPv4 address that's available on the Linode. You can also use the `any` keyword to enable the Linode's assigned public IPv4 address.\n\n- A specified address can't be shared with another Linode.\n\n- Omit this object or include it and set it to `null` or an empty string (`\"\"`) to block creation of a 1:1 NAT.\n\n<<LB>>\n\n> 📘\n>\n> You can't set this to a specific IPv4 address when creating a new Linode. During the creation process, the network automatically establishes a public IPv4 address for the Linode. Since this address doesn't exist yet, you can't include a custom IPv4 address to change it. After your Linode is created, you can [update your configuration profile interface](https://www.linode.com/docs/api/linode-instances/#configuration-profile-interface-update) to change the `nat_1_1` address.",
-                          "example": "192.0.2.181",
+                          "example": "192.0.2.134",
                           "nullable": true,
                           "type": "string"
                         },
                         "vpc": {
                           "description": "The VPC subnet IPv4 address for this interface.\n\n- This only applies to interfaces with a `purpose` of `vpc`.\n\n- Returned as an empty string (`\"\"`) for non-`vpc` type interfaces.\n\nWhen included in a request:\n\n- The `vpc` can't be assigned to an existing Linode as an address or in a range.\n\n- The target address can't be the first two or last two addresses in the subnet IPv4 range.\n\n- If omitted, a valid address within the Subnet IPv4 range is automatically assigned.",
-                          "example": "192.0.2.120",
+                          "example": "192.0.2.191",
                           "format": "ip",
                           "nullable": true,
                           "type": "string"
@@ -46977,8 +46837,8 @@
                   "ip_ranges": {
                     "description": "IPv4 CIDR VPC subnet ranges that are routed to this interface.\n\n- A range can't include any addresses that are assigned to an active Linode or another VPC subnet.\n\n- When updating, you need to include any existing ranges to maintain them. If a range is left out, it will be removed.\n\n- Include this as an empty array (`[]`) to remove all existing `nat_1_1` values.\n\n- Omit this array to leave all existing `ip_ranges` as is.\n<<LB>>\n> 📘\n>\n> This only applies to interfaces with a `purpose` of `vpc`.",
                     "example": [
-                      "192.0.2.96/24",
-                      "2001:db8:8446:e5b9:2432:46e4:321a:60/32"
+                      "192.0.2.241/24",
+                      "2001:db8:b2d8:2cf7:ab0b:bc06:fb20:7f39/32"
                     ],
                     "items": {
                       "format": "ip",
@@ -47007,13 +46867,13 @@
                           }
                         ],
                         "description": "The 1:1 NAT IPv4 address, used to associate a public IPv4 address with the interface's VPC subnet IPv4 address.\n\n- You can set this to a specific, public IPv4 address that's available on the Linode. You can also use the `any` keyword to enable the Linode's assigned public IPv4 address.\n\n- A specified address can't be used on another Linode.\n\n- Include this as an empty object (`\"\"`) to remove an existing `nat_1_1` value.\n\n- Omit this object or include it and set it to `null` to leave an existing `nat_1_1` value as is.",
-                        "example": "192.0.2.81",
+                        "example": "192.0.2.39",
                         "nullable": true,
                         "type": "string"
                       },
                       "vpc": {
                         "description": "The VPC subnet IPv4 address for this interface.\n\n- The `vpc` can't be assigned to an existing Linode as an address or in a range.\n\n- The target address can't be the first two or last two addresses in the subnet IPv4 range.\n\n- If omitted, a valid address within the subnet IPv4 range is automatically assigned.",
-                        "example": "192.0.2.21",
+                        "example": "192.0.2.148",
                         "format": "ip",
                         "nullable": true,
                         "type": "string"
@@ -47063,8 +46923,8 @@
                     "ip_ranges": {
                       "description": "IPv4 CIDR VPC subnet ranges that are routed to this interface. This only applies to interfaces with a `purpose` of `vpc`. Returned as an empty string (`\"\"`) if the interface has a `purpose` of `public` or `vlan`.",
                       "example": [
-                        "192.0.2.175/24",
-                        "2001:db8:3b57:231:8b85:8da5:aa41:10f2/32"
+                        "192.0.2.251/24",
+                        "2001:db8:57f3:e272:6d23:3eaa:6dae:917e/32"
                       ],
                       "items": {
                         "format": "ip",
@@ -47087,14 +46947,14 @@
                       "properties": {
                         "nat_1_1": {
                           "description": "The 1:1 NAT IPv4 address, used to associate a public IPv4 address with the interface's VPC subnet IPv4 address. This only applies to interfaces with a `purpose` of `vpc`. Returned as `null` if no 1:1 NAT is set for a `vpc` interface. Returned as an empty string (`\"\"`) if the interface has a `purpose` of `public` or `vlan`.",
-                          "example": "192.0.2.130",
+                          "example": "192.0.2.161",
                           "format": "ip",
                           "nullable": true,
                           "type": "string"
                         },
                         "vpc": {
                           "description": "The VPC subnet IPv4 address for this interface. This only applies to interfaces with a `purpose` of `vpc`. Returned as an empty string (`\"\"`) if the interface has a `purpose` of `public` or `vlan`.",
-                          "example": "192.0.2.139",
+                          "example": "192.0.2.36",
                           "format": "ip",
                           "nullable": true,
                           "type": "string"
@@ -49263,7 +49123,7 @@
                                           "description": "A list of IPv4 addresses or networks. Addresses must be in IP/mask format. Must not be an empty list.\n\nIf `0.0.0.0/0` is included in this list, all IPv4 addresses are affected by this rule.",
                                           "example": [
                                             "192.0.2.0/24",
-                                            "192.0.2.48/24"
+                                            "192.0.2.130/24"
                                           ],
                                           "items": {
                                             "type": "string"
@@ -49355,7 +49215,7 @@
                                           "description": "A list of IPv4 addresses or networks. Addresses must be in IP/mask format. Must not be an empty list.\n\nIf `0.0.0.0/0` is included in this list, all IPv4 addresses are affected by this rule.",
                                           "example": [
                                             "192.0.2.0/24",
-                                            "192.0.2.50/24"
+                                            "192.0.2.67/24"
                                           ],
                                           "items": {
                                             "type": "string"
@@ -49809,7 +49669,7 @@
                   "properties": {
                     "address": {
                       "description": "__Read-only__ The IP address.",
-                      "example": "192.0.2.16",
+                      "example": "192.0.2.13",
                       "format": "ip",
                       "readOnly": true,
                       "type": "string",
@@ -49817,7 +49677,7 @@
                     },
                     "gateway": {
                       "description": "__Read-only__ The default gateway for this address.",
-                      "example": "192.0.2.99",
+                      "example": "192.0.2.72",
                       "format": "ip",
                       "nullable": true,
                       "readOnly": true,
@@ -49859,7 +49719,7 @@
                     },
                     "subnet_mask": {
                       "description": "__Read-only__ The mask that separates host bits from network bits for this address.",
-                      "example": "192.0.2.165",
+                      "example": "192.0.2.205",
                       "format": "ip",
                       "readOnly": true,
                       "type": "string"
@@ -49879,7 +49739,7 @@
                     },
                     "vpc_nat_1_1": {
                       "additionalProperties": false,
-                      "description": "IPv4 address configured as a 1:1 NAT for this Interface. If no address is configured as a 1:1 NAT, `null` is returned.\n\n__Note__. Only allowed for `vpc` type Interfaces.",
+                      "description": "IPv4 address configured as a 1:1 NAT for this Interface. If no address is configured as a 1:1 NAT, `null` is returned.\n\n> 📘\n>\n> Only allowed for `vpc` type interfaces.",
                       "properties": {
                         "address": {
                           "description": "The IPv4 address that is configured as a 1:1 NAT for this VPC interface.",
@@ -49888,13 +49748,13 @@
                           "type": "string"
                         },
                         "subnet_id": {
-                          "description": "The `id` of the VPC Subnet for this Interface.",
+                          "description": "The `id` of the VPC Subnet for this interface.",
                           "example": 101,
                           "nullable": false,
                           "type": "integer"
                         },
                         "vpc_id": {
-                          "description": "__Read-only__ The `id` of the VPC configured for this Interface.",
+                          "description": "__Read-only__ The `id` of the VPC configured for this interface.",
                           "example": 111,
                           "nullable": false,
                           "readOnly": true,
@@ -49985,7 +49845,7 @@
         "x-linode-grant": "read_write"
       },
       "get": {
-        "description": "Returns networking information for a single Linode.\n\n__Note__. If the target Linode has several configuration profiles that include a Virtual Private Cloud (VPC) interface, address information for all of VPCs will be listed in the response.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli linodes ips-list 123\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    linodes:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Returns networking information for a single Linode.\n\n> 📘\n>\n> If the target Linode has several configuration profiles that include a Virtual Private Cloud (VPC) interface, the response lists address information for all of the VPCs.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli linodes ips-list 123\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    linodes:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-linode-ips"
@@ -50010,7 +49870,7 @@
                             "properties": {
                               "address": {
                                 "description": "__Read-only__ The private IPv4 address.",
-                                "example": "192.0.2.104",
+                                "example": "192.0.2.41",
                                 "format": "ip",
                                 "readOnly": true,
                                 "type": "string",
@@ -50060,7 +49920,7 @@
                               },
                               "subnet_mask": {
                                 "description": "__Read-only__ The mask that separates host bits from network bits for this address.",
-                                "example": "192.0.2.122",
+                                "example": "192.0.2.115",
                                 "format": "ip",
                                 "readOnly": true,
                                 "type": "string"
@@ -50089,7 +49949,7 @@
                             "properties": {
                               "address": {
                                 "description": "__Read-only__ The IP address.",
-                                "example": "192.0.2.43",
+                                "example": "192.0.2.152",
                                 "format": "ip",
                                 "readOnly": true,
                                 "type": "string",
@@ -50097,7 +49957,7 @@
                               },
                               "gateway": {
                                 "description": "__Read-only__ The default gateway for this address.",
-                                "example": "192.0.2.157",
+                                "example": "192.0.2.2",
                                 "format": "ip",
                                 "nullable": true,
                                 "readOnly": true,
@@ -50139,7 +49999,7 @@
                               },
                               "subnet_mask": {
                                 "description": "__Read-only__ The mask that separates host bits from network bits for this address.",
-                                "example": "192.0.2.185",
+                                "example": "192.0.2.152",
                                 "format": "ip",
                                 "readOnly": true,
                                 "type": "string"
@@ -50159,22 +50019,22 @@
                               },
                               "vpc_nat_1_1": {
                                 "additionalProperties": false,
-                                "description": "IPv4 address configured as a 1:1 NAT for this Interface. If no address is configured as a 1:1 NAT, `null` is returned.\n\n__Note__. Only allowed for `vpc` type Interfaces.",
+                                "description": "IPv4 address configured as a 1:1 NAT for this Interface. If no address is configured as a 1:1 NAT, `null` is returned.\n\n> 📘\n>\n> Only allowed for `vpc` type interfaces.",
                                 "properties": {
                                   "address": {
                                     "description": "The IPv4 address that is configured as a 1:1 NAT for this VPC interface.",
-                                    "example": "192.0.2.161",
+                                    "example": "192.0.2.108",
                                     "format": "ipv4",
                                     "type": "string"
                                   },
                                   "subnet_id": {
-                                    "description": "The `id` of the VPC Subnet for this Interface.",
+                                    "description": "The `id` of the VPC Subnet for this interface.",
                                     "example": 101,
                                     "nullable": false,
                                     "type": "integer"
                                   },
                                   "vpc_id": {
-                                    "description": "__Read-only__ The `id` of the VPC configured for this Interface.",
+                                    "description": "__Read-only__ The `id` of the VPC configured for this interface.",
                                     "example": 111,
                                     "nullable": false,
                                     "readOnly": true,
@@ -50200,7 +50060,7 @@
                             "properties": {
                               "address": {
                                 "description": "__Read-only__ The IP address.",
-                                "example": "192.0.2.93",
+                                "example": "192.0.2.232",
                                 "format": "ip",
                                 "readOnly": true,
                                 "type": "string",
@@ -50208,7 +50068,7 @@
                               },
                               "gateway": {
                                 "description": "__Read-only__ The default gateway for this address.",
-                                "example": "192.0.2.17",
+                                "example": "192.0.2.50",
                                 "format": "ip",
                                 "nullable": true,
                                 "readOnly": true,
@@ -50250,7 +50110,7 @@
                               },
                               "subnet_mask": {
                                 "description": "__Read-only__ The mask that separates host bits from network bits for this address.",
-                                "example": "192.0.2.4",
+                                "example": "192.0.2.202",
                                 "format": "ip",
                                 "readOnly": true,
                                 "type": "string"
@@ -50270,22 +50130,22 @@
                               },
                               "vpc_nat_1_1": {
                                 "additionalProperties": false,
-                                "description": "IPv4 address configured as a 1:1 NAT for this Interface. If no address is configured as a 1:1 NAT, `null` is returned.\n\n__Note__. Only allowed for `vpc` type Interfaces.",
+                                "description": "IPv4 address configured as a 1:1 NAT for this Interface. If no address is configured as a 1:1 NAT, `null` is returned.\n\n> 📘\n>\n> Only allowed for `vpc` type interfaces.",
                                 "properties": {
                                   "address": {
                                     "description": "The IPv4 address that is configured as a 1:1 NAT for this VPC interface.",
-                                    "example": "192.0.2.181",
+                                    "example": "192.0.2.247",
                                     "format": "ipv4",
                                     "type": "string"
                                   },
                                   "subnet_id": {
-                                    "description": "The `id` of the VPC Subnet for this Interface.",
+                                    "description": "The `id` of the VPC Subnet for this interface.",
                                     "example": 101,
                                     "nullable": false,
                                     "type": "integer"
                                   },
                                   "vpc_id": {
-                                    "description": "__Read-only__ The `id` of the VPC configured for this Interface.",
+                                    "description": "__Read-only__ The `id` of the VPC configured for this interface.",
                                     "example": 111,
                                     "nullable": false,
                                     "readOnly": true,
@@ -50311,7 +50171,7 @@
                             "properties": {
                               "address": {
                                 "description": "__Read-only__ The IP address.",
-                                "example": "192.0.2.3",
+                                "example": "192.0.2.179",
                                 "format": "ip",
                                 "readOnly": true,
                                 "type": "string",
@@ -50319,7 +50179,7 @@
                               },
                               "gateway": {
                                 "description": "__Read-only__ The default gateway for this address.",
-                                "example": "192.0.2.213",
+                                "example": "192.0.2.174",
                                 "format": "ip",
                                 "nullable": true,
                                 "readOnly": true,
@@ -50361,7 +50221,7 @@
                               },
                               "subnet_mask": {
                                 "description": "__Read-only__ The mask that separates host bits from network bits for this address.",
-                                "example": "192.0.2.212",
+                                "example": "192.0.2.72",
                                 "format": "ip",
                                 "readOnly": true,
                                 "type": "string"
@@ -50381,22 +50241,22 @@
                               },
                               "vpc_nat_1_1": {
                                 "additionalProperties": false,
-                                "description": "IPv4 address configured as a 1:1 NAT for this Interface. If no address is configured as a 1:1 NAT, `null` is returned.\n\n__Note__. Only allowed for `vpc` type Interfaces.",
+                                "description": "IPv4 address configured as a 1:1 NAT for this Interface. If no address is configured as a 1:1 NAT, `null` is returned.\n\n> 📘\n>\n> Only allowed for `vpc` type interfaces.",
                                 "properties": {
                                   "address": {
                                     "description": "The IPv4 address that is configured as a 1:1 NAT for this VPC interface.",
-                                    "example": "192.0.2.37",
+                                    "example": "192.0.2.152",
                                     "format": "ipv4",
                                     "type": "string"
                                   },
                                   "subnet_id": {
-                                    "description": "The `id` of the VPC Subnet for this Interface.",
+                                    "description": "The `id` of the VPC Subnet for this interface.",
                                     "example": 101,
                                     "nullable": false,
                                     "type": "integer"
                                   },
                                   "vpc_id": {
-                                    "description": "__Read-only__ The `id` of the VPC configured for this Interface.",
+                                    "description": "__Read-only__ The `id` of the VPC configured for this interface.",
                                     "example": 111,
                                     "nullable": false,
                                     "readOnly": true,
@@ -50488,7 +50348,7 @@
                               },
                               "nat_1_1": {
                                 "description": "__Read-only__ The public IP address used for NAT 1:1 with the VPC. This is empty if NAT 1:1 isn't used.",
-                                "example": "192.0.2.125",
+                                "example": "192.0.2.29",
                                 "format": "ip",
                                 "readOnly": true,
                                 "type": "string"
@@ -50522,7 +50382,7 @@
                               },
                               "subnet_mask": {
                                 "description": "__Read-only__ The mask that separates host bits from network bits for the `address` or `address_range`.",
-                                "example": "192.0.2.23",
+                                "example": "192.0.2.169",
                                 "format": "ip",
                                 "readOnly": true,
                                 "type": "string"
@@ -50571,7 +50431,7 @@
                               },
                               "range": {
                                 "description": "__Read-only__ The IPv6 address of this range.",
-                                "example": "2001:db8:ac98:6533:6821:34f7:bb35:b892",
+                                "example": "2001:db8:79ea:9876:4fff:bc8e:4918:9716",
                                 "readOnly": true,
                                 "type": "string",
                                 "x-linode-cli-display": 1
@@ -50585,7 +50445,7 @@
                               },
                               "route_target": {
                                 "description": "The IPv6 SLAAC address.",
-                                "example": "2001:db8:98be:78b9:f599:c156:ae4d:537c",
+                                "example": "2001:db8:122:d755:3006:34c:9e5a:dc1f",
                                 "type": "string"
                               }
                             },
@@ -50602,7 +50462,7 @@
                           "properties": {
                             "address": {
                               "description": "__Read-only__ The IPv6 link-local address.",
-                              "example": "2001:db8:615e:c7b4:f8e0:89bc:2149:94b8",
+                              "example": "2001:db8:3536:c7a:5ad4:487f:eb95:163",
                               "format": "ip",
                               "readOnly": true,
                               "type": "string",
@@ -50610,7 +50470,7 @@
                             },
                             "gateway": {
                               "description": "__Read-only__ The default gateway for this address.",
-                              "example": "2001:db8:ff35:96e7:e057:83a7:c71a:a66d",
+                              "example": "2001:db8:5a43:f546:447c:e80b:ec9b:e0bb",
                               "readOnly": true,
                               "type": "string"
                             },
@@ -50656,7 +50516,7 @@
                             },
                             "subnet_mask": {
                               "description": "__Read-only__ The subnet mask.",
-                              "example": "2001:db8:ec26:5be4:2040:fdb1:8f3b:2270",
+                              "example": "2001:db8:2386:f7f7:717c:c3d2:85e8:3bb",
                               "format": "ip",
                               "readOnly": true,
                               "type": "string"
@@ -50680,7 +50540,7 @@
                           "properties": {
                             "address": {
                               "description": "__Read-only__ The address.",
-                              "example": "2001:db8:f57c:12a2:aed0:53c9:5fa4:773c",
+                              "example": "2001:db8:7b4:d8f2:b7ad:264a:cbe7:9c08",
                               "format": "ip",
                               "readOnly": true,
                               "type": "string",
@@ -50688,7 +50548,7 @@
                             },
                             "gateway": {
                               "description": "__Read-only__ The default gateway for this address.",
-                              "example": "2001:db8:d5cb:d701:c450:b40b:d751:f5ac",
+                              "example": "2001:db8:6751:2bdf:d0ae:8e89:5238:f39c",
                               "readOnly": true,
                               "type": "string"
                             },
@@ -50734,7 +50594,7 @@
                             },
                             "subnet_mask": {
                               "description": "__Read-only__ The subnet mask.",
-                              "example": "2001:db8:335a:daf3:1b34:8fcd:a66:94b3",
+                              "example": "2001:db8:792e:6e26:6a99:1d9d:b413:1676",
                               "format": "ip",
                               "readOnly": true,
                               "type": "string"
@@ -50904,7 +50764,7 @@
                   "properties": {
                     "address": {
                       "description": "__Read-only__ The IP address.",
-                      "example": "192.0.2.177",
+                      "example": "192.0.2.141",
                       "format": "ip",
                       "readOnly": true,
                       "type": "string",
@@ -50912,7 +50772,7 @@
                     },
                     "gateway": {
                       "description": "__Read-only__ The default gateway for this address.",
-                      "example": "192.0.2.174",
+                      "example": "192.0.2.136",
                       "format": "ip",
                       "nullable": true,
                       "readOnly": true,
@@ -50954,7 +50814,7 @@
                     },
                     "subnet_mask": {
                       "description": "__Read-only__ The mask that separates host bits from network bits for this address.",
-                      "example": "192.0.2.205",
+                      "example": "192.0.2.135",
                       "format": "ip",
                       "readOnly": true,
                       "type": "string"
@@ -50974,22 +50834,22 @@
                     },
                     "vpc_nat_1_1": {
                       "additionalProperties": false,
-                      "description": "IPv4 address configured as a 1:1 NAT for this Interface. If no address is configured as a 1:1 NAT, `null` is returned.\n\n__Note__. Only allowed for `vpc` type Interfaces.",
+                      "description": "IPv4 address configured as a 1:1 NAT for this Interface. If no address is configured as a 1:1 NAT, `null` is returned.\n\n> 📘\n>\n> Only allowed for `vpc` type interfaces.",
                       "properties": {
                         "address": {
                           "description": "The IPv4 address that is configured as a 1:1 NAT for this VPC interface.",
-                          "example": "192.0.2.245",
+                          "example": "192.0.2.58",
                           "format": "ipv4",
                           "type": "string"
                         },
                         "subnet_id": {
-                          "description": "The `id` of the VPC Subnet for this Interface.",
+                          "description": "The `id` of the VPC Subnet for this interface.",
                           "example": 101,
                           "nullable": false,
                           "type": "integer"
                         },
                         "vpc_id": {
-                          "description": "__Read-only__ The `id` of the VPC configured for this Interface.",
+                          "description": "__Read-only__ The `id` of the VPC configured for this interface.",
                           "example": 111,
                           "nullable": false,
                           "readOnly": true,
@@ -51124,7 +50984,7 @@
                   "properties": {
                     "address": {
                       "description": "__Read-only__ The IP address.",
-                      "example": "192.0.2.107",
+                      "example": "192.0.2.106",
                       "format": "ip",
                       "readOnly": true,
                       "type": "string",
@@ -51132,7 +50992,7 @@
                     },
                     "gateway": {
                       "description": "__Read-only__ The default gateway for this address.",
-                      "example": "192.0.2.19",
+                      "example": "192.0.2.243",
                       "format": "ip",
                       "nullable": true,
                       "readOnly": true,
@@ -51174,7 +51034,7 @@
                     },
                     "subnet_mask": {
                       "description": "__Read-only__ The mask that separates host bits from network bits for this address.",
-                      "example": "192.0.2.177",
+                      "example": "192.0.2.232",
                       "format": "ip",
                       "readOnly": true,
                       "type": "string"
@@ -51194,22 +51054,22 @@
                     },
                     "vpc_nat_1_1": {
                       "additionalProperties": false,
-                      "description": "IPv4 address configured as a 1:1 NAT for this Interface. If no address is configured as a 1:1 NAT, `null` is returned.\n\n__Note__. Only allowed for `vpc` type Interfaces.",
+                      "description": "IPv4 address configured as a 1:1 NAT for this Interface. If no address is configured as a 1:1 NAT, `null` is returned.\n\n> 📘\n>\n> Only allowed for `vpc` type interfaces.",
                       "properties": {
                         "address": {
                           "description": "The IPv4 address that is configured as a 1:1 NAT for this VPC interface.",
-                          "example": "192.0.2.169",
+                          "example": "192.0.2.205",
                           "format": "ipv4",
                           "type": "string"
                         },
                         "subnet_id": {
-                          "description": "The `id` of the VPC Subnet for this Interface.",
+                          "description": "The `id` of the VPC Subnet for this interface.",
                           "example": 101,
                           "nullable": false,
                           "type": "integer"
                         },
                         "vpc_id": {
-                          "description": "__Read-only__ The `id` of the VPC configured for this Interface.",
+                          "description": "__Read-only__ The `id` of the VPC configured for this interface.",
                           "example": 111,
                           "nullable": false,
                           "readOnly": true,
@@ -51822,7 +51682,7 @@
                             "maximum": 20,
                             "minimum": 0,
                             "type": "integer",
-                            "x-linode-cli-display": 7
+                            "x-linode-cli-display": 9
                           },
                           "created": {
                             "description": "__Read-only__ When this NodeBalancer was created.",
@@ -51836,7 +51696,7 @@
                             "example": "192.0.2.1.ip.linodeusercontent.com",
                             "readOnly": true,
                             "type": "string",
-                            "x-linode-cli-display": 4
+                            "x-linode-cli-display": 5
                           },
                           "id": {
                             "description": "__Read-only__ This NodeBalancer's unique ID.",
@@ -51847,7 +51707,7 @@
                           },
                           "ipv4": {
                             "description": "__Filterable__, __Read-only__ This NodeBalancer's public IPv4 address.",
-                            "example": "192.0.2.8",
+                            "example": "192.0.2.135",
                             "format": "ip",
                             "readOnly": true,
                             "type": "string",
@@ -51856,7 +51716,7 @@
                                 "Filterable"
                               ]
                             },
-                            "x-linode-cli-display": 5,
+                            "x-linode-cli-display": 6,
                             "x-linode-filterable": true
                           },
                           "ipv6": {
@@ -51866,7 +51726,7 @@
                             "nullable": true,
                             "readOnly": true,
                             "type": "string",
-                            "x-linode-cli-display": 6
+                            "x-linode-cli-display": 7
                           },
                           "label": {
                             "description": "__Filterable__ This NodeBalancer's label. These must be unique on your Account.",
@@ -51882,6 +51742,36 @@
                             },
                             "x-linode-cli-display": 2,
                             "x-linode-filterable": true
+                          },
+                          "lke_cluster": {
+                            "description": "__Read-only__ This NodeBalancer's related LKE Cluster, if any. The value is `null` if this NodeBalancer isn't related to an LKE Cluster.",
+                            "nullable": true,
+                            "properties": {
+                              "id": {
+                                "description": "The ID of the related LKE Cluster.",
+                                "example": 12345,
+                                "type": "string"
+                              },
+                              "label": {
+                                "description": "The label of the related LKE Cluster.",
+                                "example": "lkecluster12345",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "__Read-only__ The type for LKE Clusters.",
+                                "example": "lkecluster",
+                                "readOnly": true,
+                                "type": "string"
+                              },
+                              "url": {
+                                "description": "The URL where you can access the related LKE Cluster.",
+                                "example": "/v4/lke/clusters/12345",
+                                "type": "string"
+                              }
+                            },
+                            "readOnly": true,
+                            "type": "object",
+                            "x-linode-cli-display": 8
                           },
                           "region": {
                             "description": "__Filterable__, __Read-only__ The Region where this NodeBalancer is located. NodeBalancers only support backends in the same Region.",
@@ -51941,6 +51831,16 @@
                             },
                             "readOnly": true,
                             "type": "object"
+                          },
+                          "type": {
+                            "description": "__Read-only__ The type of NodeBalancer.",
+                            "enum": [
+                              "common"
+                            ],
+                            "example": "common",
+                            "readOnly": true,
+                            "type": "string",
+                            "x-linode-cli-display": 4
                           },
                           "updated": {
                             "description": "__Read-only__ When this NodeBalancer was last updated.",
@@ -52724,7 +52624,7 @@
                     "ipv4": {
                       "description": "__Filterable__, __Read-only__ This Linode's IPv4 Addresses. Each Linode is assigned a single public IPv4 address upon creation, and may get a single private IPv4 address if needed. You may need to [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) to get additional IPv4 addresses.\n\nIPv4 addresses may be reassigned between your Linodes, or shared with other Linodes. See the [networking](https://techdocs.akamai.com/linode-api/reference/post-firewalls) operations for details.",
                       "example": [
-                        "192.0.2.173",
+                        "192.0.2.28",
                         "192.0.2.1"
                       ],
                       "format": "ipv4",
@@ -52743,7 +52643,7 @@
                     },
                     "ipv6": {
                       "description": "__Read-only__ This Linode's IPv6 SLAAC address. This address is specific to a Linode, and may not be shared. If the Linode has not been assigned an IPv6 address, the return value will be `null`.",
-                      "example": "2001:db8:dd4f:884:eefb:3f02:67d1:6027/32",
+                      "example": "2001:db8:2432:88e4:d43f:83ee:f85f:3fee/32",
                       "format": "ipv6/128",
                       "nullable": true,
                       "readOnly": true,
@@ -58043,7 +57943,7 @@
                               "ipv4": {
                                 "description": "A list of individual ipv4 addresses or CIDRs to ALLOW. Defaults to `[]`.",
                                 "example": [
-                                  "192.0.2.96",
+                                  "192.0.2.64",
                                   "192.0.2.0/24"
                                 ],
                                 "items": {
@@ -59037,7 +58937,7 @@
                               "ipv4": {
                                 "description": "A list of individual ipv4 addresses or CIDRs to ALLOW. Defaults to `[]`.",
                                 "example": [
-                                  "192.0.2.106",
+                                  "192.0.2.182",
                                   "192.0.2.0/24"
                                 ],
                                 "items": {
@@ -59543,7 +59443,7 @@
     },
     "/{apiVersion}/lke/clusters/{clusterId}/control_plane_acl": {
       "get": {
-        "description": "Get a specific cluster's control plane access control List. __Note__: control plane ACLs may not currently be available to all users.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli lke cluster-acl-view 12345\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    lke:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Get a specific cluster's control plane access control List.\n\n> 📘\n>\n> Currently, control plane ACLs may not be available to all users.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli lke cluster-acl-view 12345\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    lke:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-lke-cluster-acl"
@@ -59568,7 +59468,7 @@
                                 "ipv4": {
                                   "description": "A list of individual ipv4 addresses or CIDRs to ALLOW. Defaults to `[]`.",
                                   "example": [
-                                    "192.0.2.231",
+                                    "192.0.2.168",
                                     "192.0.2.0/24"
                                   ],
                                   "items": {
@@ -59789,7 +59689,7 @@
         "x-linode-cli-action": "cluster-acl-view"
       },
       "put": {
-        "description": "Updates a specific cluster's control plane access control list. __Note__: control plane ACLs may not currently be available to all users.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli lke cluster-acl-update 12345 \\\n      --acl.enabled true \\\n      --acl.addresses.ipv4 \"203.0.113.1\" \\\n      --acl.addresses.ipv6 \"2001:db8:1234:abcd::/64\"\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    lke:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Updates a specific cluster's control plane access control list.\n\n> 📘\n>\n> Currently, control plane ACLs may not be available to all users.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli lke cluster-acl-update 12345 \\\n      --acl.enabled true \\\n      --acl.addresses.ipv4 \"203.0.113.1\" \\\n      --acl.addresses.ipv6 \"2001:db8:1234:abcd::/64\"\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    lke:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/put-lke-cluster-acl"
@@ -59813,7 +59713,7 @@
                           "ipv4": {
                             "description": "A list of individual ipv4 addresses or CIDRs to ALLOW. Defaults to `[]`.",
                             "example": [
-                              "192.0.2.191",
+                              "192.0.2.183",
                               "192.0.2.0/24"
                             ],
                             "items": {
@@ -59877,7 +59777,7 @@
                                 "ipv4": {
                                   "description": "A list of individual ipv4 addresses or CIDRs to ALLOW. Defaults to `[]`.",
                                   "example": [
-                                    "192.0.2.159",
+                                    "192.0.2.103",
                                     "192.0.2.0/24"
                                   ],
                                   "items": {
@@ -60098,7 +59998,7 @@
         "x-linode-cli-action": "cluster-acl-update"
       },
       "delete": {
-        "description": "Disable control plane access controls and deletes all rules. This has the same effect as calling `PUT` with an acl json map value of `{“enabled” : false}`. __Note__: control plane ACLs may not currently be available to all users.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli lke cluster-acl-delete 12345\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    lke:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Disable control plane access controls and deletes all rules. This has the same effect as calling `PUT` with an acl json map value of `{“enabled” : false}`. \n\n> 📘\n>\n> Currently, control plane ACLs may not be available to all users.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli lke cluster-acl-delete 12345\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    lke:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/delete-lke-cluster-acl"
@@ -63018,7 +62918,7 @@
     },
     "/{apiVersion}/lke/clusters/{clusterId}/regenerate": {
       "post": {
-        "description": "Regenerate the Kubeconfig file and/or the service account token for a Cluster.\n\nThis is a helper operation that allows performing both the [Delete a Kubeconfig](https://techdocs.akamai.com/linode-api/reference/delete-lke-cluster-kubeconfig) and the [Delete a service token](https://techdocs.akamai.com/linode-api/reference/delete-lke-service-token) operations with a single request.\n\nWhen using this operation, at least one of `kubeconfig` or `servicetoken` is required.\n\n__Note__. When regenerating a service account token, the Cluster's control plane components and Linode CSI drivers are also restarted and configured with the new token. High Availability Clusters should not experience any disruption, while standard Clusters may experience brief control plane downtime while components are restarted.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli lke regenerate 12345 \\\n    --kubeconfig true \\\n    --servicetoken true\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    lke:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Regenerate the Kubeconfig file and/or the service account token for a Cluster.\n\nThis is a helper operation that allows performing both the [Delete a Kubeconfig](https://techdocs.akamai.com/linode-api/reference/delete-lke-cluster-kubeconfig) and the [Delete a service token](https://techdocs.akamai.com/linode-api/reference/delete-lke-service-token) operations with a single request.\n\nWhen using this operation, at least one of `kubeconfig` or `servicetoken` is required.\n\n> 📘\n>\n> When regenerating a service account token, the cluster's control plane components and Linode CSI drivers are also restarted and configured with the new token. High availability clusters shouldn't experience any disruption, while standard clusters may experience brief control plane downtime while components are restarted.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli lke regenerate 12345 \\\n    --kubeconfig true \\\n    --servicetoken true\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    lke:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/post-lke-cluster-regenerate"
@@ -63181,7 +63081,7 @@
     },
     "/{apiVersion}/lke/clusters/{clusterId}/servicetoken": {
       "delete": {
-        "description": "Delete and regenerate the service account token for a Cluster.\n\n__Note__. When regenerating a service account token, the Cluster's control plane components and Linode CSI drivers are also restarted and configured with the new token. High Availability Clusters should not experience any disruption, while standard Clusters may experience brief control plane downtime while components are restarted.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli lke service-token-delete 12345\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    lke:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Delete and regenerate the service account token for a Cluster.\n\n> 📘\n>\n> When you regenerate a service account token, the cluster's control plane components and Linode CSI drivers are also restarted and configured with the new token. High availability clusters shouldn't experience any disruption, while standard clusters may experience brief control plane downtime while components are restarted.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli lke service-token-delete 12345\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    lke:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/delete-lke-service-token"
@@ -68668,7 +68568,7 @@
                               "ip": {
                                 "default": "any",
                                 "description": "The IP Linode special forces should use to access this Linode when responding to an Issue.\n\nBy default, any of a Linode's IP addresses can be used for incident response access.",
-                                "example": "192.0.2.131",
+                                "example": "192.0.2.207",
                                 "format": "ip",
                                 "type": "string"
                               },
@@ -68877,7 +68777,7 @@
                         "ip": {
                           "default": "any",
                           "description": "The IP Linode special forces should use to access this Linode when responding to an Issue.\n\nBy default, any of a Linode's IP addresses can be used for incident response access.",
-                          "example": "192.0.2.186",
+                          "example": "192.0.2.46",
                           "format": "ip",
                           "type": "string"
                         },
@@ -69033,7 +68933,7 @@
                       "ip": {
                         "default": "any",
                         "description": "The IP Linode special forces should use to access this Linode when responding to an Issue.\n\nBy default, any of a Linode's IP addresses can be used for incident response access.",
-                        "example": "192.0.2.14",
+                        "example": "192.0.2.109",
                         "format": "ip",
                         "type": "string"
                       },
@@ -69116,7 +69016,7 @@
                         "ip": {
                           "default": "any",
                           "description": "The IP Linode special forces should use to access this Linode when responding to an Issue.\n\nBy default, any of a Linode's IP addresses can be used for incident response access.",
-                          "example": "192.0.2.32",
+                          "example": "192.0.2.170",
                           "format": "ip",
                           "type": "string"
                         },
@@ -71656,7 +71556,7 @@
                                       "description": "A list of IPv4 addresses or networks. Addresses must be in IP/mask format. Must not be an empty list.\n\nIf `0.0.0.0/0` is included in this list, all IPv4 addresses are affected by this rule.",
                                       "example": [
                                         "192.0.2.0/24",
-                                        "192.0.2.11/24"
+                                        "192.0.2.12/24"
                                       ],
                                       "items": {
                                         "type": "string"
@@ -71748,7 +71648,7 @@
                                       "description": "A list of IPv4 addresses or networks. Addresses must be in IP/mask format. Must not be an empty list.\n\nIf `0.0.0.0/0` is included in this list, all IPv4 addresses are affected by this rule.",
                                       "example": [
                                         "192.0.2.0/24",
-                                        "192.0.2.206/24"
+                                        "192.0.2.131/24"
                                       ],
                                       "items": {
                                         "type": "string"
@@ -72027,7 +71927,7 @@
                                     "description": "A list of IPv4 addresses or networks. Addresses must be in IP/mask format. Must not be an empty list.\n\nIf `0.0.0.0/0` is included in this list, all IPv4 addresses are affected by this rule.",
                                     "example": [
                                       "192.0.2.0/24",
-                                      "192.0.2.22/24"
+                                      "192.0.2.159/24"
                                     ],
                                     "items": {
                                       "type": "string"
@@ -72119,7 +72019,7 @@
                                     "description": "A list of IPv4 addresses or networks. Addresses must be in IP/mask format. Must not be an empty list.\n\nIf `0.0.0.0/0` is included in this list, all IPv4 addresses are affected by this rule.",
                                     "example": [
                                       "192.0.2.0/24",
-                                      "192.0.2.150/24"
+                                      "192.0.2.188/24"
                                     ],
                                     "items": {
                                       "type": "string"
@@ -72454,7 +72354,7 @@
                                           "description": "A list of IPv4 addresses or networks. Addresses must be in IP/mask format. Must not be an empty list.\n\nIf `0.0.0.0/0` is included in this list, all IPv4 addresses are affected by this rule.",
                                           "example": [
                                             "192.0.2.0/24",
-                                            "192.0.2.199/24"
+                                            "192.0.2.23/24"
                                           ],
                                           "items": {
                                             "type": "string"
@@ -72546,7 +72446,7 @@
                                           "description": "A list of IPv4 addresses or networks. Addresses must be in IP/mask format. Must not be an empty list.\n\nIf `0.0.0.0/0` is included in this list, all IPv4 addresses are affected by this rule.",
                                           "example": [
                                             "192.0.2.0/24",
-                                            "192.0.2.157/24"
+                                            "192.0.2.54/24"
                                           ],
                                           "items": {
                                             "type": "string"
@@ -72898,7 +72798,7 @@
                                     "description": "A list of IPv4 addresses or networks. Addresses must be in IP/mask format. Must not be an empty list.\n\nIf `0.0.0.0/0` is included in this list, all IPv4 addresses are affected by this rule.",
                                     "example": [
                                       "192.0.2.0/24",
-                                      "192.0.2.126/24"
+                                      "192.0.2.119/24"
                                     ],
                                     "items": {
                                       "type": "string"
@@ -72990,7 +72890,7 @@
                                     "description": "A list of IPv4 addresses or networks. Addresses must be in IP/mask format. Must not be an empty list.\n\nIf `0.0.0.0/0` is included in this list, all IPv4 addresses are affected by this rule.",
                                     "example": [
                                       "192.0.2.0/24",
-                                      "192.0.2.94/24"
+                                      "192.0.2.128/24"
                                     ],
                                     "items": {
                                       "type": "string"
@@ -73348,7 +73248,7 @@
                                     "description": "A list of IPv4 addresses or networks. Addresses must be in IP/mask format. Must not be an empty list.\n\nIf `0.0.0.0/0` is included in this list, all IPv4 addresses are affected by this rule.",
                                     "example": [
                                       "192.0.2.0/24",
-                                      "192.0.2.207/24"
+                                      "192.0.2.177/24"
                                     ],
                                     "items": {
                                       "type": "string"
@@ -73440,7 +73340,7 @@
                                     "description": "A list of IPv4 addresses or networks. Addresses must be in IP/mask format. Must not be an empty list.\n\nIf `0.0.0.0/0` is included in this list, all IPv4 addresses are affected by this rule.",
                                     "example": [
                                       "192.0.2.0/24",
-                                      "192.0.2.223/24"
+                                      "192.0.2.11/24"
                                     ],
                                     "items": {
                                       "type": "string"
@@ -74744,7 +74644,7 @@
                                     "description": "A list of IPv4 addresses or networks. Addresses must be in IP/mask format. Must not be an empty list.\n\nIf `0.0.0.0/0` is included in this list, all IPv4 addresses are affected by this rule.",
                                     "example": [
                                       "192.0.2.0/24",
-                                      "192.0.2.218/24"
+                                      "192.0.2.112/24"
                                     ],
                                     "items": {
                                       "type": "string"
@@ -74836,7 +74736,7 @@
                                     "description": "A list of IPv4 addresses or networks. Addresses must be in IP/mask format. Must not be an empty list.\n\nIf `0.0.0.0/0` is included in this list, all IPv4 addresses are affected by this rule.",
                                     "example": [
                                       "192.0.2.0/24",
-                                      "192.0.2.124/24"
+                                      "192.0.2.135/24"
                                     ],
                                     "items": {
                                       "type": "string"
@@ -75173,7 +75073,7 @@
                                     "description": "A list of IPv4 addresses or networks. Addresses must be in IP/mask format. Must not be an empty list.\n\nIf `0.0.0.0/0` is included in this list, all IPv4 addresses are affected by this rule.",
                                     "example": [
                                       "192.0.2.0/24",
-                                      "192.0.2.197/24"
+                                      "192.0.2.234/24"
                                     ],
                                     "items": {
                                       "type": "string"
@@ -75265,7 +75165,7 @@
                                     "description": "A list of IPv4 addresses or networks. Addresses must be in IP/mask format. Must not be an empty list.\n\nIf `0.0.0.0/0` is included in this list, all IPv4 addresses are affected by this rule.",
                                     "example": [
                                       "192.0.2.0/24",
-                                      "192.0.2.241/24"
+                                      "192.0.2.157/24"
                                     ],
                                     "items": {
                                       "type": "string"
@@ -75570,7 +75470,7 @@
                                 "description": "A list of IPv4 addresses or networks. Addresses must be in IP/mask format. Must not be an empty list.\n\nIf `0.0.0.0/0` is included in this list, all IPv4 addresses are affected by this rule.",
                                 "example": [
                                   "192.0.2.0/24",
-                                  "192.0.2.194/24"
+                                  "192.0.2.51/24"
                                 ],
                                 "items": {
                                   "type": "string"
@@ -75662,7 +75562,7 @@
                                 "description": "A list of IPv4 addresses or networks. Addresses must be in IP/mask format. Must not be an empty list.\n\nIf `0.0.0.0/0` is included in this list, all IPv4 addresses are affected by this rule.",
                                 "example": [
                                   "192.0.2.0/24",
-                                  "192.0.2.54/24"
+                                  "192.0.2.11/24"
                                 ],
                                 "items": {
                                   "type": "string"
@@ -75869,7 +75769,7 @@
                                   "description": "A list of IPv4 addresses or networks. Addresses must be in IP/mask format. Must not be an empty list.\n\nIf `0.0.0.0/0` is included in this list, all IPv4 addresses are affected by this rule.",
                                   "example": [
                                     "192.0.2.0/24",
-                                    "192.0.2.40/24"
+                                    "192.0.2.216/24"
                                   ],
                                   "items": {
                                     "type": "string"
@@ -75961,7 +75861,7 @@
                                   "description": "A list of IPv4 addresses or networks. Addresses must be in IP/mask format. Must not be an empty list.\n\nIf `0.0.0.0/0` is included in this list, all IPv4 addresses are affected by this rule.",
                                   "example": [
                                     "192.0.2.0/24",
-                                    "192.0.2.192/24"
+                                    "192.0.2.207/24"
                                   ],
                                   "items": {
                                     "type": "string"
@@ -76108,7 +76008,7 @@
                                 "description": "A list of IPv4 addresses or networks. Addresses must be in IP/mask format. Must not be an empty list.\n\nIf `0.0.0.0/0` is included in this list, all IPv4 addresses are affected by this rule.",
                                 "example": [
                                   "192.0.2.0/24",
-                                  "192.0.2.46/24"
+                                  "192.0.2.67/24"
                                 ],
                                 "items": {
                                   "type": "string"
@@ -76200,7 +76100,7 @@
                                 "description": "A list of IPv4 addresses or networks. Addresses must be in IP/mask format. Must not be an empty list.\n\nIf `0.0.0.0/0` is included in this list, all IPv4 addresses are affected by this rule.",
                                 "example": [
                                   "192.0.2.0/24",
-                                  "192.0.2.1/24"
+                                  "192.0.2.15/24"
                                 ],
                                 "items": {
                                   "type": "string"
@@ -76462,7 +76362,7 @@
                   "properties": {
                     "address": {
                       "description": "__Read-only__ The IP address.",
-                      "example": "192.0.2.31",
+                      "example": "192.0.2.155",
                       "format": "ip",
                       "readOnly": true,
                       "type": "string",
@@ -76470,7 +76370,7 @@
                     },
                     "gateway": {
                       "description": "__Read-only__ The default gateway for this address.",
-                      "example": "192.0.2.73",
+                      "example": "192.0.2.213",
                       "format": "ip",
                       "nullable": true,
                       "readOnly": true,
@@ -76512,7 +76412,7 @@
                     },
                     "subnet_mask": {
                       "description": "__Read-only__ The mask that separates host bits from network bits for this address.",
-                      "example": "192.0.2.178",
+                      "example": "192.0.2.119",
                       "format": "ip",
                       "readOnly": true,
                       "type": "string"
@@ -76532,22 +76432,22 @@
                     },
                     "vpc_nat_1_1": {
                       "additionalProperties": false,
-                      "description": "IPv4 address configured as a 1:1 NAT for this Interface. If no address is configured as a 1:1 NAT, `null` is returned.\n\n__Note__. Only allowed for `vpc` type Interfaces.",
+                      "description": "IPv4 address configured as a 1:1 NAT for this Interface. If no address is configured as a 1:1 NAT, `null` is returned.\n\n> 📘\n>\n> Only allowed for `vpc` type interfaces.",
                       "properties": {
                         "address": {
                           "description": "The IPv4 address that is configured as a 1:1 NAT for this VPC interface.",
-                          "example": "192.0.2.205",
+                          "example": "192.0.2.60",
                           "format": "ipv4",
                           "type": "string"
                         },
                         "subnet_id": {
-                          "description": "The `id` of the VPC Subnet for this Interface.",
+                          "description": "The `id` of the VPC Subnet for this interface.",
                           "example": 101,
                           "nullable": false,
                           "type": "integer"
                         },
                         "vpc_id": {
-                          "description": "__Read-only__ The `id` of the VPC configured for this Interface.",
+                          "description": "__Read-only__ The `id` of the VPC configured for this interface.",
                           "example": 111,
                           "nullable": false,
                           "readOnly": true,
@@ -76638,7 +76538,7 @@
         "x-linode-grant": "read_write"
       },
       "get": {
-        "description": "Returns a paginated list of IP addresses on your account, excluding private addresses.\n\n__Note__. Use the `skip_ipv6_rdns` query string to improve performance if your application frequently accesses this operation and doesn't require IPv6 RDNS data.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli networking ips-list\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    ips:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Returns a paginated list of IP addresses on your account, excluding private addresses.\n\n> 👍\n>\n> if your application frequently accesses this operation and doesn't require IPv6 RDNS data, you can use the `skip_ipv6_rdns` query string to improve performance.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli networking ips-list\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    ips:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-ips"
@@ -76801,7 +76701,7 @@
                               },
                               "subnet_mask": {
                                 "description": "__Read-only__ The mask that separates host bits from network bits for this address.",
-                                "example": "192.0.2.157",
+                                "example": "192.0.2.143",
                                 "format": "ip",
                                 "readOnly": true,
                                 "type": "string"
@@ -76827,16 +76727,16 @@
                               },
                               "vpc_nat_1_1": {
                                 "additionalProperties": false,
-                                "description": "IPv4 address configured as a 1:1 NAT for this Interface. Empty if no address is configured as a 1:1 NAT.\n\n__Note__. Only allowed for `vpc` type Interfaces.",
+                                "description": "IPv4 address configured as a 1:1 NAT for this interface. Empty if no address is configured as a 1:1 NAT.\n\n> 📘\n>\n> Only allowed for `vpc` type interfaces.",
                                 "properties": {
                                   "address": {
                                     "description": "The IPv4 address that is configured as a 1:1 NAT for this VPC interface.",
-                                    "example": "192.0.2.43",
+                                    "example": "192.0.2.147",
                                     "format": "ipv4",
                                     "type": "string"
                                   },
                                   "subnet_id": {
-                                    "description": "The `id` of the VPC Subnet for this Interface.",
+                                    "description": "The `id` of the VPC Subnet for this interface.",
                                     "example": 101,
                                     "nullable": false,
                                     "type": "integer"
@@ -76964,7 +76864,7 @@
     },
     "/{apiVersion}/networking/ips/assign": {
       "post": {
-        "description": "Assign multiple IPv4 addresses and/or IPv6 ranges to multiple Linodes in one Region. This allows swapping, shuffling, or otherwise reorganizing IPs to your Linodes.\n\nThe following restrictions apply:\n\n- All Linodes involved must have at least one public IPv4 address after assignment.\n- Linodes may have no more than one assigned private IPv4 address.\n- Linodes may have no more than one assigned IPv6 range.\n- Shared IP addresses cannot be swapped between Linodes.\n\n[Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) to request additional IPv4 addresses or IPv6 ranges beyond standard account limits.\n\n__Note__. Removing an IP address that has been set as a Managed Linode's `ssh.ip` causes the Managed Linode's SSH access settings to reset to their default values.\n\nTo view and configure Managed Linode SSH settings, use the following operations:\n\n- [Get a Linode's managed settings](https://techdocs.akamai.com/linode-api/reference/get-managed-linode-setting)\n- [Update a Linode's managed settings](https://techdocs.akamai.com/linode-api/reference/put-managed-linode-setting)\n\n__Note__. Addresses with an active 1:1 NAT to a VPC Interface address cannot be assigned to other Linodes.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli networking ip-assign \\\n  --region us-east \\\n  --assignments.address 192.0.2.1 \\\n  --assignments.linode_id 123 \\\n  --assignments.address 2001:db8:3c4d:15::/64 \\\n  --assignments.linode_id 234\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    ips:read_write\nlinodes:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Assign multiple IPv4 addresses and/or IPv6 ranges to multiple Linodes in one Region. This allows swapping, shuffling, or otherwise reorganizing IPs to your Linodes.\n\nThe following restrictions apply:\n\n- All Linodes involved must have at least one public IPv4 address after assignment.\n- Linodes may have no more than one assigned private IPv4 address.\n- Linodes may have no more than one assigned IPv6 range.\n- Shared IP addresses cannot be swapped between Linodes.\n\n[Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) to request additional IPv4 addresses or IPv6 ranges beyond standard account limits.\n\n> 📘\n>\n> Removing an IP address that has been set as a Managed Linode's `ssh.ip` causes the Managed Linode's SSH access settings to reset to their default values.\n\nTo view and configure Managed Linode SSH settings, use the following operations:\n\n- [Get a Linode's managed settings](https://techdocs.akamai.com/linode-api/reference/get-managed-linode-setting)\n- [Update a Linode's managed settings](https://techdocs.akamai.com/linode-api/reference/put-managed-linode-setting)\n\n> 📘\n>\n> Addresses with an active 1:1 NAT to a VPC Interface address cannot be assigned to other Linodes.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli networking ip-assign \\\n  --region us-east \\\n  --assignments.address 192.0.2.1 \\\n  --assignments.linode_id 123 \\\n  --assignments.address 2001:db8:3c4d:15::/64 \\\n  --assignments.linode_id 234\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    ips:read_write\nlinodes:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/post-assign-ips"
@@ -77140,7 +77040,7 @@
     },
     "/{apiVersion}/networking/ips/share": {
       "post": {
-        "description": "Configure shared IPs.\n\nIP sharing allows IP address reassignment (also referred to as IP failover) from one Linode to another if the primary Linode becomes unresponsive. This means that requests to the primary Linode's IP address can be automatically rerouted to secondary Linodes at the configured shared IP addresses.\n\nIP failover requires configuration of a [BGP based failover service](https://techdocs.akamai.com/cloud-computing/docs/configure-failover-on-a-compute-instance) within the internal system of the primary Linode.\n\n__Note__. A public IPv4 address cannot be shared if it is configured for a 1:1 NAT on a `vpc` purpose Configuration Profile Interface.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli networking ip-share \\\n  --linode_id 123 \\\n  --ips 192.0.2.1 \\\n  --ips 2001:db8:3c4d:15::\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    ips:read_write\nlinodes:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Configure shared IPs.\n\nIP sharing allows IP address reassignment (also referred to as IP failover) from one Linode to another if the primary Linode becomes unresponsive. This means that requests to the primary Linode's IP address can be automatically rerouted to secondary Linodes at the configured shared IP addresses.\n\nIP failover requires configuration of a [BGP based failover service](https://techdocs.akamai.com/cloud-computing/docs/configure-failover-on-a-compute-instance) within the internal system of the primary Linode.\n\n> 📘\n>\n> A public IPv4 address can't be shared if it's configured for a 1:1 NAT on a `vpc` purpose Configuration Profile Interface.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli networking ip-share \\\n  --linode_id 123 \\\n  --ips 192.0.2.1 \\\n  --ips 2001:db8:3c4d:15::\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    ips:read_write\nlinodes:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/post-share-ips"
@@ -77324,7 +77224,7 @@
                   "properties": {
                     "address": {
                       "description": "__Read-only__ The IP address.",
-                      "example": "192.0.2.130",
+                      "example": "192.0.2.120",
                       "format": "ip",
                       "readOnly": true,
                       "type": "string",
@@ -77332,7 +77232,7 @@
                     },
                     "gateway": {
                       "description": "__Read-only__ The default gateway for this address.",
-                      "example": "192.0.2.111",
+                      "example": "192.0.2.52",
                       "format": "ip",
                       "nullable": true,
                       "readOnly": true,
@@ -77374,7 +77274,7 @@
                     },
                     "subnet_mask": {
                       "description": "__Read-only__ The mask that separates host bits from network bits for this address.",
-                      "example": "192.0.2.77",
+                      "example": "192.0.2.24",
                       "format": "ip",
                       "readOnly": true,
                       "type": "string"
@@ -77394,22 +77294,22 @@
                     },
                     "vpc_nat_1_1": {
                       "additionalProperties": false,
-                      "description": "IPv4 address configured as a 1:1 NAT for this Interface. If no address is configured as a 1:1 NAT, `null` is returned.\n\n__Note__. Only allowed for `vpc` type Interfaces.",
+                      "description": "IPv4 address configured as a 1:1 NAT for this Interface. If no address is configured as a 1:1 NAT, `null` is returned.\n\n> 📘\n>\n> Only allowed for `vpc` type interfaces.",
                       "properties": {
                         "address": {
                           "description": "The IPv4 address that is configured as a 1:1 NAT for this VPC interface.",
-                          "example": "192.0.2.25",
+                          "example": "192.0.2.204",
                           "format": "ipv4",
                           "type": "string"
                         },
                         "subnet_id": {
-                          "description": "The `id` of the VPC Subnet for this Interface.",
+                          "description": "The `id` of the VPC Subnet for this interface.",
                           "example": 101,
                           "nullable": false,
                           "type": "integer"
                         },
                         "vpc_id": {
-                          "description": "__Read-only__ The `id` of the VPC configured for this Interface.",
+                          "description": "__Read-only__ The `id` of the VPC configured for this interface.",
                           "example": 111,
                           "nullable": false,
                           "readOnly": true,
@@ -77546,7 +77446,7 @@
                   "properties": {
                     "address": {
                       "description": "__Read-only__ The IP address.",
-                      "example": "192.0.2.67",
+                      "example": "192.0.2.153",
                       "format": "ip",
                       "readOnly": true,
                       "type": "string",
@@ -77554,7 +77454,7 @@
                     },
                     "gateway": {
                       "description": "__Read-only__ The default gateway for this address.",
-                      "example": "192.0.2.215",
+                      "example": "192.0.2.188",
                       "format": "ip",
                       "nullable": true,
                       "readOnly": true,
@@ -77596,7 +77496,7 @@
                     },
                     "subnet_mask": {
                       "description": "__Read-only__ The mask that separates host bits from network bits for this address.",
-                      "example": "192.0.2.147",
+                      "example": "192.0.2.171",
                       "format": "ip",
                       "readOnly": true,
                       "type": "string"
@@ -77616,22 +77516,22 @@
                     },
                     "vpc_nat_1_1": {
                       "additionalProperties": false,
-                      "description": "IPv4 address configured as a 1:1 NAT for this Interface. If no address is configured as a 1:1 NAT, `null` is returned.\n\n__Note__. Only allowed for `vpc` type Interfaces.",
+                      "description": "IPv4 address configured as a 1:1 NAT for this Interface. If no address is configured as a 1:1 NAT, `null` is returned.\n\n> 📘\n>\n> Only allowed for `vpc` type interfaces.",
                       "properties": {
                         "address": {
                           "description": "The IPv4 address that is configured as a 1:1 NAT for this VPC interface.",
-                          "example": "192.0.2.115",
+                          "example": "192.0.2.151",
                           "format": "ipv4",
                           "type": "string"
                         },
                         "subnet_id": {
-                          "description": "The `id` of the VPC Subnet for this Interface.",
+                          "description": "The `id` of the VPC Subnet for this interface.",
                           "example": 101,
                           "nullable": false,
                           "type": "integer"
                         },
                         "vpc_id": {
-                          "description": "__Read-only__ The `id` of the VPC configured for this Interface.",
+                          "description": "__Read-only__ The `id` of the VPC configured for this interface.",
                           "example": 111,
                           "nullable": false,
                           "readOnly": true,
@@ -77762,7 +77662,7 @@
     },
     "/{apiVersion}/networking/ipv4/assign": {
       "post": {
-        "description": "This operation is equivalent to [Assign IP addresses](https://techdocs.akamai.com/linode-api/reference/post-assign-ips).\n\nAssign multiple IPv4 addresses and/or IPv6 ranges to multiple Linodes in one Region. This allows swapping, shuffling, or otherwise reorganizing IPs to your Linodes.\n\nThe following restrictions apply:\n\n- All Linodes involved must have at least one public IPv4 address after assignment.\n- Linodes may have no more than one assigned private IPv4 address.\n- Linodes may have no more than one assigned IPv6 range.\n\n[Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) to request additional IPv4 addresses or IPv6 ranges beyond standard account limits.\n\n__Note__. Removing an IP address that has been set as a Managed Linode's `ssh.ip` causes the Managed Linode's SSH access settings to reset to their default values.\n\nTo view and configure Managed Linode SSH settings, use the following operations:\n- [Get a Linode's managed settings](https://techdocs.akamai.com/linode-api/reference/get-managed-linode-setting)\n- [Update a Linode's managed settings](https://techdocs.akamai.com/linode-api/reference/put-managed-linode-setting)\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    ips:read_write\nlinodes:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "This operation is equivalent to [Assign IP addresses](https://techdocs.akamai.com/linode-api/reference/post-assign-ips).\n\nAssign multiple IPv4 addresses and/or IPv6 ranges to multiple Linodes in one Region. This allows swapping, shuffling, or otherwise reorganizing IPs to your Linodes.\n\nThe following restrictions apply:\n\n- All Linodes involved must have at least one public IPv4 address after assignment.\n- Linodes may have no more than one assigned private IPv4 address.\n- Linodes may have no more than one assigned IPv6 range.\n\n[Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) to request additional IPv4 addresses or IPv6 ranges beyond standard account limits.\n\n> 📘\n>\n> Removing an IP address that has been set as a Managed Linode's `ssh.ip` causes the Managed Linode's SSH access settings to reset to their default values.\n\nTo view and configure Managed Linode SSH settings, use the following operations:\n- [Get a Linode's managed settings](https://techdocs.akamai.com/linode-api/reference/get-managed-linode-setting)\n- [Update a Linode's managed settings](https://techdocs.akamai.com/linode-api/reference/put-managed-linode-setting)\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    ips:read_write\nlinodes:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/post-assign-ipv4s"
@@ -78151,7 +78051,7 @@
                           },
                           "range": {
                             "description": "__Read-only__ The IPv6 range of addresses in this pool.",
-                            "example": "2001:db8:8128:3e65:7bed:f83e:16af:2e86",
+                            "example": "2001:db8:e26b:383:17a0:5bcc:d57b:464",
                             "readOnly": true,
                             "type": "string",
                             "x-linode-cli-display": 1
@@ -78171,7 +78071,7 @@
                           },
                           "route_target": {
                             "description": "The last address in this block of IPv6 addresses.",
-                            "example": "2001:db8:19da:e27b:da13:1d8d:596c:a72d",
+                            "example": "2001:db8:e9fc:f17c:1bb1:f84c:923d:55ce",
                             "nullable": true,
                             "type": "string"
                           }
@@ -78308,7 +78208,7 @@
     },
     "/{apiVersion}/networking/ipv6/ranges": {
       "post": {
-        "description": "Creates an IPv6 Range and assigns it based on the provided Linode or route target IPv6 SLAAC address. See the `ipv6` property when running the [Get a Linode](https://techdocs.akamai.com/linode-api/reference/get-linode-instance) operation to view a Linode's IPv6 SLAAC address.\n\n- Either `linode_id` or `route_target` is required in a request.\n- `linode_id` and `route_target` are mutually exclusive. Submitting values for both properties in a request results in an error.\n- Upon a successful request, an IPv6 range is created in the [region](https://techdocs.akamai.com/linode-api/reference/get-regions) that corresponds to the provided `linode_id` or `route_target`.\n- Your Linode is responsible for routing individual addresses in the range, or handling traffic for all the addresses in the range.\n- Run the [Assign IP addresses](https://techdocs.akamai.com/linode-api/reference/post-assign-ips) operation to re-assign IPv6 Ranges to your Linodes.\n\n__Note__. The following restrictions apply:\n\n  - A Linode can only have one IPv6 range targeting its SLAAC address.\n  - An account can only have one IPv6 range in each [region](https://techdocs.akamai.com/linode-api/reference/get-regions).\n  - [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) to request expansion of these restrictions.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli networking v6-range-create \\\n  --linode_id 123 \\\n  --prefix_length 64\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    ips:read_write\nlinodes:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Creates an IPv6 Range and assigns it based on the provided Linode or route target IPv6 SLAAC address. See the `ipv6` property when running the [Get a Linode](https://techdocs.akamai.com/linode-api/reference/get-linode-instance) operation to view a Linode's IPv6 SLAAC address.\n\n- Either `linode_id` or `route_target` is required in a request.\n- `linode_id` and `route_target` are mutually exclusive. Submitting values for both properties in a request results in an error.\n- Upon a successful request, an IPv6 range is created in the [region](https://techdocs.akamai.com/linode-api/reference/get-regions) that corresponds to the provided `linode_id` or `route_target`.\n- Your Linode is responsible for routing individual addresses in the range, or handling traffic for all the addresses in the range.\n- Run the [Assign IP addresses](https://techdocs.akamai.com/linode-api/reference/post-assign-ips) operation to re-assign IPv6 Ranges to your Linodes.\n\n> 📘\n>\n> - A Linode can only have one IPv6 range targeting its SLAAC address.\n> - An account can only have one IPv6 range in each [region](https://techdocs.akamai.com/linode-api/reference/get-regions).\n> - [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) to request expansion of these restrictions.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli networking v6-range-create \\\n  --linode_id 123 \\\n  --prefix_length 64\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    ips:read_write\nlinodes:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/post-ipv6-range"
@@ -78335,7 +78235,7 @@
                     "type": "integer"
                   },
                   "route_target": {
-                    "description": "The IPv6 SLAAC address to assign this range to.\n\n- __Required__ if `linode_id` is omitted from the request.\n\n- Mutually exclusive with `linode_id`. Submitting values for both properties in a request results in an error.\n\n- __Note__. Omit the `/128` prefix length of the SLAAC address when using this property.",
+                    "description": "The IPv6 SLAAC address to assign this range to.\n\n- __Required__ if `linode_id` is omitted from the request.\n\n- Mutually exclusive with `linode_id`. Submitting values for both properties in a request results in an error.\n\n> 📘\n>\n> You need to omit the `/128` prefix length of the SLAAC address when using this property.",
                     "example": "{{route_target}}",
                     "format": "ipv6",
                     "type": "string"
@@ -78518,7 +78418,7 @@
                           },
                           "range": {
                             "description": "__Read-only__ The IPv6 address of this range.",
-                            "example": "2001:db8:feb2:50f1:62f1:8579:241c:4928",
+                            "example": "2001:db8:5827:2f1b:d9b3:1ae2:a8e8:49f",
                             "readOnly": true,
                             "type": "string",
                             "x-linode-cli-display": 1
@@ -78532,7 +78432,7 @@
                           },
                           "route_target": {
                             "description": "The IPv6 SLAAC address.",
-                            "example": "2001:db8:b199:15c2:18c0:b6c5:8a5f:c7f4",
+                            "example": "2001:db8:b18f:dcbb:ad4c:829e:2fce:1f81",
                             "type": "string"
                           }
                         },
@@ -78708,7 +78608,7 @@
                     },
                     "range": {
                       "description": "__Read-only__ The IPv6 address of this range.",
-                      "example": "2001:db8:a6ba:298:c7bd:bbf:392:834a",
+                      "example": "2001:db8:22f1:c0f9:b6ca:7bfa:367b:6b82",
                       "readOnly": true,
                       "type": "string",
                       "x-linode-cli-display": 1
@@ -78801,7 +78701,7 @@
         "x-linode-cli-action": "v6-range-view"
       },
       "delete": {
-        "description": "Removes this IPv6 range from your account and disconnects the range from any assigned Linodes.\n\n__Note__. Shared IPv6 ranges cannot be deleted at this time. Please contact Customer Support for assistance.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli networking v6-range-delete 2001:0db8::\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    ips:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Removes this IPv6 range from your account and disconnects the range from any assigned Linodes.\n\n> 📘\n>\n> You can't delete shared IPv6 ranges. Contact Customer Support for assistance.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli networking v6-range-delete 2001:0db8::\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    ips:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/delete-ipv6-range"
@@ -78912,7 +78812,7 @@
           }
         },
         {
-          "description": "The IPv6 range to access. Corresponds to the `range` property of objects returned from the [List IPv6 ranges](https://techdocs.akamai.com/linode-api/reference/get-ipv6-ranges) operation.\n\n__Note__. Omit the prefix length of the IPv6 range.",
+          "description": "The IPv6 range to access. Corresponds to the `range` property of objects returned from the [List IPv6 ranges](https://techdocs.akamai.com/linode-api/reference/get-ipv6-ranges) operation.\n\n> 📘\n>\n> You need to omit the prefix length of the IPv6 range.",
           "example": "{{range}}",
           "in": "path",
           "name": "range",
@@ -78934,7 +78834,7 @@
     },
     "/{apiVersion}/networking/vlans": {
       "get": {
-        "description": "Returns a list of all Virtual Local Area Networks (VLANs) on your Account. VLANs provide a mechanism for secure communication between two or more Linodes that are assigned to the same VLAN and are both within the same Layer 2 broadcast domain.\n\nVLANs are created and attached to Linodes by using the `interfaces` property for the following operations:\n\n- [Create a Linode](https://techdocs.akamai.com/linode-api/reference/post-linode-instance)\n- [Create a config profile](https://techdocs.akamai.com/linode-api/reference/post-add-linode-config)\n- [Update a config profile](https://techdocs.akamai.com/linode-api/reference/put-linode-config)\n\nThere are several ways to detach a VLAN from a Linode:\n\n- [Update](https://techdocs.akamai.com/linode-api/reference/put-linode-config) the active Configuration Profile to remove the VLAN Interface, then [reboot](https://techdocs.akamai.com/linode-api/reference/post-reboot-linode-instance) the Linode.\n- [Create a config profile](https://techdocs.akamai.com/linode-api/reference/post-add-linode-config) without the VLAN Interface, then [reboot](https://techdocs.akamai.com/linode-api/reference/post-reboot-linode-instance) the Linode into the new Configuration Profile.\n- [Delete](https://techdocs.akamai.com/linode-api/reference/delete-linode-instance) the Linode.\n\n__Note__. Only Next Generation Network (NGN) data centers support VLANs. Run the [List regions](https://techdocs.akamai.com/linode-api/reference/get-regions) operation to view the capabilities of data center regions. If a VLAN is attached to your Linode and you attempt to migrate or clone it to a non-NGN data center, the migration or cloning will not initiate. If a Linode cannot be migrated because of an incompatibility, you will be prompted to select a different data center or contact support.\n\n__Note__. See the [VLANs Overview](https://www.linode.com/docs/products/networking/vlans/#technical-specifications) to view additional specifications and limitations.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli vlans list\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    linodes:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Returns a list of all Virtual Local Area Networks (VLANs) on your Account. VLANs provide a mechanism for secure communication between two or more Linodes that are assigned to the same VLAN and are both within the same Layer 2 broadcast domain.\n\nVLANs are created and attached to Linodes by using the `interfaces` property for the following operations:\n\n- [Create a Linode](https://techdocs.akamai.com/linode-api/reference/post-linode-instance)\n- [Create a config profile](https://techdocs.akamai.com/linode-api/reference/post-add-linode-config)\n- [Update a config profile](https://techdocs.akamai.com/linode-api/reference/put-linode-config)\n\nThere are several ways to detach a VLAN from a Linode:\n\n- [Update](https://techdocs.akamai.com/linode-api/reference/put-linode-config) the active Configuration Profile to remove the VLAN Interface, then [reboot](https://techdocs.akamai.com/linode-api/reference/post-reboot-linode-instance) the Linode.\n- [Create a config profile](https://techdocs.akamai.com/linode-api/reference/post-add-linode-config) without the VLAN Interface, then [reboot](https://techdocs.akamai.com/linode-api/reference/post-reboot-linode-instance) the Linode into the new Configuration Profile.\n- [Delete](https://techdocs.akamai.com/linode-api/reference/delete-linode-instance) the Linode.\n\n> 📘\n>\n> - Only Next Generation Network (NGN) data centers support VLANs. Run the [List regions](https://techdocs.akamai.com/linode-api/reference/get-regions) operation to view the capabilities of data center regions. If a VLAN is attached to your Linode and you attempt to migrate or clone it to a non-NGN data center, the migration or cloning won't initiate. If a Linode cannot be migrated because of an incompatibility, you will be prompted to select a different data center or contact support.\n>\n> - See the [VLANs Overview](https://www.linode.com/docs/products/networking/vlans/#technical-specifications) to view additional specifications and limitations.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli vlans list\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    linodes:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-vlans"
@@ -79020,7 +78920,7 @@
                             "x-linode-cli-display": 3
                           },
                           "region": {
-                            "description": "__Filterable__, __Read-only__ This VLAN's data center region.\n\n__Note__. Currently, a VLAN can only be assigned to a Linode within the same data center region.",
+                            "description": "__Filterable__, __Read-only__ This VLAN's data center region.\n\n> 📘\n>\n> Currently, a VLAN can only be assigned to a Linode within the same data center region.",
                             "example": "ap-west",
                             "readOnly": true,
                             "type": "string",
@@ -79345,7 +79245,7 @@
                     "maximum": 20,
                     "minimum": 0,
                     "type": "integer",
-                    "x-linode-cli-display": 7
+                    "x-linode-cli-display": 9
                   },
                   "configs": {
                     "description": "The port configs to create for this NodeBalancer. Each config needs a unique port and at least one node.",
@@ -79369,7 +79269,7 @@
                             },
                             "check": {
                               "default": "none",
-                              "description": "The type of check to perform against backends to ensure they are serving requests. This is used to determine if backends are up or down.\n\n- If `none`, no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
+                              "description": "The type of check to perform against backends to ensure they are serving requests. The `check` is used to determine if backends are up or down.\n\n- If `none`, no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
                               "enum": [
                                 "none",
                                 "connection",
@@ -79422,8 +79322,8 @@
                               "type": "integer"
                             },
                             "cipher_suite": {
-                              "description": "__Read-only__ Not applicable for HTTP configs.",
-                              "example": "recommended",
+                              "description": "__Read-only__ Not applicable for TCP configs.",
+                              "example": "none",
                               "readOnly": true,
                               "type": "string",
                               "x-linode-cli-color": {
@@ -79613,11 +79513,10 @@
                             },
                             "stickiness": {
                               "default": "none",
-                              "description": "__Read-only__ Controls how session stickiness is handled on this port.\n\nNot applicable to TCP configurations.",
+                              "description": "__Read-only__ Controls how session stickiness is handled on this port.\n\n- If set to `none`, connections will always be assigned a backend based on the algorithm configured.\n- If set to `table`, sessions from the same remote address will be routed to the same backend.",
                               "enum": [
                                 "none",
-                                "table",
-                                "http_cookie"
+                                "table"
                               ],
                               "example": "none",
                               "readOnly": true,
@@ -79838,7 +79737,7 @@
                             },
                             "port": {
                               "default": 80,
-                              "description": "This is the port the NodeBalancer listens on for this configuration. Port numbers need to be unique across TCP, HTTP, and HTTPS configurations on a single NodeBalancer. However, ports assigned to TCP, HTTP, or HTTPS configurations can also be reused for UDP configurations. For example, Port 80 can simultaneously serve a TCP and a UDP configuration on the same NodeBalancer, but it can't be shared by both a TCP and an HTTP configuration. Although certain ports are traditionally associated with specific protocols, this is not strictly enforced. You may configure your NodeBalancer however is useful to you.",
+                              "description": "This is the port the NodeBalancer listens on for this configuration. Port numbers need to be unique across TCP, HTTP, and HTTPS configurations on a single NodeBalancer. However, ports assigned to TCP, HTTP, or HTTPS configurations can also be reused for UDP configurations. For example, Port 80 can simultaneously serve a TCP and a UDP configuration on the same NodeBalancer, but it can't be shared by both a TCP and an HTTP configuration. Although certain ports are traditionally associated with specific protocols, this isn't strictly enforced. You may configure your NodeBalancer however you find useful.",
                               "example": 80,
                               "maximum": 65535,
                               "minimum": 1,
@@ -79930,7 +79829,7 @@
                             },
                             "check": {
                               "default": "none",
-                              "description": "The type of check to perform against backends to ensure they are serving requests. This is used to determine if backends are up or down.\n\n- If `none` no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
+                              "description": "The type of check to perform against backends to ensure they are serving requests. The `check` is used to determine if backends are up or down.\n\n- If `none` no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
                               "enum": [
                                 "none",
                                 "connection",
@@ -80159,7 +80058,7 @@
                               "x-linode-cli-display": 8
                             },
                             "ssl_fingerprint": {
-                              "description": "__Read-only__ The read-only SHA1-encoded fingerprint automatically derived from the SSL certificate assigned to this NodeBalancerConfig. Please refer to this field to verify that the appropriate certificate is assigned to your NodeBalancerConfig.",
+                              "description": "__Read-only__ The read-only SHA1-encoded fingerprint automatically derived from the SSL certificate assigned to this NodeBalancer configuration. Please refer to the `ssl_fingerprint` field to verify that the appropriate certificate is assigned to your NodeBalancer configuration.",
                               "example": "00:01:02:03:04:05:06:07:08:09:0A:0B:0C:0D:0E:0F:10:11:12:13",
                               "readOnly": true,
                               "type": "string",
@@ -80269,7 +80168,7 @@
                       "maximum": 20,
                       "minimum": 0,
                       "type": "integer",
-                      "x-linode-cli-display": 7
+                      "x-linode-cli-display": 9
                     },
                     "created": {
                       "description": "__Read-only__ When this NodeBalancer was created.",
@@ -80283,7 +80182,7 @@
                       "example": "192.0.2.1.ip.linodeusercontent.com",
                       "readOnly": true,
                       "type": "string",
-                      "x-linode-cli-display": 4
+                      "x-linode-cli-display": 5
                     },
                     "id": {
                       "description": "__Read-only__ This NodeBalancer's unique ID.",
@@ -80294,7 +80193,7 @@
                     },
                     "ipv4": {
                       "description": "__Filterable__, __Read-only__ This NodeBalancer's public IPv4 address.",
-                      "example": "192.0.2.183",
+                      "example": "192.0.2.27",
                       "format": "ip",
                       "readOnly": true,
                       "type": "string",
@@ -80303,7 +80202,7 @@
                           "Filterable"
                         ]
                       },
-                      "x-linode-cli-display": 5,
+                      "x-linode-cli-display": 6,
                       "x-linode-filterable": true
                     },
                     "ipv6": {
@@ -80313,7 +80212,7 @@
                       "nullable": true,
                       "readOnly": true,
                       "type": "string",
-                      "x-linode-cli-display": 6
+                      "x-linode-cli-display": 7
                     },
                     "label": {
                       "description": "__Filterable__ This NodeBalancer's label. These must be unique on your Account.",
@@ -80329,6 +80228,36 @@
                       },
                       "x-linode-cli-display": 2,
                       "x-linode-filterable": true
+                    },
+                    "lke_cluster": {
+                      "description": "__Read-only__ This NodeBalancer's related LKE Cluster, if any. The value is `null` if this NodeBalancer isn't related to an LKE Cluster.",
+                      "nullable": true,
+                      "properties": {
+                        "id": {
+                          "description": "The ID of the related LKE Cluster.",
+                          "example": 12345,
+                          "type": "string"
+                        },
+                        "label": {
+                          "description": "The label of the related LKE Cluster.",
+                          "example": "lkecluster12345",
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "__Read-only__ The type for LKE Clusters.",
+                          "example": "lkecluster",
+                          "readOnly": true,
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "The URL where you can access the related LKE Cluster.",
+                          "example": "/v4/lke/clusters/12345",
+                          "type": "string"
+                        }
+                      },
+                      "readOnly": true,
+                      "type": "object",
+                      "x-linode-cli-display": 8
                     },
                     "region": {
                       "description": "__Filterable__, __Read-only__ The Region where this NodeBalancer is located. NodeBalancers only support backends in the same Region.",
@@ -80388,6 +80317,16 @@
                       },
                       "readOnly": true,
                       "type": "object"
+                    },
+                    "type": {
+                      "description": "__Read-only__ The type of NodeBalancer.",
+                      "enum": [
+                        "common"
+                      ],
+                      "example": "common",
+                      "readOnly": true,
+                      "type": "string",
+                      "x-linode-cli-display": 4
                     },
                     "updated": {
                       "description": "__Read-only__ When this NodeBalancer was last updated.",
@@ -80537,7 +80476,7 @@
                             "maximum": 20,
                             "minimum": 0,
                             "type": "integer",
-                            "x-linode-cli-display": 7
+                            "x-linode-cli-display": 9
                           },
                           "created": {
                             "description": "__Read-only__ When this NodeBalancer was created.",
@@ -80551,7 +80490,7 @@
                             "example": "192.0.2.1.ip.linodeusercontent.com",
                             "readOnly": true,
                             "type": "string",
-                            "x-linode-cli-display": 4
+                            "x-linode-cli-display": 5
                           },
                           "id": {
                             "description": "__Read-only__ This NodeBalancer's unique ID.",
@@ -80562,7 +80501,7 @@
                           },
                           "ipv4": {
                             "description": "__Filterable__, __Read-only__ This NodeBalancer's public IPv4 address.",
-                            "example": "192.0.2.199",
+                            "example": "192.0.2.251",
                             "format": "ip",
                             "readOnly": true,
                             "type": "string",
@@ -80571,7 +80510,7 @@
                                 "Filterable"
                               ]
                             },
-                            "x-linode-cli-display": 5,
+                            "x-linode-cli-display": 6,
                             "x-linode-filterable": true
                           },
                           "ipv6": {
@@ -80581,7 +80520,7 @@
                             "nullable": true,
                             "readOnly": true,
                             "type": "string",
-                            "x-linode-cli-display": 6
+                            "x-linode-cli-display": 7
                           },
                           "label": {
                             "description": "__Filterable__ This NodeBalancer's label. These must be unique on your Account.",
@@ -80597,6 +80536,36 @@
                             },
                             "x-linode-cli-display": 2,
                             "x-linode-filterable": true
+                          },
+                          "lke_cluster": {
+                            "description": "__Read-only__ This NodeBalancer's related LKE Cluster, if any. The value is `null` if this NodeBalancer isn't related to an LKE Cluster.",
+                            "nullable": true,
+                            "properties": {
+                              "id": {
+                                "description": "The ID of the related LKE Cluster.",
+                                "example": 12345,
+                                "type": "string"
+                              },
+                              "label": {
+                                "description": "The label of the related LKE Cluster.",
+                                "example": "lkecluster12345",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "__Read-only__ The type for LKE Clusters.",
+                                "example": "lkecluster",
+                                "readOnly": true,
+                                "type": "string"
+                              },
+                              "url": {
+                                "description": "The URL where you can access the related LKE Cluster.",
+                                "example": "/v4/lke/clusters/12345",
+                                "type": "string"
+                              }
+                            },
+                            "readOnly": true,
+                            "type": "object",
+                            "x-linode-cli-display": 8
                           },
                           "region": {
                             "description": "__Filterable__, __Read-only__ The Region where this NodeBalancer is located. NodeBalancers only support backends in the same Region.",
@@ -80656,6 +80625,16 @@
                             },
                             "readOnly": true,
                             "type": "object"
+                          },
+                          "type": {
+                            "description": "__Read-only__ The type of NodeBalancer.",
+                            "enum": [
+                              "common"
+                            ],
+                            "example": "common",
+                            "readOnly": true,
+                            "type": "string",
+                            "x-linode-cli-display": 4
                           },
                           "updated": {
                             "description": "__Read-only__ When this NodeBalancer was last updated.",
@@ -81058,7 +81037,7 @@
                       "maximum": 20,
                       "minimum": 0,
                       "type": "integer",
-                      "x-linode-cli-display": 7
+                      "x-linode-cli-display": 9
                     },
                     "created": {
                       "description": "__Read-only__ When this NodeBalancer was created.",
@@ -81072,7 +81051,7 @@
                       "example": "192.0.2.1.ip.linodeusercontent.com",
                       "readOnly": true,
                       "type": "string",
-                      "x-linode-cli-display": 4
+                      "x-linode-cli-display": 5
                     },
                     "id": {
                       "description": "__Read-only__ This NodeBalancer's unique ID.",
@@ -81083,7 +81062,7 @@
                     },
                     "ipv4": {
                       "description": "__Filterable__, __Read-only__ This NodeBalancer's public IPv4 address.",
-                      "example": "192.0.2.212",
+                      "example": "192.0.2.216",
                       "format": "ip",
                       "readOnly": true,
                       "type": "string",
@@ -81092,7 +81071,7 @@
                           "Filterable"
                         ]
                       },
-                      "x-linode-cli-display": 5,
+                      "x-linode-cli-display": 6,
                       "x-linode-filterable": true
                     },
                     "ipv6": {
@@ -81102,7 +81081,7 @@
                       "nullable": true,
                       "readOnly": true,
                       "type": "string",
-                      "x-linode-cli-display": 6
+                      "x-linode-cli-display": 7
                     },
                     "label": {
                       "description": "__Filterable__ This NodeBalancer's label. These must be unique on your Account.",
@@ -81118,6 +81097,36 @@
                       },
                       "x-linode-cli-display": 2,
                       "x-linode-filterable": true
+                    },
+                    "lke_cluster": {
+                      "description": "__Read-only__ This NodeBalancer's related LKE Cluster, if any. The value is `null` if this NodeBalancer isn't related to an LKE Cluster.",
+                      "nullable": true,
+                      "properties": {
+                        "id": {
+                          "description": "The ID of the related LKE Cluster.",
+                          "example": 12345,
+                          "type": "string"
+                        },
+                        "label": {
+                          "description": "The label of the related LKE Cluster.",
+                          "example": "lkecluster12345",
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "__Read-only__ The type for LKE Clusters.",
+                          "example": "lkecluster",
+                          "readOnly": true,
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "The URL where you can access the related LKE Cluster.",
+                          "example": "/v4/lke/clusters/12345",
+                          "type": "string"
+                        }
+                      },
+                      "readOnly": true,
+                      "type": "object",
+                      "x-linode-cli-display": 8
                     },
                     "region": {
                       "description": "__Filterable__, __Read-only__ The Region where this NodeBalancer is located. NodeBalancers only support backends in the same Region.",
@@ -81177,6 +81186,16 @@
                       },
                       "readOnly": true,
                       "type": "object"
+                    },
+                    "type": {
+                      "description": "__Read-only__ The type of NodeBalancer.",
+                      "enum": [
+                        "common"
+                      ],
+                      "example": "common",
+                      "readOnly": true,
+                      "type": "string",
+                      "x-linode-cli-display": 4
                     },
                     "updated": {
                       "description": "__Read-only__ When this NodeBalancer was last updated.",
@@ -81287,7 +81306,7 @@
                     "maximum": 20,
                     "minimum": 0,
                     "type": "integer",
-                    "x-linode-cli-display": 7
+                    "x-linode-cli-display": 9
                   },
                   "created": {
                     "description": "__Read-only__ When this NodeBalancer was created.",
@@ -81301,7 +81320,7 @@
                     "example": "{{hostname}}",
                     "readOnly": true,
                     "type": "string",
-                    "x-linode-cli-display": 4
+                    "x-linode-cli-display": 5
                   },
                   "id": {
                     "description": "__Read-only__ This NodeBalancer's unique ID.",
@@ -81321,7 +81340,7 @@
                         "Filterable"
                       ]
                     },
-                    "x-linode-cli-display": 5,
+                    "x-linode-cli-display": 6,
                     "x-linode-filterable": true
                   },
                   "ipv6": {
@@ -81331,7 +81350,7 @@
                     "nullable": true,
                     "readOnly": true,
                     "type": "string",
-                    "x-linode-cli-display": 6
+                    "x-linode-cli-display": 7
                   },
                   "label": {
                     "description": "__Filterable__ This NodeBalancer's label. These must be unique on your Account.",
@@ -81347,6 +81366,36 @@
                     },
                     "x-linode-cli-display": 2,
                     "x-linode-filterable": true
+                  },
+                  "lke_cluster": {
+                    "description": "__Read-only__ This NodeBalancer's related LKE Cluster, if any. The value is `null` if this NodeBalancer isn't related to an LKE Cluster.",
+                    "nullable": true,
+                    "properties": {
+                      "id": {
+                        "description": "The ID of the related LKE Cluster.",
+                        "example": 12345,
+                        "type": "string"
+                      },
+                      "label": {
+                        "description": "The label of the related LKE Cluster.",
+                        "example": "lkecluster12345",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "__Read-only__ The type for LKE Clusters.",
+                        "example": "lkecluster",
+                        "readOnly": true,
+                        "type": "string"
+                      },
+                      "url": {
+                        "description": "The URL where you can access the related LKE Cluster.",
+                        "example": "/v4/lke/clusters/12345",
+                        "type": "string"
+                      }
+                    },
+                    "readOnly": true,
+                    "type": "object",
+                    "x-linode-cli-display": 8
                   },
                   "region": {
                     "description": "__Filterable__, __Read-only__ The Region where this NodeBalancer is located. NodeBalancers only support backends in the same Region.",
@@ -81407,6 +81456,16 @@
                     "readOnly": true,
                     "type": "object"
                   },
+                  "type": {
+                    "description": "__Read-only__ The type of NodeBalancer.",
+                    "enum": [
+                      "common"
+                    ],
+                    "example": "{{type}}",
+                    "readOnly": true,
+                    "type": "string",
+                    "x-linode-cli-display": 4
+                  },
                   "updated": {
                     "description": "__Read-only__ When this NodeBalancer was last updated.",
                     "example": "{{updated}}",
@@ -81443,7 +81502,7 @@
                       "maximum": 20,
                       "minimum": 0,
                       "type": "integer",
-                      "x-linode-cli-display": 7
+                      "x-linode-cli-display": 9
                     },
                     "created": {
                       "description": "__Read-only__ When this NodeBalancer was created.",
@@ -81457,7 +81516,7 @@
                       "example": "192.0.2.1.ip.linodeusercontent.com",
                       "readOnly": true,
                       "type": "string",
-                      "x-linode-cli-display": 4
+                      "x-linode-cli-display": 5
                     },
                     "id": {
                       "description": "__Read-only__ This NodeBalancer's unique ID.",
@@ -81468,7 +81527,7 @@
                     },
                     "ipv4": {
                       "description": "__Filterable__, __Read-only__ This NodeBalancer's public IPv4 address.",
-                      "example": "192.0.2.158",
+                      "example": "192.0.2.48",
                       "format": "ip",
                       "readOnly": true,
                       "type": "string",
@@ -81477,7 +81536,7 @@
                           "Filterable"
                         ]
                       },
-                      "x-linode-cli-display": 5,
+                      "x-linode-cli-display": 6,
                       "x-linode-filterable": true
                     },
                     "ipv6": {
@@ -81487,7 +81546,7 @@
                       "nullable": true,
                       "readOnly": true,
                       "type": "string",
-                      "x-linode-cli-display": 6
+                      "x-linode-cli-display": 7
                     },
                     "label": {
                       "description": "__Filterable__ This NodeBalancer's label. These must be unique on your Account.",
@@ -81503,6 +81562,36 @@
                       },
                       "x-linode-cli-display": 2,
                       "x-linode-filterable": true
+                    },
+                    "lke_cluster": {
+                      "description": "__Read-only__ This NodeBalancer's related LKE Cluster, if any. The value is `null` if this NodeBalancer isn't related to an LKE Cluster.",
+                      "nullable": true,
+                      "properties": {
+                        "id": {
+                          "description": "The ID of the related LKE Cluster.",
+                          "example": 12345,
+                          "type": "string"
+                        },
+                        "label": {
+                          "description": "The label of the related LKE Cluster.",
+                          "example": "lkecluster12345",
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "__Read-only__ The type for LKE Clusters.",
+                          "example": "lkecluster",
+                          "readOnly": true,
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "The URL where you can access the related LKE Cluster.",
+                          "example": "/v4/lke/clusters/12345",
+                          "type": "string"
+                        }
+                      },
+                      "readOnly": true,
+                      "type": "object",
+                      "x-linode-cli-display": 8
                     },
                     "region": {
                       "description": "__Filterable__, __Read-only__ The Region where this NodeBalancer is located. NodeBalancers only support backends in the same Region.",
@@ -81562,6 +81651,16 @@
                       },
                       "readOnly": true,
                       "type": "object"
+                    },
+                    "type": {
+                      "description": "__Read-only__ The type of NodeBalancer.",
+                      "enum": [
+                        "common"
+                      ],
+                      "example": "common",
+                      "readOnly": true,
+                      "type": "string",
+                      "x-linode-cli-display": 4
                     },
                     "updated": {
                       "description": "__Read-only__ When this NodeBalancer was last updated.",
@@ -81819,7 +81918,7 @@
                       },
                       "check": {
                         "default": "none",
-                        "description": "The type of check to perform against backends to ensure they are serving requests. This is used to determine if backends are up or down.\n\n- If `none`, no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
+                        "description": "The type of check to perform against backends to ensure they are serving requests. The `check` is used to determine if backends are up or down.\n\n- If `none`, no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
                         "enum": [
                           "none",
                           "connection",
@@ -81872,8 +81971,8 @@
                         "type": "integer"
                       },
                       "cipher_suite": {
-                        "description": "__Read-only__ Not applicable for HTTP configs.",
-                        "example": "recommended",
+                        "description": "__Read-only__ Not applicable for TCP configs.",
+                        "example": "none",
                         "readOnly": true,
                         "type": "string",
                         "x-linode-cli-color": {
@@ -82063,11 +82162,10 @@
                       },
                       "stickiness": {
                         "default": "none",
-                        "description": "__Read-only__ Controls how session stickiness is handled on this port.\n\nNot applicable to TCP configurations.",
+                        "description": "__Read-only__ Controls how session stickiness is handled on this port.\n\n- If set to `none`, connections will always be assigned a backend based on the algorithm configured.\n- If set to `table`, sessions from the same remote address will be routed to the same backend.",
                         "enum": [
                           "none",
-                          "table",
-                          "http_cookie"
+                          "table"
                         ],
                         "example": "none",
                         "readOnly": true,
@@ -82288,7 +82386,7 @@
                       },
                       "port": {
                         "default": 80,
-                        "description": "This is the port the NodeBalancer listens on for this configuration. Port numbers need to be unique across TCP, HTTP, and HTTPS configurations on a single NodeBalancer. However, ports assigned to TCP, HTTP, or HTTPS configurations can also be reused for UDP configurations. For example, Port 80 can simultaneously serve a TCP and a UDP configuration on the same NodeBalancer, but it can't be shared by both a TCP and an HTTP configuration. Although certain ports are traditionally associated with specific protocols, this is not strictly enforced. You may configure your NodeBalancer however is useful to you.",
+                        "description": "This is the port the NodeBalancer listens on for this configuration. Port numbers need to be unique across TCP, HTTP, and HTTPS configurations on a single NodeBalancer. However, ports assigned to TCP, HTTP, or HTTPS configurations can also be reused for UDP configurations. For example, Port 80 can simultaneously serve a TCP and a UDP configuration on the same NodeBalancer, but it can't be shared by both a TCP and an HTTP configuration. Although certain ports are traditionally associated with specific protocols, this isn't strictly enforced. You may configure your NodeBalancer however you find useful.",
                         "example": 80,
                         "maximum": 65535,
                         "minimum": 1,
@@ -82380,7 +82478,7 @@
                       },
                       "check": {
                         "default": "none",
-                        "description": "The type of check to perform against backends to ensure they are serving requests. This is used to determine if backends are up or down.\n\n- If `none` no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
+                        "description": "The type of check to perform against backends to ensure they are serving requests. The `check` is used to determine if backends are up or down.\n\n- If `none` no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
                         "enum": [
                           "none",
                           "connection",
@@ -82609,7 +82707,7 @@
                         "x-linode-cli-display": 8
                       },
                       "ssl_fingerprint": {
-                        "description": "__Read-only__ The read-only SHA1-encoded fingerprint automatically derived from the SSL certificate assigned to this NodeBalancerConfig. Please refer to this field to verify that the appropriate certificate is assigned to your NodeBalancerConfig.",
+                        "description": "__Read-only__ The read-only SHA1-encoded fingerprint automatically derived from the SSL certificate assigned to this NodeBalancer configuration. Please refer to the `ssl_fingerprint` field to verify that the appropriate certificate is assigned to your NodeBalancer configuration.",
                         "example": "00:01:02:03:04:05:06:07:08:09:0A:0B:0C:0D:0E:0F:10:11:12:13",
                         "readOnly": true,
                         "type": "string",
@@ -82815,7 +82913,7 @@
                     "x-linode-cli-display": 8
                   },
                   "ssl_fingerprint": {
-                    "description": "__Read-only__ The read-only SHA1-encoded fingerprint automatically derived from the SSL certificate assigned to this NodeBalancer config. Please refer to this field to verify that the appropriate certificate is assigned to your config.",
+                    "description": "__Read-only__ The read-only SHA1-encoded fingerprint automatically derived from the SSL certificate assigned to this NodeBalancer configuration. You can use the `ssl_fingerprint` field to verify that the appropriate certificate is assigned to your NodeBalancer configuration.",
                     "example": "00:01:02:03:04:05:06:07:08:09:0A:0B:0C:0D:0E:0F:10:11:12:13",
                     "readOnly": true,
                     "type": "string",
@@ -82875,7 +82973,7 @@
                         },
                         "check": {
                           "default": "none",
-                          "description": "The type of check to perform against backends to ensure they are serving requests. This is used to determine if backends are up or down.\n\n- If `none`, no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
+                          "description": "The type of check to perform against backends to ensure they are serving requests. This determines if backends are up or down.\n\n- If `none`, no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
                           "enum": [
                             "none",
                             "connection",
@@ -82908,13 +83006,13 @@
                         },
                         "check_passive": {
                           "default": true,
-                          "description": "If `true`, any response from this backend with a `5xx` status code will be enough for it to be considered unhealthy and taken out of rotation.",
+                          "description": "If `true`, any response from this backend with a `5xx` status code is enough for it to be considered unhealthy and taken out of rotation.",
                           "example": true,
                           "type": "boolean",
                           "x-linode-cli-display": 6
                         },
                         "check_path": {
-                          "description": "The URL path to check on each backend. If the backend does not respond to this request it is considered to be down.",
+                          "description": "The URL path to check on each backend. If the backend does not respond to this request, it's considered to be down.",
                           "example": "/test",
                           "pattern": "^[a-zA-Z0-9\\/\\-%?&=.]*$",
                           "type": "string"
@@ -82928,8 +83026,8 @@
                           "type": "integer"
                         },
                         "cipher_suite": {
-                          "description": "__Read-only__ Not applicable for HTTP configs.",
-                          "example": "recommended",
+                          "description": "__Read-only__ Not applicable for `tcp` configs.",
+                          "example": "none",
                           "readOnly": true,
                           "type": "string",
                           "x-linode-cli-color": {
@@ -82950,93 +83048,6 @@
                           "example": 12345,
                           "readOnly": true,
                           "type": "integer"
-                        },
-                        "nodes": {
-                          "description": "The NodeBalancer nodes that serve this configuration.",
-                          "items": {
-                            "additionalProperties": false,
-                            "description": "A NodeBalancer node represents a single backend serving requests for a single port of a NodeBalancer.  Nodes are specific to NodeBalancer configs, and serve traffic over their private IP.  If the same Linode is serving traffic for more than one port on the same NodeBalancer, one NodeBalancer node is required for each config (port) it should serve requests on.  For example, if you have four backends, and each should respond to both HTTP and HTTPS requests, you will need two NodeBalancer configs (port 80 and port 443) and four backends each, one for each of the Linodes serving requests for that port.",
-                            "properties": {
-                              "address": {
-                                "description": "The private IP Address where this backend can be reached. This _must_ be a private IP address.",
-                                "example": "192.168.210.120:80",
-                                "format": "ip",
-                                "type": "string",
-                                "x-linode-cli-display": 3
-                              },
-                              "config_id": {
-                                "description": "__Read-only__ The NodeBalancer Config ID that this Node belongs to.",
-                                "example": 4567,
-                                "readOnly": true,
-                                "type": "integer"
-                              },
-                              "id": {
-                                "description": "__Read-only__ This node's unique ID.",
-                                "example": 54321,
-                                "readOnly": true,
-                                "type": "integer",
-                                "x-linode-cli-display": 1
-                              },
-                              "label": {
-                                "description": "The label for this node.  This is for display purposes only.",
-                                "example": "node54321",
-                                "maxLength": 32,
-                                "minLength": 3,
-                                "pattern": "[a-zA-Z0-9-_.]{3,32}",
-                                "type": "string",
-                                "x-linode-cli-display": 2
-                              },
-                              "mode": {
-                                "description": "The mode this NodeBalancer should use when sending traffic to this backend.\n\n- If set to `accept` this backend is accepting traffic.\n- If set to `reject` this backend will not receive traffic.\n- If set to `drain` this backend will not receive _new_ traffic, but connections already pinned to it will continue to be routed to it.\n- If set to `backup`, this backend will only receive traffic if all `accept` nodes are down.",
-                                "enum": [
-                                  "accept",
-                                  "reject",
-                                  "drain",
-                                  "backup"
-                                ],
-                                "example": "accept",
-                                "type": "string",
-                                "x-linode-cli-display": 6
-                              },
-                              "nodebalancer_id": {
-                                "description": "__Read-only__ The NodeBalancer ID that this Node belongs to.",
-                                "example": 12345,
-                                "readOnly": true,
-                                "type": "integer"
-                              },
-                              "status": {
-                                "description": "__Read-only__ The current status of this node, based on the configured checks of its NodeBalancer Config.",
-                                "enum": [
-                                  "unknown",
-                                  "UP",
-                                  "DOWN"
-                                ],
-                                "example": "UP",
-                                "readOnly": true,
-                                "type": "string",
-                                "x-linode-cli-color": {
-                                  "DOWN": "red",
-                                  "UP": "green",
-                                  "default_": "white",
-                                  "unknown": "yellow"
-                                },
-                                "x-linode-cli-display": 4
-                              },
-                              "weight": {
-                                "description": "Used when picking a backend to serve a request and is not pinned to a single backend yet.  Nodes with a higher weight will receive more traffic.",
-                                "example": 50,
-                                "maximum": 255,
-                                "minimum": 1,
-                                "type": "integer",
-                                "x-linode-cli-display": 5
-                              }
-                            },
-                            "title": "TCP, HTTP, or HTTPS config",
-                            "x-akamai": {
-                              "file-path": "schemas/node-balancer-node-tcp-http-https.yaml"
-                            }
-                          },
-                          "type": "array"
                         },
                         "nodes_status": {
                           "additionalProperties": false,
@@ -83070,7 +83081,7 @@
                         },
                         "protocol": {
                           "default": "http",
-                          "description": "The protocol the port is configured to serve, `tcp` in this case.\n\nReview our guide on [Available protocols](https://techdocs.akamai.com/cloud-computing/docs/available-protocols) for information on protocol features.",
+                          "description": "The protocol the port is configured to serve, `tcp` in this case. Review our guide on [Available protocols](https://techdocs.akamai.com/cloud-computing/docs/available-protocols) for information on protocol features.",
                           "enum": [
                             "tcp"
                           ],
@@ -83137,7 +83148,7 @@
                       "title": "TCP",
                       "type": "object",
                       "x-akamai": {
-                        "file-path": "schemas/node-balancer-config-tcp.yaml"
+                        "file-path": "schemas/node-balancer-config-tcp-response.yaml"
                       }
                     },
                     {
@@ -83177,7 +83188,7 @@
                           "type": "integer"
                         },
                         "check_body": {
-                          "description": "Use when the active health `check` type is `http_body`. This value must be present in the response body of the check in order for it to pass. If this value is not present in the response body of a check request, the backend is considered to be down.",
+                          "description": "Use when the active health `check` type is `http_body`. This value needs to be in the response body of the check in order for it to pass. Otherwise the backend is considered to be down.",
                           "example": "it works",
                           "type": "string"
                         },
@@ -83211,8 +83222,8 @@
                           "type": "integer"
                         },
                         "cipher_suite": {
-                          "description": "__Read-only__ Not applicable for HTTP configs.",
-                          "example": "recommended",
+                          "description": "__Read-only__ Not applicable for `http` configs.",
+                          "example": "none",
                           "readOnly": true,
                           "type": "string",
                           "x-linode-cli-color": {
@@ -83233,93 +83244,6 @@
                           "example": 12345,
                           "readOnly": true,
                           "type": "integer"
-                        },
-                        "nodes": {
-                          "description": "The NodeBalancer nodes that serve this configuration.",
-                          "items": {
-                            "additionalProperties": false,
-                            "description": "A NodeBalancer node represents a single backend serving requests for a single port of a NodeBalancer.  Nodes are specific to NodeBalancer configs, and serve traffic over their private IP.  If the same Linode is serving traffic for more than one port on the same NodeBalancer, one NodeBalancer node is required for each config (port) it should serve requests on.  For example, if you have four backends, and each should respond to both HTTP and HTTPS requests, you will need two NodeBalancer configs (port 80 and port 443) and four backends each, one for each of the Linodes serving requests for that port.",
-                            "properties": {
-                              "address": {
-                                "description": "The private IP Address where this backend can be reached. This _must_ be a private IP address.",
-                                "example": "192.168.210.120:80",
-                                "format": "ip",
-                                "type": "string",
-                                "x-linode-cli-display": 3
-                              },
-                              "config_id": {
-                                "description": "__Read-only__ The NodeBalancer Config ID that this Node belongs to.",
-                                "example": 4567,
-                                "readOnly": true,
-                                "type": "integer"
-                              },
-                              "id": {
-                                "description": "__Read-only__ This node's unique ID.",
-                                "example": 54321,
-                                "readOnly": true,
-                                "type": "integer",
-                                "x-linode-cli-display": 1
-                              },
-                              "label": {
-                                "description": "The label for this node.  This is for display purposes only.",
-                                "example": "node54321",
-                                "maxLength": 32,
-                                "minLength": 3,
-                                "pattern": "[a-zA-Z0-9-_.]{3,32}",
-                                "type": "string",
-                                "x-linode-cli-display": 2
-                              },
-                              "mode": {
-                                "description": "The mode this NodeBalancer should use when sending traffic to this backend.\n\n- If set to `accept` this backend is accepting traffic.\n- If set to `reject` this backend will not receive traffic.\n- If set to `drain` this backend will not receive _new_ traffic, but connections already pinned to it will continue to be routed to it.\n- If set to `backup`, this backend will only receive traffic if all `accept` nodes are down.",
-                                "enum": [
-                                  "accept",
-                                  "reject",
-                                  "drain",
-                                  "backup"
-                                ],
-                                "example": "accept",
-                                "type": "string",
-                                "x-linode-cli-display": 6
-                              },
-                              "nodebalancer_id": {
-                                "description": "__Read-only__ The NodeBalancer ID that this Node belongs to.",
-                                "example": 12345,
-                                "readOnly": true,
-                                "type": "integer"
-                              },
-                              "status": {
-                                "description": "__Read-only__ The current status of this node, based on the configured checks of its NodeBalancer Config.",
-                                "enum": [
-                                  "unknown",
-                                  "UP",
-                                  "DOWN"
-                                ],
-                                "example": "UP",
-                                "readOnly": true,
-                                "type": "string",
-                                "x-linode-cli-color": {
-                                  "DOWN": "red",
-                                  "UP": "green",
-                                  "default_": "white",
-                                  "unknown": "yellow"
-                                },
-                                "x-linode-cli-display": 4
-                              },
-                              "weight": {
-                                "description": "Used when picking a backend to serve a request and is not pinned to a single backend yet.  Nodes with a higher weight will receive more traffic.",
-                                "example": 50,
-                                "maximum": 255,
-                                "minimum": 1,
-                                "type": "integer",
-                                "x-linode-cli-display": 5
-                              }
-                            },
-                            "title": "TCP, HTTP, or HTTPS config",
-                            "x-akamai": {
-                              "file-path": "schemas/node-balancer-node-tcp-http-https.yaml"
-                            }
-                          },
-                          "type": "array"
                         },
                         "nodes_status": {
                           "additionalProperties": false,
@@ -83344,7 +83268,7 @@
                         },
                         "port": {
                           "default": 80,
-                          "description": "This is the port the NodeBalancer listens on for this configuration. Port numbers need to be unique across TCP, HTTP, and HTTPS configurations on a single NodeBalancer. However, ports assigned to TCP, HTTP, or HTTPS configurations can also be reused for UDP configurations. For example, Port 80 can simultaneously serve a TCP and a UDP configuration on the same NodeBalancer, but it can't be shared by both a TCP and an HTTP configuration. Although certain ports are traditionally associated with specific protocols, this is not strictly enforced. You may configure your NodeBalancer however is useful to you.",
+                          "description": "This is the port the NodeBalancer listens on for this configuration. Port numbers need to be unique across TCP, HTTP, and HTTPS configurations on a single NodeBalancer. However, ports assigned to TCP, HTTP, or HTTPS configurations can also be reused for UDP configurations. For example, Port 80 can simultaneously serve a TCP and a UDP configuration on the same NodeBalancer, but it can't be shared by both a TCP and an HTTP configuration. Although certain ports are traditionally associated with specific protocols, this isn't strictly enforced. You may configure your NodeBalancer however you find useful.",
                           "example": 80,
                           "maximum": 65535,
                           "minimum": 1,
@@ -83353,7 +83277,7 @@
                         },
                         "protocol": {
                           "default": "http",
-                          "description": "The protocol the port is configured to serve, `http` in this case.\nReview our guide on [Available protocols](https://techdocs.akamai.com/cloud-computing/docs/available-protocols) for information on protocol features.",
+                          "description": "The protocol the port is configured to serve, `http` in this case. Review our guide on [Available protocols](https://techdocs.akamai.com/cloud-computing/docs/available-protocols) for information on protocol features.",
                           "enum": [
                             "http"
                           ],
@@ -83398,7 +83322,7 @@
                         },
                         "stickiness": {
                           "default": "table",
-                          "description": "Controls how session stickiness is handled on this port.\n\n- If set to `none`, connections will always be assigned a backend based on the algorithm configured.\n- If set to `table`, sessions from the same remote address will be routed to the same backend.\n- If set to `http_cookie`, sessions are routed to the same backend based on a cookie set by the NodeBalancer.",
+                          "description": "Controls how session stickiness is handled on this port.\n\n- If set to `none`, connections are always assigned a backend based on the algorithm configured.\n- If set to `table`, sessions from the same remote address are routed to the same backend.\n- If set to `http_cookie`, sessions are routed to the same backend based on a cookie set by the NodeBalancer.",
                           "enum": [
                             "none",
                             "table",
@@ -83415,7 +83339,7 @@
                       "title": "HTTP",
                       "type": "object",
                       "x-akamai": {
-                        "file-path": "schemas/node-balancer-config-http.yaml"
+                        "file-path": "schemas/node-balancer-config-http-response.yaml"
                       }
                     },
                     {
@@ -83436,7 +83360,7 @@
                         },
                         "check": {
                           "default": "none",
-                          "description": "The type of check to perform against backends to ensure they are serving requests. This is used to determine if backends are up or down.\n\n- If `none` no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
+                          "description": "The type of check to perform against backends to ensure they are serving requests. The `check` is used to determine if backends are up or down.\n\n- If `none` no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
                           "enum": [
                             "none",
                             "connection",
@@ -83461,7 +83385,7 @@
                         },
                         "check_interval": {
                           "default": 5,
-                          "description": "How often, in seconds, to check that backends are up and serving requests.\n\nMust be greater than `check_timeout`.",
+                          "description": "The number of seconds between each check that backends are up and serving requests.\n\nMust be greater than `check_timeout`.",
                           "example": 90,
                           "maximum": 3600,
                           "minimum": 2,
@@ -83490,7 +83414,7 @@
                         },
                         "cipher_suite": {
                           "default": "recommended",
-                          "description": "What ciphers to use for SSL connections served by this NodeBalancer.\n\n- `legacy` is considered insecure and should only be used if necessary.",
+                          "description": "What ciphers to use for SSL connections served by this NodeBalancer. The `legacy` cipher is considered insecure and should only be used if necessary. For information on recommended and legacy ciphers, see [TLS cipher suites](https://techdocs.akamai.com/cloud-computing/docs/tls-ssl-termination-on-nodebalancers#tls-cipher-suites).",
                           "enum": [
                             "recommended",
                             "legacy"
@@ -83515,93 +83439,6 @@
                           "example": 12345,
                           "readOnly": true,
                           "type": "integer"
-                        },
-                        "nodes": {
-                          "description": "The NodeBalancer nodes that serve this configuration.",
-                          "items": {
-                            "additionalProperties": false,
-                            "description": "A NodeBalancer node represents a single backend serving requests for a single port of a NodeBalancer.  Nodes are specific to NodeBalancer configs, and serve traffic over their private IP.  If the same Linode is serving traffic for more than one port on the same NodeBalancer, one NodeBalancer node is required for each config (port) it should serve requests on.  For example, if you have four backends, and each should respond to both HTTP and HTTPS requests, you will need two NodeBalancer configs (port 80 and port 443) and four backends each, one for each of the Linodes serving requests for that port.",
-                            "properties": {
-                              "address": {
-                                "description": "The private IP Address where this backend can be reached. This _must_ be a private IP address.",
-                                "example": "192.168.210.120:80",
-                                "format": "ip",
-                                "type": "string",
-                                "x-linode-cli-display": 3
-                              },
-                              "config_id": {
-                                "description": "__Read-only__ The NodeBalancer Config ID that this Node belongs to.",
-                                "example": 4567,
-                                "readOnly": true,
-                                "type": "integer"
-                              },
-                              "id": {
-                                "description": "__Read-only__ This node's unique ID.",
-                                "example": 54321,
-                                "readOnly": true,
-                                "type": "integer",
-                                "x-linode-cli-display": 1
-                              },
-                              "label": {
-                                "description": "The label for this node.  This is for display purposes only.",
-                                "example": "node54321",
-                                "maxLength": 32,
-                                "minLength": 3,
-                                "pattern": "[a-zA-Z0-9-_.]{3,32}",
-                                "type": "string",
-                                "x-linode-cli-display": 2
-                              },
-                              "mode": {
-                                "description": "The mode this NodeBalancer should use when sending traffic to this backend.\n\n- If set to `accept` this backend is accepting traffic.\n- If set to `reject` this backend will not receive traffic.\n- If set to `drain` this backend will not receive _new_ traffic, but connections already pinned to it will continue to be routed to it.\n- If set to `backup`, this backend will only receive traffic if all `accept` nodes are down.",
-                                "enum": [
-                                  "accept",
-                                  "reject",
-                                  "drain",
-                                  "backup"
-                                ],
-                                "example": "accept",
-                                "type": "string",
-                                "x-linode-cli-display": 6
-                              },
-                              "nodebalancer_id": {
-                                "description": "__Read-only__ The NodeBalancer ID that this Node belongs to.",
-                                "example": 12345,
-                                "readOnly": true,
-                                "type": "integer"
-                              },
-                              "status": {
-                                "description": "__Read-only__ The current status of this node, based on the configured checks of its NodeBalancer Config.",
-                                "enum": [
-                                  "unknown",
-                                  "UP",
-                                  "DOWN"
-                                ],
-                                "example": "UP",
-                                "readOnly": true,
-                                "type": "string",
-                                "x-linode-cli-color": {
-                                  "DOWN": "red",
-                                  "UP": "green",
-                                  "default_": "white",
-                                  "unknown": "yellow"
-                                },
-                                "x-linode-cli-display": 4
-                              },
-                              "weight": {
-                                "description": "Used when picking a backend to serve a request and is not pinned to a single backend yet.  Nodes with a higher weight will receive more traffic.",
-                                "example": 50,
-                                "maximum": 255,
-                                "minimum": 1,
-                                "type": "integer",
-                                "x-linode-cli-display": 5
-                              }
-                            },
-                            "title": "TCP, HTTP, or HTTPS config",
-                            "x-akamai": {
-                              "file-path": "schemas/node-balancer-node-tcp-http-https.yaml"
-                            }
-                          },
-                          "type": "array"
                         },
                         "nodes_status": {
                           "additionalProperties": false,
@@ -83635,7 +83472,7 @@
                         },
                         "protocol": {
                           "default": "http",
-                          "description": "The protocol the port is configured to serve, `https` in this case.\n\n- The `https` protocol is mutually required with `ssl_cert` and `ssl_key`.\n\nReview our guide on [Available protocols](https://techdocs.akamai.com/cloud-computing/docs/available-protocols) for information on protocol features.",
+                          "description": "The protocol the port is configured to serve, `https` in this case. Review our guide on [Available protocols](https://techdocs.akamai.com/cloud-computing/docs/available-protocols) for information on protocol features. The `https` protocol needs to be specified with both `ssl_cert` and `ssl_key`.",
                           "enum": [
                             "https"
                           ],
@@ -83665,7 +83502,7 @@
                           "x-linode-cli-display": 8
                         },
                         "ssl_fingerprint": {
-                          "description": "__Read-only__ The read-only SHA1-encoded fingerprint automatically derived from the SSL certificate assigned to this NodeBalancerConfig. Please refer to this field to verify that the appropriate certificate is assigned to your NodeBalancerConfig.",
+                          "description": "__Read-only__ The read-only SHA1-encoded fingerprint automatically derived from the SSL certificate assigned to this NodeBalancer configuration. Please refer to the `ssl_fingerprint` field to verify that the appropriate certificate is assigned to your NodeBalancer configuration.",
                           "example": "00:01:02:03:04:05:06:07:08:09:0A:0B:0C:0D:0E:0F:10:11:12:13",
                           "readOnly": true,
                           "type": "string",
@@ -83697,12 +83534,12 @@
                       "title": "HTTPS",
                       "type": "object",
                       "x-akamai": {
-                        "file-path": "schemas/node-balancer-config-https.yaml"
+                        "file-path": "schemas/node-balancer-config-https-response.yaml"
                       }
                     }
                   ],
                   "x-akamai": {
-                    "file-path": "schemas/node-balancer-config.yaml"
+                    "file-path": "schemas/node-balancer-config-response.yaml"
                   }
                 },
                 "x-example": {
@@ -83871,7 +83708,7 @@
                       "x-linode-cli-display": 8
                     },
                     "ssl_fingerprint": {
-                      "description": "__Read-only__ The read-only SHA1-encoded fingerprint automatically derived from the SSL certificate assigned to this NodeBalancer config. Please refer to this field to verify that the appropriate certificate is assigned to your config.",
+                      "description": "__Read-only__ The read-only SHA1-encoded fingerprint automatically derived from the SSL certificate assigned to this NodeBalancer configuration. You can use the `ssl_fingerprint` field to verify that the appropriate certificate is assigned to your NodeBalancer configuration.",
                       "example": "00:01:02:03:04:05:06:07:08:09:0A:0B:0C:0D:0E:0F:10:11:12:13",
                       "readOnly": true,
                       "type": "string",
@@ -84030,884 +83867,593 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "data": {
-                      "items": {
-                        "description": "NodeBalancer `config` options for each protocol.",
-                        "oneOf": [
-                          {
-                            "additionalProperties": false,
-                            "description": "A NodeBalancer configuration defines the protocol and settings for a specific port on the NodeBalancer. These fields apply to TCP configurations.",
-                            "properties": {
-                              "algorithm": {
-                                "default": "roundrobin",
-                                "description": "The algorithm this TCP NodeBalancer uses to route traffic to backends.",
-                                "enum": [
-                                  "roundrobin",
-                                  "leastconn",
-                                  "source"
-                                ],
-                                "example": "leastconn",
-                                "type": "string",
-                                "x-linode-cli-display": 4
-                              },
-                              "check": {
-                                "default": "none",
-                                "description": "The type of check to perform against backends to ensure they are serving requests. This is used to determine if backends are up or down.\n\n- If `none`, no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
-                                "enum": [
-                                  "none",
-                                  "connection",
-                                  "http",
-                                  "http_body"
-                                ],
-                                "example": "http_body",
-                                "type": "string"
-                              },
-                              "check_attempts": {
-                                "default": 3,
-                                "description": "How many times to attempt a check before considering a backend to be down.",
-                                "example": 3,
-                                "maximum": 30,
-                                "minimum": 1,
-                                "type": "integer"
-                              },
-                              "check_body": {
-                                "description": "This value must be present in the response body of the check in order for it to pass. If this value is not present in the response body of a check request, the backend is considered to be down.",
-                                "example": "it works",
-                                "type": "string"
-                              },
-                              "check_interval": {
-                                "default": 5,
-                                "description": "How often, in seconds, to check that backends are up and serving requests.\n\nMust be greater than `check_timeout`.",
-                                "example": 90,
-                                "maximum": 3600,
-                                "minimum": 2,
-                                "type": "integer"
-                              },
-                              "check_passive": {
-                                "default": true,
-                                "description": "If `true`, any response from this backend with a `5xx` status code will be enough for it to be considered unhealthy and taken out of rotation.",
-                                "example": true,
-                                "type": "boolean",
-                                "x-linode-cli-display": 6
-                              },
-                              "check_path": {
-                                "description": "The URL path to check on each backend. If the backend does not respond to this request it is considered to be down.",
-                                "example": "/test",
-                                "pattern": "^[a-zA-Z0-9\\/\\-%?&=.]*$",
-                                "type": "string"
-                              },
-                              "check_timeout": {
-                                "default": 30,
-                                "description": "How long, in seconds, to wait for a check attempt before considering it failed.\n\nMust be less than `check_interval`.",
-                                "example": 10,
-                                "maximum": 30,
-                                "minimum": 1,
-                                "type": "integer"
-                              },
-                              "cipher_suite": {
-                                "description": "__Read-only__ Not applicable for HTTP configs.",
-                                "example": "recommended",
-                                "readOnly": true,
-                                "type": "string",
-                                "x-linode-cli-color": {
-                                  "default_": "white",
-                                  "legacy": "red"
-                                },
-                                "x-linode-cli-display": 7
-                              },
-                              "id": {
-                                "description": "__Read-only__ This config's unique ID.",
-                                "example": 6000,
-                                "readOnly": true,
-                                "type": "integer",
-                                "x-linode-cli-display": 1
-                              },
-                              "nodebalancer_id": {
-                                "description": "__Read-only__ The ID for the NodeBalancer this config belongs to.",
-                                "example": 12345,
-                                "readOnly": true,
-                                "type": "integer"
-                              },
-                              "nodes": {
-                                "description": "The NodeBalancer nodes that serve this configuration.",
-                                "items": {
-                                  "additionalProperties": false,
-                                  "description": "A NodeBalancer node represents a single backend serving requests for a single port of a NodeBalancer.  Nodes are specific to NodeBalancer configs, and serve traffic over their private IP.  If the same Linode is serving traffic for more than one port on the same NodeBalancer, one NodeBalancer node is required for each config (port) it should serve requests on.  For example, if you have four backends, and each should respond to both HTTP and HTTPS requests, you will need two NodeBalancer configs (port 80 and port 443) and four backends each, one for each of the Linodes serving requests for that port.",
-                                  "properties": {
-                                    "address": {
-                                      "description": "The private IP Address where this backend can be reached. This _must_ be a private IP address.",
-                                      "example": "192.168.210.120:80",
-                                      "format": "ip",
-                                      "type": "string",
-                                      "x-linode-cli-display": 3
-                                    },
-                                    "config_id": {
-                                      "description": "__Read-only__ The NodeBalancer Config ID that this Node belongs to.",
-                                      "example": 4567,
-                                      "readOnly": true,
-                                      "type": "integer"
-                                    },
-                                    "id": {
-                                      "description": "__Read-only__ This node's unique ID.",
-                                      "example": 54321,
-                                      "readOnly": true,
-                                      "type": "integer",
-                                      "x-linode-cli-display": 1
-                                    },
-                                    "label": {
-                                      "description": "The label for this node.  This is for display purposes only.",
-                                      "example": "node54321",
-                                      "maxLength": 32,
-                                      "minLength": 3,
-                                      "pattern": "[a-zA-Z0-9-_.]{3,32}",
-                                      "type": "string",
-                                      "x-linode-cli-display": 2
-                                    },
-                                    "mode": {
-                                      "description": "The mode this NodeBalancer should use when sending traffic to this backend.\n\n- If set to `accept` this backend is accepting traffic.\n- If set to `reject` this backend will not receive traffic.\n- If set to `drain` this backend will not receive _new_ traffic, but connections already pinned to it will continue to be routed to it.\n- If set to `backup`, this backend will only receive traffic if all `accept` nodes are down.",
-                                      "enum": [
-                                        "accept",
-                                        "reject",
-                                        "drain",
-                                        "backup"
-                                      ],
-                                      "example": "accept",
-                                      "type": "string",
-                                      "x-linode-cli-display": 6
-                                    },
-                                    "nodebalancer_id": {
-                                      "description": "__Read-only__ The NodeBalancer ID that this Node belongs to.",
-                                      "example": 12345,
-                                      "readOnly": true,
-                                      "type": "integer"
-                                    },
-                                    "status": {
-                                      "description": "__Read-only__ The current status of this node, based on the configured checks of its NodeBalancer Config.",
-                                      "enum": [
-                                        "unknown",
-                                        "UP",
-                                        "DOWN"
-                                      ],
-                                      "example": "UP",
-                                      "readOnly": true,
-                                      "type": "string",
-                                      "x-linode-cli-color": {
-                                        "DOWN": "red",
-                                        "UP": "green",
-                                        "default_": "white",
-                                        "unknown": "yellow"
-                                      },
-                                      "x-linode-cli-display": 4
-                                    },
-                                    "weight": {
-                                      "description": "Used when picking a backend to serve a request and is not pinned to a single backend yet.  Nodes with a higher weight will receive more traffic.",
-                                      "example": 50,
-                                      "maximum": 255,
-                                      "minimum": 1,
-                                      "type": "integer",
-                                      "x-linode-cli-display": 5
-                                    }
-                                  },
-                                  "title": "TCP, HTTP, or HTTPS config",
-                                  "x-akamai": {
-                                    "file-path": "schemas/node-balancer-node-tcp-http-https.yaml"
-                                  }
-                                },
-                                "type": "array"
-                              },
-                              "nodes_status": {
-                                "additionalProperties": false,
-                                "description": "__Read-only__ Describes the health of the backends for this port. This data updates periodically as checks are performed against backends.",
-                                "properties": {
-                                  "down": {
-                                    "description": "__Read-only__ The number of backends considered to be `DOWN` and unhealthy.  These are not in rotation, and not serving requests.",
-                                    "example": 0,
-                                    "readOnly": true,
-                                    "type": "integer"
-                                  },
-                                  "up": {
-                                    "description": "__Read-only__ The number of backends considered to be `UP` and healthy, and that are serving requests.",
-                                    "example": 4,
-                                    "readOnly": true,
-                                    "type": "integer"
-                                  }
-                                },
-                                "readOnly": true,
-                                "type": "object",
-                                "x-linode-cli-display": 10
-                              },
-                              "port": {
-                                "default": 80,
-                                "description": "This is the port the NodeBalancer listens on for this configuration. Port numbers must be unique across TCP, HTTP, and HTTPS configurations on a single NodeBalancer. However, ports assigned to TCP, HTTP, or HTTPS configurations can also be reused for UDP configurations. For example, Port 80 can simultaneously serve a TCP and a UDP configuration on the same NodeBalancer, but it can't be shared by both a TCP and an HTTP configuration. Although certain ports are traditionally associated with specific protocols, this isn't strictly enforced, and you may configure your NodeBalancer however you find useful.",
-                                "example": 22,
-                                "maximum": 65535,
-                                "minimum": 1,
-                                "type": "integer",
-                                "x-linode-cli-display": 2
-                              },
-                              "protocol": {
-                                "default": "http",
-                                "description": "The protocol the port is configured to serve, `tcp` in this case.\n\nReview our guide on [Available protocols](https://techdocs.akamai.com/cloud-computing/docs/available-protocols) for information on protocol features.",
-                                "enum": [
-                                  "tcp"
-                                ],
-                                "example": "tcp",
-                                "type": "string",
-                                "x-linode-cli-display": 3
-                              },
-                              "proxy_protocol": {
-                                "default": "none",
-                                "description": "Proxy protocol is a TCP extension that sends initial TCP connection information such as source or destination IPs and ports to backend devices. Proxy protocol preserves initial TCP information that would be lost otherwise. Backend devices must be configured to work with `proxy_protocol` if enabled.\n\n- If omitted, or set to `none`, the NodeBalancer doesn't send any auxiliary data over TCP connections. This is the default.\n- If set to `v1`, the human-readable header format (Version 1) is used. Requires `tcp` protocol.\n- If set to `v2`, the binary header format (Version 2) is used. Requires `tcp` protocol.",
-                                "enum": [
-                                  "none",
-                                  "v1",
-                                  "v2"
-                                ],
-                                "example": "none",
-                                "type": "string"
-                              },
-                              "ssl_cert": {
-                                "description": "__Read-only__ Not applicable for TCP configs.",
-                                "example": null,
-                                "nullable": true,
-                                "readOnly": true,
-                                "type": "string"
-                              },
-                              "ssl_commonname": {
-                                "description": "__Read-only__ Not applicable for TCP configs.",
-                                "example": "",
-                                "readOnly": true,
-                                "type": "string",
-                                "x-linode-cli-display": 8
-                              },
-                              "ssl_fingerprint": {
-                                "description": "__Read-only__ Not applicable for TCP configs.",
-                                "example": "",
-                                "readOnly": true,
-                                "type": "string",
-                                "x-linode-cli-display": 9
-                              },
-                              "ssl_key": {
-                                "description": "__Read-only__ Not applicable for HTTP configs.",
-                                "example": null,
-                                "nullable": true,
-                                "readOnly": true,
-                                "type": "string"
-                              },
-                              "stickiness": {
-                                "default": "none",
-                                "description": "__Read-only__ Controls how session stickiness is handled on this port.\n\nNot applicable to TCP configurations.",
-                                "enum": [
-                                  "none",
-                                  "table",
-                                  "http_cookie"
-                                ],
-                                "example": "none",
-                                "readOnly": true,
-                                "type": "string",
-                                "x-linode-cli-display": 5
-                              }
+                  "description": "NodeBalancer `config` options for each protocol.",
+                  "oneOf": [
+                    {
+                      "additionalProperties": false,
+                      "description": "A NodeBalancer configuration defines the protocol and settings for a specific port on the NodeBalancer. These fields apply to TCP configurations.",
+                      "properties": {
+                        "algorithm": {
+                          "default": "roundrobin",
+                          "description": "The algorithm this TCP NodeBalancer uses to route traffic to backends.",
+                          "enum": [
+                            "roundrobin",
+                            "leastconn",
+                            "source"
+                          ],
+                          "example": "leastconn",
+                          "type": "string",
+                          "x-linode-cli-display": 4
+                        },
+                        "check": {
+                          "default": "none",
+                          "description": "The type of check to perform against backends to ensure they are serving requests. This determines if backends are up or down.\n\n- If `none`, no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
+                          "enum": [
+                            "none",
+                            "connection",
+                            "http",
+                            "http_body"
+                          ],
+                          "example": "http_body",
+                          "type": "string"
+                        },
+                        "check_attempts": {
+                          "default": 3,
+                          "description": "How many times to attempt a check before considering a backend to be down.",
+                          "example": 3,
+                          "maximum": 30,
+                          "minimum": 1,
+                          "type": "integer"
+                        },
+                        "check_body": {
+                          "description": "This value must be present in the response body of the check in order for it to pass. If this value is not present in the response body of a check request, the backend is considered to be down.",
+                          "example": "it works",
+                          "type": "string"
+                        },
+                        "check_interval": {
+                          "default": 5,
+                          "description": "How often, in seconds, to check that backends are up and serving requests.\n\nMust be greater than `check_timeout`.",
+                          "example": 90,
+                          "maximum": 3600,
+                          "minimum": 2,
+                          "type": "integer"
+                        },
+                        "check_passive": {
+                          "default": true,
+                          "description": "If `true`, any response from this backend with a `5xx` status code is enough for it to be considered unhealthy and taken out of rotation.",
+                          "example": true,
+                          "type": "boolean",
+                          "x-linode-cli-display": 6
+                        },
+                        "check_path": {
+                          "description": "The URL path to check on each backend. If the backend does not respond to this request, it's considered to be down.",
+                          "example": "/test",
+                          "pattern": "^[a-zA-Z0-9\\/\\-%?&=.]*$",
+                          "type": "string"
+                        },
+                        "check_timeout": {
+                          "default": 30,
+                          "description": "How long, in seconds, to wait for a check attempt before considering it failed.\n\nMust be less than `check_interval`.",
+                          "example": 10,
+                          "maximum": 30,
+                          "minimum": 1,
+                          "type": "integer"
+                        },
+                        "cipher_suite": {
+                          "description": "__Read-only__ Not applicable for `tcp` configs.",
+                          "example": "none",
+                          "readOnly": true,
+                          "type": "string",
+                          "x-linode-cli-color": {
+                            "default_": "white",
+                            "legacy": "red"
+                          },
+                          "x-linode-cli-display": 7
+                        },
+                        "id": {
+                          "description": "__Read-only__ This config's unique ID.",
+                          "example": 6000,
+                          "readOnly": true,
+                          "type": "integer",
+                          "x-linode-cli-display": 1
+                        },
+                        "nodebalancer_id": {
+                          "description": "__Read-only__ The ID for the NodeBalancer this config belongs to.",
+                          "example": 12345,
+                          "readOnly": true,
+                          "type": "integer"
+                        },
+                        "nodes_status": {
+                          "additionalProperties": false,
+                          "description": "__Read-only__ Describes the health of the backends for this port. This data updates periodically as checks are performed against backends.",
+                          "properties": {
+                            "down": {
+                              "description": "__Read-only__ The number of backends considered to be `DOWN` and unhealthy.  These are not in rotation, and not serving requests.",
+                              "example": 0,
+                              "readOnly": true,
+                              "type": "integer"
                             },
-                            "required": [
-                              "nodes"
-                            ],
-                            "title": "TCP",
-                            "type": "object",
-                            "x-akamai": {
-                              "file-path": "schemas/node-balancer-config-tcp.yaml"
+                            "up": {
+                              "description": "__Read-only__ The number of backends considered to be `UP` and healthy, and that are serving requests.",
+                              "example": 4,
+                              "readOnly": true,
+                              "type": "integer"
                             }
                           },
-                          {
-                            "additionalProperties": false,
-                            "description": "A NodeBalancer configuration defines the protocol and settings for a specific port on the NodeBalancer. These fields apply to HTTP configurations.",
-                            "properties": {
-                              "algorithm": {
-                                "default": "roundrobin",
-                                "description": "The algorithm this HTTP NodeBalancer uses for routing traffic to backends.",
-                                "enum": [
-                                  "roundrobin",
-                                  "leastconn",
-                                  "source"
-                                ],
-                                "example": "roundrobin",
-                                "type": "string",
-                                "x-linode-cli-display": 4
-                              },
-                              "check": {
-                                "default": "none",
-                                "description": "The type of check to perform against backends to ensure they are serving requests. This determines if backends are up or down.\n\n- If `none`, no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
-                                "enum": [
-                                  "none",
-                                  "connection",
-                                  "http",
-                                  "http_body"
-                                ],
-                                "example": "http_body",
-                                "type": "string"
-                              },
-                              "check_attempts": {
-                                "default": 3,
-                                "description": "How many times to attempt a check before considering a backend to be down.",
-                                "example": 3,
-                                "maximum": 30,
-                                "minimum": 1,
-                                "type": "integer"
-                              },
-                              "check_body": {
-                                "description": "Use when the active health `check` type is `http_body`. This value must be present in the response body of the check in order for it to pass. If this value is not present in the response body of a check request, the backend is considered to be down.",
-                                "example": "it works",
-                                "type": "string"
-                              },
-                              "check_interval": {
-                                "default": 5,
-                                "description": "How often, in seconds, to check that backends are up and serving requests.\n\nMust be greater than `check_timeout`.",
-                                "example": 90,
-                                "maximum": 3600,
-                                "minimum": 2,
-                                "type": "integer"
-                              },
-                              "check_passive": {
-                                "default": true,
-                                "description": "If `true`, any response from this backend with a `5xx` status code will be enough for it to be considered unhealthy and taken out of rotation.",
-                                "example": true,
-                                "type": "boolean",
-                                "x-linode-cli-display": 6
-                              },
-                              "check_path": {
-                                "description": "The URL path to check on each backend. Use when the active health `check` type is `http`. If the backend doesn't respond to this request, it's considered to be down.",
-                                "example": "/test",
-                                "pattern": "^[a-zA-Z0-9\\/\\-%?&=.]*$",
-                                "type": "string"
-                              },
-                              "check_timeout": {
-                                "default": 3,
-                                "description": "How long, in seconds, to wait for a check attempt before considering it failed.\n\nMust be less than `check_interval`.",
-                                "example": 10,
-                                "maximum": 30,
-                                "minimum": 1,
-                                "type": "integer"
-                              },
-                              "cipher_suite": {
-                                "description": "__Read-only__ Not applicable for HTTP configs.",
-                                "example": "recommended",
-                                "readOnly": true,
-                                "type": "string",
-                                "x-linode-cli-color": {
-                                  "default_": "white",
-                                  "legacy": "red"
-                                },
-                                "x-linode-cli-display": 7
-                              },
-                              "id": {
-                                "description": "__Read-only__ This config's unique ID.",
-                                "example": 4000,
-                                "readOnly": true,
-                                "type": "integer",
-                                "x-linode-cli-display": 1
-                              },
-                              "nodebalancer_id": {
-                                "description": "__Read-only__ Identifies the NodeBalancer this config belongs to.",
-                                "example": 12345,
-                                "readOnly": true,
-                                "type": "integer"
-                              },
-                              "nodes": {
-                                "description": "The NodeBalancer nodes that serve this configuration.",
-                                "items": {
-                                  "additionalProperties": false,
-                                  "description": "A NodeBalancer node represents a single backend serving requests for a single port of a NodeBalancer.  Nodes are specific to NodeBalancer configs, and serve traffic over their private IP.  If the same Linode is serving traffic for more than one port on the same NodeBalancer, one NodeBalancer node is required for each config (port) it should serve requests on.  For example, if you have four backends, and each should respond to both HTTP and HTTPS requests, you will need two NodeBalancer configs (port 80 and port 443) and four backends each, one for each of the Linodes serving requests for that port.",
-                                  "properties": {
-                                    "address": {
-                                      "description": "The private IP Address where this backend can be reached. This _must_ be a private IP address.",
-                                      "example": "192.168.210.120:80",
-                                      "format": "ip",
-                                      "type": "string",
-                                      "x-linode-cli-display": 3
-                                    },
-                                    "config_id": {
-                                      "description": "__Read-only__ The NodeBalancer Config ID that this Node belongs to.",
-                                      "example": 4567,
-                                      "readOnly": true,
-                                      "type": "integer"
-                                    },
-                                    "id": {
-                                      "description": "__Read-only__ This node's unique ID.",
-                                      "example": 54321,
-                                      "readOnly": true,
-                                      "type": "integer",
-                                      "x-linode-cli-display": 1
-                                    },
-                                    "label": {
-                                      "description": "The label for this node.  This is for display purposes only.",
-                                      "example": "node54321",
-                                      "maxLength": 32,
-                                      "minLength": 3,
-                                      "pattern": "[a-zA-Z0-9-_.]{3,32}",
-                                      "type": "string",
-                                      "x-linode-cli-display": 2
-                                    },
-                                    "mode": {
-                                      "description": "The mode this NodeBalancer should use when sending traffic to this backend.\n\n- If set to `accept` this backend is accepting traffic.\n- If set to `reject` this backend will not receive traffic.\n- If set to `drain` this backend will not receive _new_ traffic, but connections already pinned to it will continue to be routed to it.\n- If set to `backup`, this backend will only receive traffic if all `accept` nodes are down.",
-                                      "enum": [
-                                        "accept",
-                                        "reject",
-                                        "drain",
-                                        "backup"
-                                      ],
-                                      "example": "accept",
-                                      "type": "string",
-                                      "x-linode-cli-display": 6
-                                    },
-                                    "nodebalancer_id": {
-                                      "description": "__Read-only__ The NodeBalancer ID that this Node belongs to.",
-                                      "example": 12345,
-                                      "readOnly": true,
-                                      "type": "integer"
-                                    },
-                                    "status": {
-                                      "description": "__Read-only__ The current status of this node, based on the configured checks of its NodeBalancer Config.",
-                                      "enum": [
-                                        "unknown",
-                                        "UP",
-                                        "DOWN"
-                                      ],
-                                      "example": "UP",
-                                      "readOnly": true,
-                                      "type": "string",
-                                      "x-linode-cli-color": {
-                                        "DOWN": "red",
-                                        "UP": "green",
-                                        "default_": "white",
-                                        "unknown": "yellow"
-                                      },
-                                      "x-linode-cli-display": 4
-                                    },
-                                    "weight": {
-                                      "description": "Used when picking a backend to serve a request and is not pinned to a single backend yet.  Nodes with a higher weight will receive more traffic.",
-                                      "example": 50,
-                                      "maximum": 255,
-                                      "minimum": 1,
-                                      "type": "integer",
-                                      "x-linode-cli-display": 5
-                                    }
-                                  },
-                                  "title": "TCP, HTTP, or HTTPS config",
-                                  "x-akamai": {
-                                    "file-path": "schemas/node-balancer-node-tcp-http-https.yaml"
-                                  }
-                                },
-                                "type": "array"
-                              },
-                              "nodes_status": {
-                                "additionalProperties": false,
-                                "description": "__Read-only__ Describes the health of the backends for this port. This data updates periodically as checks are performed against backends.",
-                                "properties": {
-                                  "down": {
-                                    "description": "__Read-only__ The number of backends considered to be `DOWN` and unhealthy.  These are not in rotation, and not serving requests.",
-                                    "example": 0,
-                                    "readOnly": true,
-                                    "type": "integer"
-                                  },
-                                  "up": {
-                                    "description": "__Read-only__ The number of backends considered to be `UP` and healthy, and that are serving requests.",
-                                    "example": 4,
-                                    "readOnly": true,
-                                    "type": "integer"
-                                  }
-                                },
-                                "readOnly": true,
-                                "type": "object",
-                                "x-linode-cli-display": 10
-                              },
-                              "port": {
-                                "default": 80,
-                                "description": "This is the port the NodeBalancer listens on for this configuration. Port numbers need to be unique across TCP, HTTP, and HTTPS configurations on a single NodeBalancer. However, ports assigned to TCP, HTTP, or HTTPS configurations can also be reused for UDP configurations. For example, Port 80 can simultaneously serve a TCP and a UDP configuration on the same NodeBalancer, but it can't be shared by both a TCP and an HTTP configuration. Although certain ports are traditionally associated with specific protocols, this is not strictly enforced. You may configure your NodeBalancer however is useful to you.",
-                                "example": 80,
-                                "maximum": 65535,
-                                "minimum": 1,
-                                "type": "integer",
-                                "x-linode-cli-display": 2
-                              },
-                              "protocol": {
-                                "default": "http",
-                                "description": "The protocol the port is configured to serve, `http` in this case.\nReview our guide on [Available protocols](https://techdocs.akamai.com/cloud-computing/docs/available-protocols) for information on protocol features.",
-                                "enum": [
-                                  "http"
-                                ],
-                                "example": "http",
-                                "type": "string",
-                                "x-linode-cli-display": 3
-                              },
-                              "proxy_protocol": {
-                                "default": "none",
-                                "description": "__Read-only__ Not applicable for HTTP configs.",
-                                "example": "none",
-                                "readOnly": true,
-                                "type": "string"
-                              },
-                              "ssl_cert": {
-                                "description": "__Read-only__ Not applicable for HTTP configs.",
-                                "example": null,
-                                "nullable": true,
-                                "readOnly": true,
-                                "type": "string"
-                              },
-                              "ssl_commonname": {
-                                "description": "__Read-only__ Not applicable for HTTP configs.",
-                                "example": "",
-                                "readOnly": true,
-                                "type": "string",
-                                "x-linode-cli-display": 8
-                              },
-                              "ssl_fingerprint": {
-                                "description": "__Read-only__ Not applicable for HTTP configs.",
-                                "example": "",
-                                "readOnly": true,
-                                "type": "string",
-                                "x-linode-cli-display": 9
-                              },
-                              "ssl_key": {
-                                "description": "__Read-only__ Not applicable for HTTP configs.",
-                                "example": null,
-                                "nullable": true,
-                                "readOnly": true,
-                                "type": "string"
-                              },
-                              "stickiness": {
-                                "default": "table",
-                                "description": "Controls how session stickiness is handled on this port.\n\n- If set to `none`, connections will always be assigned a backend based on the algorithm configured.\n- If set to `table`, sessions from the same remote address will be routed to the same backend.\n- If set to `http_cookie`, sessions are routed to the same backend based on a cookie set by the NodeBalancer.",
-                                "enum": [
-                                  "none",
-                                  "table",
-                                  "http_cookie"
-                                ],
-                                "example": "http_cookie",
-                                "type": "string",
-                                "x-linode-cli-display": 5
-                              }
-                            },
-                            "required": [
-                              "nodes"
-                            ],
-                            "title": "HTTP",
-                            "type": "object",
-                            "x-akamai": {
-                              "file-path": "schemas/node-balancer-config-http.yaml"
-                            }
-                          },
-                          {
-                            "additionalProperties": false,
-                            "description": "A NodeBalancer configuration defines the protocol and settings for a specific port on the NodeBalancer. These fields apply to HTTPS configurations.",
-                            "properties": {
-                              "algorithm": {
-                                "default": "roundrobin",
-                                "description": "The algorithm this HTTPS NodeBalancer uses for routing traffic to backends.",
-                                "enum": [
-                                  "roundrobin",
-                                  "leastconn",
-                                  "source"
-                                ],
-                                "example": "roundrobin",
-                                "type": "string",
-                                "x-linode-cli-display": 4
-                              },
-                              "check": {
-                                "default": "none",
-                                "description": "The type of check to perform against backends to ensure they are serving requests. This is used to determine if backends are up or down.\n\n- If `none` no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
-                                "enum": [
-                                  "none",
-                                  "connection",
-                                  "http",
-                                  "http_body"
-                                ],
-                                "example": "http_body",
-                                "type": "string"
-                              },
-                              "check_attempts": {
-                                "default": 3,
-                                "description": "How many times to attempt a check before considering a backend to be down.",
-                                "example": 3,
-                                "maximum": 30,
-                                "minimum": 1,
-                                "type": "integer"
-                              },
-                              "check_body": {
-                                "description": "Use when the active health `check` type is `http_body`. This value must be present in the response body of the check in order for it to pass. If this value is not present in the response body of a check request, the backend is considered to be down.",
-                                "example": "it works",
-                                "type": "string"
-                              },
-                              "check_interval": {
-                                "default": 5,
-                                "description": "How often, in seconds, to check that backends are up and serving requests.\n\nMust be greater than `check_timeout`.",
-                                "example": 90,
-                                "maximum": 3600,
-                                "minimum": 2,
-                                "type": "integer"
-                              },
-                              "check_passive": {
-                                "default": true,
-                                "description": "If `true`, any response from this backend with a `5xx` status code will be enough for it to be considered unhealthy and taken out of rotation.",
-                                "example": true,
-                                "type": "boolean",
-                                "x-linode-cli-display": 6
-                              },
-                              "check_path": {
-                                "description": "The URL path to check on each backend. Use when the active health `check` type is `http`. If the backend doesn't respond to this request, it's considered to be down.",
-                                "example": "/test",
-                                "pattern": "^[a-zA-Z0-9\\/\\-%?&=.]*$",
-                                "type": "string"
-                              },
-                              "check_timeout": {
-                                "default": 3,
-                                "description": "How long, in seconds, to wait for a check attempt before considering it failed.\n\nMust be less than `check_interval`.",
-                                "example": 10,
-                                "maximum": 30,
-                                "minimum": 1,
-                                "type": "integer"
-                              },
-                              "cipher_suite": {
-                                "default": "recommended",
-                                "description": "What ciphers to use for SSL connections served by this NodeBalancer.\n\n- `legacy` is considered insecure and should only be used if necessary.",
-                                "enum": [
-                                  "recommended",
-                                  "legacy"
-                                ],
-                                "example": "recommended",
-                                "type": "string",
-                                "x-linode-cli-color": {
-                                  "default_": "white",
-                                  "legacy": "red"
-                                },
-                                "x-linode-cli-display": 7
-                              },
-                              "id": {
-                                "description": "__Read-only__ This config's unique ID.",
-                                "example": 5000,
-                                "readOnly": true,
-                                "type": "integer",
-                                "x-linode-cli-display": 1
-                              },
-                              "nodebalancer_id": {
-                                "description": "__Read-only__ The ID for the NodeBalancer this config belongs to.",
-                                "example": 12345,
-                                "readOnly": true,
-                                "type": "integer"
-                              },
-                              "nodes": {
-                                "description": "The NodeBalancer nodes that serve this configuration.",
-                                "items": {
-                                  "additionalProperties": false,
-                                  "description": "A NodeBalancer node represents a single backend serving requests for a single port of a NodeBalancer.  Nodes are specific to NodeBalancer configs, and serve traffic over their private IP.  If the same Linode is serving traffic for more than one port on the same NodeBalancer, one NodeBalancer node is required for each config (port) it should serve requests on.  For example, if you have four backends, and each should respond to both HTTP and HTTPS requests, you will need two NodeBalancer configs (port 80 and port 443) and four backends each, one for each of the Linodes serving requests for that port.",
-                                  "properties": {
-                                    "address": {
-                                      "description": "The private IP Address where this backend can be reached. This _must_ be a private IP address.",
-                                      "example": "192.168.210.120:80",
-                                      "format": "ip",
-                                      "type": "string",
-                                      "x-linode-cli-display": 3
-                                    },
-                                    "config_id": {
-                                      "description": "__Read-only__ The NodeBalancer Config ID that this Node belongs to.",
-                                      "example": 4567,
-                                      "readOnly": true,
-                                      "type": "integer"
-                                    },
-                                    "id": {
-                                      "description": "__Read-only__ This node's unique ID.",
-                                      "example": 54321,
-                                      "readOnly": true,
-                                      "type": "integer",
-                                      "x-linode-cli-display": 1
-                                    },
-                                    "label": {
-                                      "description": "The label for this node.  This is for display purposes only.",
-                                      "example": "node54321",
-                                      "maxLength": 32,
-                                      "minLength": 3,
-                                      "pattern": "[a-zA-Z0-9-_.]{3,32}",
-                                      "type": "string",
-                                      "x-linode-cli-display": 2
-                                    },
-                                    "mode": {
-                                      "description": "The mode this NodeBalancer should use when sending traffic to this backend.\n\n- If set to `accept` this backend is accepting traffic.\n- If set to `reject` this backend will not receive traffic.\n- If set to `drain` this backend will not receive _new_ traffic, but connections already pinned to it will continue to be routed to it.\n- If set to `backup`, this backend will only receive traffic if all `accept` nodes are down.",
-                                      "enum": [
-                                        "accept",
-                                        "reject",
-                                        "drain",
-                                        "backup"
-                                      ],
-                                      "example": "accept",
-                                      "type": "string",
-                                      "x-linode-cli-display": 6
-                                    },
-                                    "nodebalancer_id": {
-                                      "description": "__Read-only__ The NodeBalancer ID that this Node belongs to.",
-                                      "example": 12345,
-                                      "readOnly": true,
-                                      "type": "integer"
-                                    },
-                                    "status": {
-                                      "description": "__Read-only__ The current status of this node, based on the configured checks of its NodeBalancer Config.",
-                                      "enum": [
-                                        "unknown",
-                                        "UP",
-                                        "DOWN"
-                                      ],
-                                      "example": "UP",
-                                      "readOnly": true,
-                                      "type": "string",
-                                      "x-linode-cli-color": {
-                                        "DOWN": "red",
-                                        "UP": "green",
-                                        "default_": "white",
-                                        "unknown": "yellow"
-                                      },
-                                      "x-linode-cli-display": 4
-                                    },
-                                    "weight": {
-                                      "description": "Used when picking a backend to serve a request and is not pinned to a single backend yet.  Nodes with a higher weight will receive more traffic.",
-                                      "example": 50,
-                                      "maximum": 255,
-                                      "minimum": 1,
-                                      "type": "integer",
-                                      "x-linode-cli-display": 5
-                                    }
-                                  },
-                                  "title": "TCP, HTTP, or HTTPS config",
-                                  "x-akamai": {
-                                    "file-path": "schemas/node-balancer-node-tcp-http-https.yaml"
-                                  }
-                                },
-                                "type": "array"
-                              },
-                              "nodes_status": {
-                                "additionalProperties": false,
-                                "description": "__Read-only__ Describes the health of the backends for this port. This data updates periodically as checks are performed against backends.",
-                                "properties": {
-                                  "down": {
-                                    "description": "__Read-only__ The number of backends considered to be `DOWN` and unhealthy.  These are not in rotation, and not serving requests.",
-                                    "example": 0,
-                                    "readOnly": true,
-                                    "type": "integer"
-                                  },
-                                  "up": {
-                                    "description": "__Read-only__ The number of backends considered to be `UP` and healthy, and that are serving requests.",
-                                    "example": 4,
-                                    "readOnly": true,
-                                    "type": "integer"
-                                  }
-                                },
-                                "readOnly": true,
-                                "type": "object",
-                                "x-linode-cli-display": 10
-                              },
-                              "port": {
-                                "default": 80,
-                                "description": "This is the port the NodeBalancer listens on for this configuration. Port numbers must be unique across TCP, HTTP, and HTTPS configurations on a single NodeBalancer. However, ports assigned to TCP, HTTP, or HTTPS configurations can also be reused for UDP configurations. For example, Port 80 can simultaneously serve a TCP and a UDP configuration on the same NodeBalancer, but it can't be shared by both a TCP and an HTTP configuration. Although certain ports are traditionally associated with specific protocols, this isn't strictly enforced, and you may configure your NodeBalancer however you find useful.",
-                                "example": 443,
-                                "maximum": 65535,
-                                "minimum": 1,
-                                "type": "integer",
-                                "x-linode-cli-display": 2
-                              },
-                              "protocol": {
-                                "default": "http",
-                                "description": "The protocol the port is configured to serve, `https` in this case.\n\n- The `https` protocol is mutually required with `ssl_cert` and `ssl_key`.\n\nReview our guide on [Available protocols](https://techdocs.akamai.com/cloud-computing/docs/available-protocols) for information on protocol features.",
-                                "enum": [
-                                  "https"
-                                ],
-                                "example": "https",
-                                "type": "string",
-                                "x-linode-cli-display": 3
-                              },
-                              "proxy_protocol": {
-                                "default": "none",
-                                "description": "__Read-only__ Not applicable for HTTPS configs.",
-                                "example": "none",
-                                "readOnly": true,
-                                "type": "string"
-                              },
-                              "ssl_cert": {
-                                "description": "\nThe PEM-formatted public SSL certificate (or the combined PEM-formatted SSL certificate and Certificate Authority chain) that should be served on this NodeBalancerConfig's port.\n\nLine breaks must be represented as `\\n` in the string for requests (but not when using the Linode CLI).\n\n[Diffie-Hellman Parameters](https://www.linode.com/docs/products/networking/nodebalancers/guides/ssl-termination/#diffie-hellman-parameters) can be included in this value to enable forward secrecy.\n\nThe contents of this field will not be shown in any responses that display the NodeBalancerConfig. Instead, `<REDACTED>` will be printed where the field appears.\n\nThe read-only `ssl_commonname` and `ssl_fingerprint` fields in a NodeBalancerConfig response are automatically derived from your certificate. Please refer to these fields to verify that the appropriate certificate was assigned to your NodeBalancerConfig.",
-                                "example": "<REDACTED>",
-                                "format": "ssl-cert",
-                                "nullable": true,
-                                "type": "string"
-                              },
-                              "ssl_commonname": {
-                                "description": "__Read-only__ The read-only common name automatically derived from the SSL certificate assigned to this NodeBalancerConfig. Please refer to this field to verify that the appropriate certificate is assigned to your NodeBalancerConfig.",
-                                "example": "www.example.com",
-                                "readOnly": true,
-                                "type": "string",
-                                "x-linode-cli-display": 8
-                              },
-                              "ssl_fingerprint": {
-                                "description": "__Read-only__ The read-only SHA1-encoded fingerprint automatically derived from the SSL certificate assigned to this NodeBalancerConfig. Please refer to this field to verify that the appropriate certificate is assigned to your NodeBalancerConfig.",
-                                "example": "00:01:02:03:04:05:06:07:08:09:0A:0B:0C:0D:0E:0F:10:11:12:13",
-                                "readOnly": true,
-                                "type": "string",
-                                "x-linode-cli-display": 9
-                              },
-                              "ssl_key": {
-                                "description": "The PEM-formatted private key for the SSL certificate set in the `ssl_cert` field.\n\nLine breaks must be represented as `\\n` in the string for requests (but not when using the Linode CLI).\n\nThe contents of this field will not be shown in any responses that display\nthe NodeBalancerConfig. Instead, `<REDACTED>` will be printed where the field\nappears.\n\nThe read-only `ssl_commonname` and `ssl_fingerprint` fields in a NodeBalancerConfig\nresponse are automatically derived from your certificate. Please refer to these fields to\nverify that the appropriate certificate was assigned to your NodeBalancerConfig.",
-                                "example": "<REDACTED>",
-                                "format": "ssl-key",
-                                "nullable": true,
-                                "type": "string"
-                              },
-                              "stickiness": {
-                                "default": "table",
-                                "description": "Controls how session stickiness is handled on this port.\n\n- If set to `none`, connections will always be assigned a backend based on the algorithm configured.\n- If set to `table`, sessions from the same remote address will be routed to the same backend.\n- For HTTP or HTTPS clients, `http_cookie` allows sessions to be routed to the same backend based on a cookie set by the NodeBalancer.",
-                                "enum": [
-                                  "none",
-                                  "table",
-                                  "http_cookie"
-                                ],
-                                "example": "http_cookie",
-                                "type": "string",
-                                "x-linode-cli-display": 5
-                              }
-                            },
-                            "required": [
-                              "nodes"
-                            ],
-                            "title": "HTTPS",
-                            "type": "object",
-                            "x-akamai": {
-                              "file-path": "schemas/node-balancer-config-https.yaml"
-                            }
-                          }
-                        ],
-                        "x-akamai": {
-                          "file-path": "schemas/node-balancer-config.yaml"
+                          "readOnly": true,
+                          "type": "object",
+                          "x-linode-cli-display": 10
+                        },
+                        "port": {
+                          "default": 80,
+                          "description": "This is the port the NodeBalancer listens on for this configuration. Port numbers must be unique across TCP, HTTP, and HTTPS configurations on a single NodeBalancer. However, ports assigned to TCP, HTTP, or HTTPS configurations can also be reused for UDP configurations. For example, Port 80 can simultaneously serve a TCP and a UDP configuration on the same NodeBalancer, but it can't be shared by both a TCP and an HTTP configuration. Although certain ports are traditionally associated with specific protocols, this isn't strictly enforced, and you may configure your NodeBalancer however you find useful.",
+                          "example": 22,
+                          "maximum": 65535,
+                          "minimum": 1,
+                          "type": "integer",
+                          "x-linode-cli-display": 2
+                        },
+                        "protocol": {
+                          "default": "http",
+                          "description": "The protocol the port is configured to serve, `tcp` in this case. Review our guide on [Available protocols](https://techdocs.akamai.com/cloud-computing/docs/available-protocols) for information on protocol features.",
+                          "enum": [
+                            "tcp"
+                          ],
+                          "example": "tcp",
+                          "type": "string",
+                          "x-linode-cli-display": 3
+                        },
+                        "proxy_protocol": {
+                          "default": "none",
+                          "description": "Proxy protocol is a TCP extension that sends initial TCP connection information such as source or destination IPs and ports to backend devices. Proxy protocol preserves initial TCP information that would be lost otherwise. Backend devices must be configured to work with `proxy_protocol` if enabled.\n\n- If omitted, or set to `none`, the NodeBalancer doesn't send any auxiliary data over TCP connections. This is the default.\n- If set to `v1`, the human-readable header format (Version 1) is used. Requires `tcp` protocol.\n- If set to `v2`, the binary header format (Version 2) is used. Requires `tcp` protocol.",
+                          "enum": [
+                            "none",
+                            "v1",
+                            "v2"
+                          ],
+                          "example": "none",
+                          "type": "string"
+                        },
+                        "ssl_cert": {
+                          "description": "__Read-only__ Not applicable for TCP configs.",
+                          "example": null,
+                          "nullable": true,
+                          "readOnly": true,
+                          "type": "string"
+                        },
+                        "ssl_commonname": {
+                          "description": "__Read-only__ Not applicable for TCP configs.",
+                          "example": "",
+                          "readOnly": true,
+                          "type": "string",
+                          "x-linode-cli-display": 8
+                        },
+                        "ssl_fingerprint": {
+                          "description": "__Read-only__ Not applicable for TCP configs.",
+                          "example": "",
+                          "readOnly": true,
+                          "type": "string",
+                          "x-linode-cli-display": 9
+                        },
+                        "ssl_key": {
+                          "description": "__Read-only__ Not applicable for HTTP configs.",
+                          "example": null,
+                          "nullable": true,
+                          "readOnly": true,
+                          "type": "string"
+                        },
+                        "stickiness": {
+                          "default": "none",
+                          "description": "__Read-only__ Controls how session stickiness is handled on this port.\n\nNot applicable to TCP configurations.",
+                          "enum": [
+                            "none",
+                            "table",
+                            "http_cookie"
+                          ],
+                          "example": "none",
+                          "readOnly": true,
+                          "type": "string",
+                          "x-linode-cli-display": 5
                         }
                       },
-                      "type": "array"
+                      "required": [
+                        "nodes"
+                      ],
+                      "title": "TCP",
+                      "type": "object",
+                      "x-akamai": {
+                        "file-path": "schemas/node-balancer-config-tcp-response.yaml"
+                      }
                     },
-                    "page": {
-                      "description": "__Read-only__ The current [page](https://techdocs.akamai.com/linode-api/reference/pagination).",
-                      "example": 1,
-                      "readOnly": true,
-                      "type": "integer"
+                    {
+                      "additionalProperties": false,
+                      "description": "A NodeBalancer configuration defines the protocol and settings for a specific port on the NodeBalancer. These fields apply to HTTP configurations.",
+                      "properties": {
+                        "algorithm": {
+                          "default": "roundrobin",
+                          "description": "The algorithm this HTTP NodeBalancer uses for routing traffic to backends.",
+                          "enum": [
+                            "roundrobin",
+                            "leastconn",
+                            "source"
+                          ],
+                          "example": "roundrobin",
+                          "type": "string",
+                          "x-linode-cli-display": 4
+                        },
+                        "check": {
+                          "default": "none",
+                          "description": "The type of check to perform against backends to ensure they are serving requests. This determines if backends are up or down.\n\n- If `none`, no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
+                          "enum": [
+                            "none",
+                            "connection",
+                            "http",
+                            "http_body"
+                          ],
+                          "example": "http_body",
+                          "type": "string"
+                        },
+                        "check_attempts": {
+                          "default": 3,
+                          "description": "How many times to attempt a check before considering a backend to be down.",
+                          "example": 3,
+                          "maximum": 30,
+                          "minimum": 1,
+                          "type": "integer"
+                        },
+                        "check_body": {
+                          "description": "Use when the active health `check` type is `http_body`. This value needs to be in the response body of the check in order for it to pass. Otherwise the backend is considered to be down.",
+                          "example": "it works",
+                          "type": "string"
+                        },
+                        "check_interval": {
+                          "default": 5,
+                          "description": "How often, in seconds, to check that backends are up and serving requests.\n\nMust be greater than `check_timeout`.",
+                          "example": 90,
+                          "maximum": 3600,
+                          "minimum": 2,
+                          "type": "integer"
+                        },
+                        "check_passive": {
+                          "default": true,
+                          "description": "If `true`, any response from this backend with a `5xx` status code will be enough for it to be considered unhealthy and taken out of rotation.",
+                          "example": true,
+                          "type": "boolean",
+                          "x-linode-cli-display": 6
+                        },
+                        "check_path": {
+                          "description": "The URL path to check on each backend. Use when the active health `check` type is `http`. If the backend doesn't respond to this request, it's considered to be down.",
+                          "example": "/test",
+                          "pattern": "^[a-zA-Z0-9\\/\\-%?&=.]*$",
+                          "type": "string"
+                        },
+                        "check_timeout": {
+                          "default": 3,
+                          "description": "How long, in seconds, to wait for a check attempt before considering it failed.\n\nMust be less than `check_interval`.",
+                          "example": 10,
+                          "maximum": 30,
+                          "minimum": 1,
+                          "type": "integer"
+                        },
+                        "cipher_suite": {
+                          "description": "__Read-only__ Not applicable for `http` configs.",
+                          "example": "none",
+                          "readOnly": true,
+                          "type": "string",
+                          "x-linode-cli-color": {
+                            "default_": "white",
+                            "legacy": "red"
+                          },
+                          "x-linode-cli-display": 7
+                        },
+                        "id": {
+                          "description": "__Read-only__ This config's unique ID.",
+                          "example": 4000,
+                          "readOnly": true,
+                          "type": "integer",
+                          "x-linode-cli-display": 1
+                        },
+                        "nodebalancer_id": {
+                          "description": "__Read-only__ Identifies the NodeBalancer this config belongs to.",
+                          "example": 12345,
+                          "readOnly": true,
+                          "type": "integer"
+                        },
+                        "nodes_status": {
+                          "additionalProperties": false,
+                          "description": "__Read-only__ Describes the health of the backends for this port. This data updates periodically as checks are performed against backends.",
+                          "properties": {
+                            "down": {
+                              "description": "__Read-only__ The number of backends considered to be `DOWN` and unhealthy.  These are not in rotation, and not serving requests.",
+                              "example": 0,
+                              "readOnly": true,
+                              "type": "integer"
+                            },
+                            "up": {
+                              "description": "__Read-only__ The number of backends considered to be `UP` and healthy, and that are serving requests.",
+                              "example": 4,
+                              "readOnly": true,
+                              "type": "integer"
+                            }
+                          },
+                          "readOnly": true,
+                          "type": "object",
+                          "x-linode-cli-display": 10
+                        },
+                        "port": {
+                          "default": 80,
+                          "description": "This is the port the NodeBalancer listens on for this configuration. Port numbers need to be unique across TCP, HTTP, and HTTPS configurations on a single NodeBalancer. However, ports assigned to TCP, HTTP, or HTTPS configurations can also be reused for UDP configurations. For example, Port 80 can simultaneously serve a TCP and a UDP configuration on the same NodeBalancer, but it can't be shared by both a TCP and an HTTP configuration. Although certain ports are traditionally associated with specific protocols, this isn't strictly enforced. You may configure your NodeBalancer however you find useful.",
+                          "example": 80,
+                          "maximum": 65535,
+                          "minimum": 1,
+                          "type": "integer",
+                          "x-linode-cli-display": 2
+                        },
+                        "protocol": {
+                          "default": "http",
+                          "description": "The protocol the port is configured to serve, `http` in this case. Review our guide on [Available protocols](https://techdocs.akamai.com/cloud-computing/docs/available-protocols) for information on protocol features.",
+                          "enum": [
+                            "http"
+                          ],
+                          "example": "http",
+                          "type": "string",
+                          "x-linode-cli-display": 3
+                        },
+                        "proxy_protocol": {
+                          "default": "none",
+                          "description": "__Read-only__ Not applicable for HTTP configs.",
+                          "example": "none",
+                          "readOnly": true,
+                          "type": "string"
+                        },
+                        "ssl_cert": {
+                          "description": "__Read-only__ Not applicable for HTTP configs.",
+                          "example": null,
+                          "nullable": true,
+                          "readOnly": true,
+                          "type": "string"
+                        },
+                        "ssl_commonname": {
+                          "description": "__Read-only__ Not applicable for HTTP configs.",
+                          "example": "",
+                          "readOnly": true,
+                          "type": "string",
+                          "x-linode-cli-display": 8
+                        },
+                        "ssl_fingerprint": {
+                          "description": "__Read-only__ Not applicable for HTTP configs.",
+                          "example": "",
+                          "readOnly": true,
+                          "type": "string",
+                          "x-linode-cli-display": 9
+                        },
+                        "ssl_key": {
+                          "description": "__Read-only__ Not applicable for HTTP configs.",
+                          "example": null,
+                          "nullable": true,
+                          "readOnly": true,
+                          "type": "string"
+                        },
+                        "stickiness": {
+                          "default": "table",
+                          "description": "Controls how session stickiness is handled on this port.\n\n- If set to `none`, connections are always assigned a backend based on the algorithm configured.\n- If set to `table`, sessions from the same remote address are routed to the same backend.\n- If set to `http_cookie`, sessions are routed to the same backend based on a cookie set by the NodeBalancer.",
+                          "enum": [
+                            "none",
+                            "table",
+                            "http_cookie"
+                          ],
+                          "example": "http_cookie",
+                          "type": "string",
+                          "x-linode-cli-display": 5
+                        }
+                      },
+                      "required": [
+                        "nodes"
+                      ],
+                      "title": "HTTP",
+                      "type": "object",
+                      "x-akamai": {
+                        "file-path": "schemas/node-balancer-config-http-response.yaml"
+                      }
                     },
-                    "pages": {
-                      "description": "__Read-only__ The total number of [pages](https://techdocs.akamai.com/linode-api/reference/pagination).",
-                      "example": 1,
-                      "readOnly": true,
-                      "type": "integer"
-                    },
-                    "results": {
-                      "description": "__Read-only__ The total number of results.",
-                      "example": 1,
-                      "readOnly": true,
-                      "type": "integer"
+                    {
+                      "additionalProperties": false,
+                      "description": "A NodeBalancer configuration defines the protocol and settings for a specific port on the NodeBalancer. These fields apply to HTTPS configurations.",
+                      "properties": {
+                        "algorithm": {
+                          "default": "roundrobin",
+                          "description": "The algorithm this HTTPS NodeBalancer uses for routing traffic to backends.",
+                          "enum": [
+                            "roundrobin",
+                            "leastconn",
+                            "source"
+                          ],
+                          "example": "roundrobin",
+                          "type": "string",
+                          "x-linode-cli-display": 4
+                        },
+                        "check": {
+                          "default": "none",
+                          "description": "The type of check to perform against backends to ensure they are serving requests. The `check` is used to determine if backends are up or down.\n\n- If `none` no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
+                          "enum": [
+                            "none",
+                            "connection",
+                            "http",
+                            "http_body"
+                          ],
+                          "example": "http_body",
+                          "type": "string"
+                        },
+                        "check_attempts": {
+                          "default": 3,
+                          "description": "How many times to attempt a check before considering a backend to be down.",
+                          "example": 3,
+                          "maximum": 30,
+                          "minimum": 1,
+                          "type": "integer"
+                        },
+                        "check_body": {
+                          "description": "Use when the active health `check` type is `http_body`. This value must be present in the response body of the check in order for it to pass. If this value is not present in the response body of a check request, the backend is considered to be down.",
+                          "example": "it works",
+                          "type": "string"
+                        },
+                        "check_interval": {
+                          "default": 5,
+                          "description": "The number of seconds between each check that backends are up and serving requests.\n\nMust be greater than `check_timeout`.",
+                          "example": 90,
+                          "maximum": 3600,
+                          "minimum": 2,
+                          "type": "integer"
+                        },
+                        "check_passive": {
+                          "default": true,
+                          "description": "If `true`, any response from this backend with a `5xx` status code will be enough for it to be considered unhealthy and taken out of rotation.",
+                          "example": true,
+                          "type": "boolean",
+                          "x-linode-cli-display": 6
+                        },
+                        "check_path": {
+                          "description": "The URL path to check on each backend. Use when the active health `check` type is `http`. If the backend doesn't respond to this request, it's considered to be down.",
+                          "example": "/test",
+                          "pattern": "^[a-zA-Z0-9\\/\\-%?&=.]*$",
+                          "type": "string"
+                        },
+                        "check_timeout": {
+                          "default": 3,
+                          "description": "How long, in seconds, to wait for a check attempt before considering it failed.\n\nMust be less than `check_interval`.",
+                          "example": 10,
+                          "maximum": 30,
+                          "minimum": 1,
+                          "type": "integer"
+                        },
+                        "cipher_suite": {
+                          "default": "recommended",
+                          "description": "What ciphers to use for SSL connections served by this NodeBalancer. The `legacy` cipher is considered insecure and should only be used if necessary. For information on recommended and legacy ciphers, see [TLS cipher suites](https://techdocs.akamai.com/cloud-computing/docs/tls-ssl-termination-on-nodebalancers#tls-cipher-suites).",
+                          "enum": [
+                            "recommended",
+                            "legacy"
+                          ],
+                          "example": "recommended",
+                          "type": "string",
+                          "x-linode-cli-color": {
+                            "default_": "white",
+                            "legacy": "red"
+                          },
+                          "x-linode-cli-display": 7
+                        },
+                        "id": {
+                          "description": "__Read-only__ This config's unique ID.",
+                          "example": 5000,
+                          "readOnly": true,
+                          "type": "integer",
+                          "x-linode-cli-display": 1
+                        },
+                        "nodebalancer_id": {
+                          "description": "__Read-only__ The ID for the NodeBalancer this config belongs to.",
+                          "example": 12345,
+                          "readOnly": true,
+                          "type": "integer"
+                        },
+                        "nodes_status": {
+                          "additionalProperties": false,
+                          "description": "__Read-only__ Describes the health of the backends for this port. This data updates periodically as checks are performed against backends.",
+                          "properties": {
+                            "down": {
+                              "description": "__Read-only__ The number of backends considered to be `DOWN` and unhealthy.  These are not in rotation, and not serving requests.",
+                              "example": 0,
+                              "readOnly": true,
+                              "type": "integer"
+                            },
+                            "up": {
+                              "description": "__Read-only__ The number of backends considered to be `UP` and healthy, and that are serving requests.",
+                              "example": 4,
+                              "readOnly": true,
+                              "type": "integer"
+                            }
+                          },
+                          "readOnly": true,
+                          "type": "object",
+                          "x-linode-cli-display": 10
+                        },
+                        "port": {
+                          "default": 80,
+                          "description": "This is the port the NodeBalancer listens on for this configuration. Port numbers must be unique across TCP, HTTP, and HTTPS configurations on a single NodeBalancer. However, ports assigned to TCP, HTTP, or HTTPS configurations can also be reused for UDP configurations. For example, Port 80 can simultaneously serve a TCP and a UDP configuration on the same NodeBalancer, but it can't be shared by both a TCP and an HTTP configuration. Although certain ports are traditionally associated with specific protocols, this isn't strictly enforced, and you may configure your NodeBalancer however you find useful.",
+                          "example": 443,
+                          "maximum": 65535,
+                          "minimum": 1,
+                          "type": "integer",
+                          "x-linode-cli-display": 2
+                        },
+                        "protocol": {
+                          "default": "http",
+                          "description": "The protocol the port is configured to serve, `https` in this case. Review our guide on [Available protocols](https://techdocs.akamai.com/cloud-computing/docs/available-protocols) for information on protocol features. The `https` protocol needs to be specified with both `ssl_cert` and `ssl_key`.",
+                          "enum": [
+                            "https"
+                          ],
+                          "example": "https",
+                          "type": "string",
+                          "x-linode-cli-display": 3
+                        },
+                        "proxy_protocol": {
+                          "default": "none",
+                          "description": "__Read-only__ Not applicable for HTTPS configs.",
+                          "example": "none",
+                          "readOnly": true,
+                          "type": "string"
+                        },
+                        "ssl_cert": {
+                          "description": "\nThe PEM-formatted public SSL certificate (or the combined PEM-formatted SSL certificate and Certificate Authority chain) that should be served on this NodeBalancerConfig's port.\n\nLine breaks must be represented as `\\n` in the string for requests (but not when using the Linode CLI).\n\n[Diffie-Hellman Parameters](https://www.linode.com/docs/products/networking/nodebalancers/guides/ssl-termination/#diffie-hellman-parameters) can be included in this value to enable forward secrecy.\n\nThe contents of this field will not be shown in any responses that display the NodeBalancerConfig. Instead, `<REDACTED>` will be printed where the field appears.\n\nThe read-only `ssl_commonname` and `ssl_fingerprint` fields in a NodeBalancerConfig response are automatically derived from your certificate. Please refer to these fields to verify that the appropriate certificate was assigned to your NodeBalancerConfig.",
+                          "example": "<REDACTED>",
+                          "format": "ssl-cert",
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "ssl_commonname": {
+                          "description": "__Read-only__ The read-only common name automatically derived from the SSL certificate assigned to this NodeBalancerConfig. Please refer to this field to verify that the appropriate certificate is assigned to your NodeBalancerConfig.",
+                          "example": "www.example.com",
+                          "readOnly": true,
+                          "type": "string",
+                          "x-linode-cli-display": 8
+                        },
+                        "ssl_fingerprint": {
+                          "description": "__Read-only__ The read-only SHA1-encoded fingerprint automatically derived from the SSL certificate assigned to this NodeBalancer configuration. Please refer to the `ssl_fingerprint` field to verify that the appropriate certificate is assigned to your NodeBalancer configuration.",
+                          "example": "00:01:02:03:04:05:06:07:08:09:0A:0B:0C:0D:0E:0F:10:11:12:13",
+                          "readOnly": true,
+                          "type": "string",
+                          "x-linode-cli-display": 9
+                        },
+                        "ssl_key": {
+                          "description": "The PEM-formatted private key for the SSL certificate set in the `ssl_cert` field.\n\nLine breaks must be represented as `\\n` in the string for requests (but not when using the Linode CLI).\n\nThe contents of this field will not be shown in any responses that display\nthe NodeBalancerConfig. Instead, `<REDACTED>` will be printed where the field\nappears.\n\nThe read-only `ssl_commonname` and `ssl_fingerprint` fields in a NodeBalancerConfig\nresponse are automatically derived from your certificate. Please refer to these fields to\nverify that the appropriate certificate was assigned to your NodeBalancerConfig.",
+                          "example": "<REDACTED>",
+                          "format": "ssl-key",
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "stickiness": {
+                          "default": "table",
+                          "description": "Controls how session stickiness is handled on this port.\n\n- If set to `none`, connections will always be assigned a backend based on the algorithm configured.\n- If set to `table`, sessions from the same remote address will be routed to the same backend.\n- For HTTP or HTTPS clients, `http_cookie` allows sessions to be routed to the same backend based on a cookie set by the NodeBalancer.",
+                          "enum": [
+                            "none",
+                            "table",
+                            "http_cookie"
+                          ],
+                          "example": "http_cookie",
+                          "type": "string",
+                          "x-linode-cli-display": 5
+                        }
+                      },
+                      "required": [
+                        "nodes"
+                      ],
+                      "title": "HTTPS",
+                      "type": "object",
+                      "x-akamai": {
+                        "file-path": "schemas/node-balancer-config-https-response.yaml"
+                      }
                     }
-                  },
-                  "type": "object",
+                  ],
                   "x-akamai": {
-                    "file-path": "schemas/added-get-node-balancer-configs-200.yaml"
+                    "file-path": "schemas/node-balancer-config-response.yaml"
                   }
                 },
                 "x-example": {
@@ -85076,7 +84622,7 @@
                       "x-linode-cli-display": 8
                     },
                     "ssl_fingerprint": {
-                      "description": "__Read-only__ The read-only SHA1-encoded fingerprint automatically derived from the SSL certificate assigned to this NodeBalancer config. Please refer to this field to verify that the appropriate certificate is assigned to your config.",
+                      "description": "__Read-only__ The read-only SHA1-encoded fingerprint automatically derived from the SSL certificate assigned to this NodeBalancer configuration. You can use the `ssl_fingerprint` field to verify that the appropriate certificate is assigned to your NodeBalancer configuration.",
                       "example": "00:01:02:03:04:05:06:07:08:09:0A:0B:0C:0D:0E:0F:10:11:12:13",
                       "readOnly": true,
                       "type": "string",
@@ -85250,7 +84796,7 @@
                         },
                         "check": {
                           "default": "none",
-                          "description": "The type of check to perform against backends to ensure they are serving requests. This is used to determine if backends are up or down.\n\n- If `none`, no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
+                          "description": "The type of check to perform against backends to ensure they are serving requests. This determines if backends are up or down.\n\n- If `none`, no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
                           "enum": [
                             "none",
                             "connection",
@@ -85283,13 +84829,13 @@
                         },
                         "check_passive": {
                           "default": true,
-                          "description": "If `true`, any response from this backend with a `5xx` status code will be enough for it to be considered unhealthy and taken out of rotation.",
+                          "description": "If `true`, any response from this backend with a `5xx` status code is enough for it to be considered unhealthy and taken out of rotation.",
                           "example": true,
                           "type": "boolean",
                           "x-linode-cli-display": 6
                         },
                         "check_path": {
-                          "description": "The URL path to check on each backend. If the backend does not respond to this request it is considered to be down.",
+                          "description": "The URL path to check on each backend. If the backend does not respond to this request, it's considered to be down.",
                           "example": "/test",
                           "pattern": "^[a-zA-Z0-9\\/\\-%?&=.]*$",
                           "type": "string"
@@ -85303,8 +84849,8 @@
                           "type": "integer"
                         },
                         "cipher_suite": {
-                          "description": "__Read-only__ Not applicable for HTTP configs.",
-                          "example": "recommended",
+                          "description": "__Read-only__ Not applicable for `tcp` configs.",
+                          "example": "none",
                           "readOnly": true,
                           "type": "string",
                           "x-linode-cli-color": {
@@ -85325,93 +84871,6 @@
                           "example": 12345,
                           "readOnly": true,
                           "type": "integer"
-                        },
-                        "nodes": {
-                          "description": "The NodeBalancer nodes that serve this configuration.",
-                          "items": {
-                            "additionalProperties": false,
-                            "description": "A NodeBalancer node represents a single backend serving requests for a single port of a NodeBalancer.  Nodes are specific to NodeBalancer configs, and serve traffic over their private IP.  If the same Linode is serving traffic for more than one port on the same NodeBalancer, one NodeBalancer node is required for each config (port) it should serve requests on.  For example, if you have four backends, and each should respond to both HTTP and HTTPS requests, you will need two NodeBalancer configs (port 80 and port 443) and four backends each, one for each of the Linodes serving requests for that port.",
-                            "properties": {
-                              "address": {
-                                "description": "The private IP Address where this backend can be reached. This _must_ be a private IP address.",
-                                "example": "192.168.210.120:80",
-                                "format": "ip",
-                                "type": "string",
-                                "x-linode-cli-display": 3
-                              },
-                              "config_id": {
-                                "description": "__Read-only__ The NodeBalancer Config ID that this Node belongs to.",
-                                "example": 4567,
-                                "readOnly": true,
-                                "type": "integer"
-                              },
-                              "id": {
-                                "description": "__Read-only__ This node's unique ID.",
-                                "example": 54321,
-                                "readOnly": true,
-                                "type": "integer",
-                                "x-linode-cli-display": 1
-                              },
-                              "label": {
-                                "description": "The label for this node.  This is for display purposes only.",
-                                "example": "node54321",
-                                "maxLength": 32,
-                                "minLength": 3,
-                                "pattern": "[a-zA-Z0-9-_.]{3,32}",
-                                "type": "string",
-                                "x-linode-cli-display": 2
-                              },
-                              "mode": {
-                                "description": "The mode this NodeBalancer should use when sending traffic to this backend.\n\n- If set to `accept` this backend is accepting traffic.\n- If set to `reject` this backend will not receive traffic.\n- If set to `drain` this backend will not receive _new_ traffic, but connections already pinned to it will continue to be routed to it.\n- If set to `backup`, this backend will only receive traffic if all `accept` nodes are down.",
-                                "enum": [
-                                  "accept",
-                                  "reject",
-                                  "drain",
-                                  "backup"
-                                ],
-                                "example": "accept",
-                                "type": "string",
-                                "x-linode-cli-display": 6
-                              },
-                              "nodebalancer_id": {
-                                "description": "__Read-only__ The NodeBalancer ID that this Node belongs to.",
-                                "example": 12345,
-                                "readOnly": true,
-                                "type": "integer"
-                              },
-                              "status": {
-                                "description": "__Read-only__ The current status of this node, based on the configured checks of its NodeBalancer Config.",
-                                "enum": [
-                                  "unknown",
-                                  "UP",
-                                  "DOWN"
-                                ],
-                                "example": "UP",
-                                "readOnly": true,
-                                "type": "string",
-                                "x-linode-cli-color": {
-                                  "DOWN": "red",
-                                  "UP": "green",
-                                  "default_": "white",
-                                  "unknown": "yellow"
-                                },
-                                "x-linode-cli-display": 4
-                              },
-                              "weight": {
-                                "description": "Used when picking a backend to serve a request and is not pinned to a single backend yet.  Nodes with a higher weight will receive more traffic.",
-                                "example": 50,
-                                "maximum": 255,
-                                "minimum": 1,
-                                "type": "integer",
-                                "x-linode-cli-display": 5
-                              }
-                            },
-                            "title": "TCP, HTTP, or HTTPS config",
-                            "x-akamai": {
-                              "file-path": "schemas/node-balancer-node-tcp-http-https.yaml"
-                            }
-                          },
-                          "type": "array"
                         },
                         "nodes_status": {
                           "additionalProperties": false,
@@ -85445,7 +84904,7 @@
                         },
                         "protocol": {
                           "default": "http",
-                          "description": "The protocol the port is configured to serve, `tcp` in this case.\n\nReview our guide on [Available protocols](https://techdocs.akamai.com/cloud-computing/docs/available-protocols) for information on protocol features.",
+                          "description": "The protocol the port is configured to serve, `tcp` in this case. Review our guide on [Available protocols](https://techdocs.akamai.com/cloud-computing/docs/available-protocols) for information on protocol features.",
                           "enum": [
                             "tcp"
                           ],
@@ -85512,7 +84971,7 @@
                       "title": "TCP",
                       "type": "object",
                       "x-akamai": {
-                        "file-path": "schemas/node-balancer-config-tcp.yaml"
+                        "file-path": "schemas/node-balancer-config-tcp-response.yaml"
                       }
                     },
                     {
@@ -85552,7 +85011,7 @@
                           "type": "integer"
                         },
                         "check_body": {
-                          "description": "Use when the active health `check` type is `http_body`. This value must be present in the response body of the check in order for it to pass. If this value is not present in the response body of a check request, the backend is considered to be down.",
+                          "description": "Use when the active health `check` type is `http_body`. This value needs to be in the response body of the check in order for it to pass. Otherwise the backend is considered to be down.",
                           "example": "it works",
                           "type": "string"
                         },
@@ -85586,8 +85045,8 @@
                           "type": "integer"
                         },
                         "cipher_suite": {
-                          "description": "__Read-only__ Not applicable for HTTP configs.",
-                          "example": "recommended",
+                          "description": "__Read-only__ Not applicable for `http` configs.",
+                          "example": "none",
                           "readOnly": true,
                           "type": "string",
                           "x-linode-cli-color": {
@@ -85608,93 +85067,6 @@
                           "example": 12345,
                           "readOnly": true,
                           "type": "integer"
-                        },
-                        "nodes": {
-                          "description": "The NodeBalancer nodes that serve this configuration.",
-                          "items": {
-                            "additionalProperties": false,
-                            "description": "A NodeBalancer node represents a single backend serving requests for a single port of a NodeBalancer.  Nodes are specific to NodeBalancer configs, and serve traffic over their private IP.  If the same Linode is serving traffic for more than one port on the same NodeBalancer, one NodeBalancer node is required for each config (port) it should serve requests on.  For example, if you have four backends, and each should respond to both HTTP and HTTPS requests, you will need two NodeBalancer configs (port 80 and port 443) and four backends each, one for each of the Linodes serving requests for that port.",
-                            "properties": {
-                              "address": {
-                                "description": "The private IP Address where this backend can be reached. This _must_ be a private IP address.",
-                                "example": "192.168.210.120:80",
-                                "format": "ip",
-                                "type": "string",
-                                "x-linode-cli-display": 3
-                              },
-                              "config_id": {
-                                "description": "__Read-only__ The NodeBalancer Config ID that this Node belongs to.",
-                                "example": 4567,
-                                "readOnly": true,
-                                "type": "integer"
-                              },
-                              "id": {
-                                "description": "__Read-only__ This node's unique ID.",
-                                "example": 54321,
-                                "readOnly": true,
-                                "type": "integer",
-                                "x-linode-cli-display": 1
-                              },
-                              "label": {
-                                "description": "The label for this node.  This is for display purposes only.",
-                                "example": "node54321",
-                                "maxLength": 32,
-                                "minLength": 3,
-                                "pattern": "[a-zA-Z0-9-_.]{3,32}",
-                                "type": "string",
-                                "x-linode-cli-display": 2
-                              },
-                              "mode": {
-                                "description": "The mode this NodeBalancer should use when sending traffic to this backend.\n\n- If set to `accept` this backend is accepting traffic.\n- If set to `reject` this backend will not receive traffic.\n- If set to `drain` this backend will not receive _new_ traffic, but connections already pinned to it will continue to be routed to it.\n- If set to `backup`, this backend will only receive traffic if all `accept` nodes are down.",
-                                "enum": [
-                                  "accept",
-                                  "reject",
-                                  "drain",
-                                  "backup"
-                                ],
-                                "example": "accept",
-                                "type": "string",
-                                "x-linode-cli-display": 6
-                              },
-                              "nodebalancer_id": {
-                                "description": "__Read-only__ The NodeBalancer ID that this Node belongs to.",
-                                "example": 12345,
-                                "readOnly": true,
-                                "type": "integer"
-                              },
-                              "status": {
-                                "description": "__Read-only__ The current status of this node, based on the configured checks of its NodeBalancer Config.",
-                                "enum": [
-                                  "unknown",
-                                  "UP",
-                                  "DOWN"
-                                ],
-                                "example": "UP",
-                                "readOnly": true,
-                                "type": "string",
-                                "x-linode-cli-color": {
-                                  "DOWN": "red",
-                                  "UP": "green",
-                                  "default_": "white",
-                                  "unknown": "yellow"
-                                },
-                                "x-linode-cli-display": 4
-                              },
-                              "weight": {
-                                "description": "Used when picking a backend to serve a request and is not pinned to a single backend yet.  Nodes with a higher weight will receive more traffic.",
-                                "example": 50,
-                                "maximum": 255,
-                                "minimum": 1,
-                                "type": "integer",
-                                "x-linode-cli-display": 5
-                              }
-                            },
-                            "title": "TCP, HTTP, or HTTPS config",
-                            "x-akamai": {
-                              "file-path": "schemas/node-balancer-node-tcp-http-https.yaml"
-                            }
-                          },
-                          "type": "array"
                         },
                         "nodes_status": {
                           "additionalProperties": false,
@@ -85719,7 +85091,7 @@
                         },
                         "port": {
                           "default": 80,
-                          "description": "This is the port the NodeBalancer listens on for this configuration. Port numbers need to be unique across TCP, HTTP, and HTTPS configurations on a single NodeBalancer. However, ports assigned to TCP, HTTP, or HTTPS configurations can also be reused for UDP configurations. For example, Port 80 can simultaneously serve a TCP and a UDP configuration on the same NodeBalancer, but it can't be shared by both a TCP and an HTTP configuration. Although certain ports are traditionally associated with specific protocols, this is not strictly enforced. You may configure your NodeBalancer however is useful to you.",
+                          "description": "This is the port the NodeBalancer listens on for this configuration. Port numbers need to be unique across TCP, HTTP, and HTTPS configurations on a single NodeBalancer. However, ports assigned to TCP, HTTP, or HTTPS configurations can also be reused for UDP configurations. For example, Port 80 can simultaneously serve a TCP and a UDP configuration on the same NodeBalancer, but it can't be shared by both a TCP and an HTTP configuration. Although certain ports are traditionally associated with specific protocols, this isn't strictly enforced. You may configure your NodeBalancer however you find useful.",
                           "example": 80,
                           "maximum": 65535,
                           "minimum": 1,
@@ -85728,7 +85100,7 @@
                         },
                         "protocol": {
                           "default": "http",
-                          "description": "The protocol the port is configured to serve, `http` in this case.\nReview our guide on [Available protocols](https://techdocs.akamai.com/cloud-computing/docs/available-protocols) for information on protocol features.",
+                          "description": "The protocol the port is configured to serve, `http` in this case. Review our guide on [Available protocols](https://techdocs.akamai.com/cloud-computing/docs/available-protocols) for information on protocol features.",
                           "enum": [
                             "http"
                           ],
@@ -85773,7 +85145,7 @@
                         },
                         "stickiness": {
                           "default": "table",
-                          "description": "Controls how session stickiness is handled on this port.\n\n- If set to `none`, connections will always be assigned a backend based on the algorithm configured.\n- If set to `table`, sessions from the same remote address will be routed to the same backend.\n- If set to `http_cookie`, sessions are routed to the same backend based on a cookie set by the NodeBalancer.",
+                          "description": "Controls how session stickiness is handled on this port.\n\n- If set to `none`, connections are always assigned a backend based on the algorithm configured.\n- If set to `table`, sessions from the same remote address are routed to the same backend.\n- If set to `http_cookie`, sessions are routed to the same backend based on a cookie set by the NodeBalancer.",
                           "enum": [
                             "none",
                             "table",
@@ -85790,7 +85162,7 @@
                       "title": "HTTP",
                       "type": "object",
                       "x-akamai": {
-                        "file-path": "schemas/node-balancer-config-http.yaml"
+                        "file-path": "schemas/node-balancer-config-http-response.yaml"
                       }
                     },
                     {
@@ -85811,7 +85183,7 @@
                         },
                         "check": {
                           "default": "none",
-                          "description": "The type of check to perform against backends to ensure they are serving requests. This is used to determine if backends are up or down.\n\n- If `none` no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
+                          "description": "The type of check to perform against backends to ensure they are serving requests. The `check` is used to determine if backends are up or down.\n\n- If `none` no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
                           "enum": [
                             "none",
                             "connection",
@@ -85836,7 +85208,7 @@
                         },
                         "check_interval": {
                           "default": 5,
-                          "description": "How often, in seconds, to check that backends are up and serving requests.\n\nMust be greater than `check_timeout`.",
+                          "description": "The number of seconds between each check that backends are up and serving requests.\n\nMust be greater than `check_timeout`.",
                           "example": 90,
                           "maximum": 3600,
                           "minimum": 2,
@@ -85865,7 +85237,7 @@
                         },
                         "cipher_suite": {
                           "default": "recommended",
-                          "description": "What ciphers to use for SSL connections served by this NodeBalancer.\n\n- `legacy` is considered insecure and should only be used if necessary.",
+                          "description": "What ciphers to use for SSL connections served by this NodeBalancer. The `legacy` cipher is considered insecure and should only be used if necessary. For information on recommended and legacy ciphers, see [TLS cipher suites](https://techdocs.akamai.com/cloud-computing/docs/tls-ssl-termination-on-nodebalancers#tls-cipher-suites).",
                           "enum": [
                             "recommended",
                             "legacy"
@@ -85890,93 +85262,6 @@
                           "example": 12345,
                           "readOnly": true,
                           "type": "integer"
-                        },
-                        "nodes": {
-                          "description": "The NodeBalancer nodes that serve this configuration.",
-                          "items": {
-                            "additionalProperties": false,
-                            "description": "A NodeBalancer node represents a single backend serving requests for a single port of a NodeBalancer.  Nodes are specific to NodeBalancer configs, and serve traffic over their private IP.  If the same Linode is serving traffic for more than one port on the same NodeBalancer, one NodeBalancer node is required for each config (port) it should serve requests on.  For example, if you have four backends, and each should respond to both HTTP and HTTPS requests, you will need two NodeBalancer configs (port 80 and port 443) and four backends each, one for each of the Linodes serving requests for that port.",
-                            "properties": {
-                              "address": {
-                                "description": "The private IP Address where this backend can be reached. This _must_ be a private IP address.",
-                                "example": "192.168.210.120:80",
-                                "format": "ip",
-                                "type": "string",
-                                "x-linode-cli-display": 3
-                              },
-                              "config_id": {
-                                "description": "__Read-only__ The NodeBalancer Config ID that this Node belongs to.",
-                                "example": 4567,
-                                "readOnly": true,
-                                "type": "integer"
-                              },
-                              "id": {
-                                "description": "__Read-only__ This node's unique ID.",
-                                "example": 54321,
-                                "readOnly": true,
-                                "type": "integer",
-                                "x-linode-cli-display": 1
-                              },
-                              "label": {
-                                "description": "The label for this node.  This is for display purposes only.",
-                                "example": "node54321",
-                                "maxLength": 32,
-                                "minLength": 3,
-                                "pattern": "[a-zA-Z0-9-_.]{3,32}",
-                                "type": "string",
-                                "x-linode-cli-display": 2
-                              },
-                              "mode": {
-                                "description": "The mode this NodeBalancer should use when sending traffic to this backend.\n\n- If set to `accept` this backend is accepting traffic.\n- If set to `reject` this backend will not receive traffic.\n- If set to `drain` this backend will not receive _new_ traffic, but connections already pinned to it will continue to be routed to it.\n- If set to `backup`, this backend will only receive traffic if all `accept` nodes are down.",
-                                "enum": [
-                                  "accept",
-                                  "reject",
-                                  "drain",
-                                  "backup"
-                                ],
-                                "example": "accept",
-                                "type": "string",
-                                "x-linode-cli-display": 6
-                              },
-                              "nodebalancer_id": {
-                                "description": "__Read-only__ The NodeBalancer ID that this Node belongs to.",
-                                "example": 12345,
-                                "readOnly": true,
-                                "type": "integer"
-                              },
-                              "status": {
-                                "description": "__Read-only__ The current status of this node, based on the configured checks of its NodeBalancer Config.",
-                                "enum": [
-                                  "unknown",
-                                  "UP",
-                                  "DOWN"
-                                ],
-                                "example": "UP",
-                                "readOnly": true,
-                                "type": "string",
-                                "x-linode-cli-color": {
-                                  "DOWN": "red",
-                                  "UP": "green",
-                                  "default_": "white",
-                                  "unknown": "yellow"
-                                },
-                                "x-linode-cli-display": 4
-                              },
-                              "weight": {
-                                "description": "Used when picking a backend to serve a request and is not pinned to a single backend yet.  Nodes with a higher weight will receive more traffic.",
-                                "example": 50,
-                                "maximum": 255,
-                                "minimum": 1,
-                                "type": "integer",
-                                "x-linode-cli-display": 5
-                              }
-                            },
-                            "title": "TCP, HTTP, or HTTPS config",
-                            "x-akamai": {
-                              "file-path": "schemas/node-balancer-node-tcp-http-https.yaml"
-                            }
-                          },
-                          "type": "array"
                         },
                         "nodes_status": {
                           "additionalProperties": false,
@@ -86010,7 +85295,7 @@
                         },
                         "protocol": {
                           "default": "http",
-                          "description": "The protocol the port is configured to serve, `https` in this case.\n\n- The `https` protocol is mutually required with `ssl_cert` and `ssl_key`.\n\nReview our guide on [Available protocols](https://techdocs.akamai.com/cloud-computing/docs/available-protocols) for information on protocol features.",
+                          "description": "The protocol the port is configured to serve, `https` in this case. Review our guide on [Available protocols](https://techdocs.akamai.com/cloud-computing/docs/available-protocols) for information on protocol features. The `https` protocol needs to be specified with both `ssl_cert` and `ssl_key`.",
                           "enum": [
                             "https"
                           ],
@@ -86040,7 +85325,7 @@
                           "x-linode-cli-display": 8
                         },
                         "ssl_fingerprint": {
-                          "description": "__Read-only__ The read-only SHA1-encoded fingerprint automatically derived from the SSL certificate assigned to this NodeBalancerConfig. Please refer to this field to verify that the appropriate certificate is assigned to your NodeBalancerConfig.",
+                          "description": "__Read-only__ The read-only SHA1-encoded fingerprint automatically derived from the SSL certificate assigned to this NodeBalancer configuration. Please refer to the `ssl_fingerprint` field to verify that the appropriate certificate is assigned to your NodeBalancer configuration.",
                           "example": "00:01:02:03:04:05:06:07:08:09:0A:0B:0C:0D:0E:0F:10:11:12:13",
                           "readOnly": true,
                           "type": "string",
@@ -86072,12 +85357,12 @@
                       "title": "HTTPS",
                       "type": "object",
                       "x-akamai": {
-                        "file-path": "schemas/node-balancer-config-https.yaml"
+                        "file-path": "schemas/node-balancer-config-https-response.yaml"
                       }
                     }
                   ],
                   "x-akamai": {
-                    "file-path": "schemas/node-balancer-config.yaml"
+                    "file-path": "schemas/node-balancer-config-response.yaml"
                   }
                 },
                 "x-example": {
@@ -86246,7 +85531,7 @@
                       "x-linode-cli-display": 8
                     },
                     "ssl_fingerprint": {
-                      "description": "__Read-only__ The read-only SHA1-encoded fingerprint automatically derived from the SSL certificate assigned to this NodeBalancer config. Please refer to this field to verify that the appropriate certificate is assigned to your config.",
+                      "description": "__Read-only__ The read-only SHA1-encoded fingerprint automatically derived from the SSL certificate assigned to this NodeBalancer configuration. You can use the `ssl_fingerprint` field to verify that the appropriate certificate is assigned to your NodeBalancer configuration.",
                       "example": "00:01:02:03:04:05:06:07:08:09:0A:0B:0C:0D:0E:0F:10:11:12:13",
                       "readOnly": true,
                       "type": "string",
@@ -86380,7 +85665,7 @@
                       },
                       "check": {
                         "default": "none",
-                        "description": "The type of check to perform against backends to ensure they are serving requests. This is used to determine if backends are up or down.\n\n- If `none`, no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
+                        "description": "The type of check to perform against backends to ensure they are serving requests. The `check` is used to determine if backends are up or down.\n\n- If `none`, no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
                         "enum": [
                           "none",
                           "connection",
@@ -86433,8 +85718,8 @@
                         "type": "integer"
                       },
                       "cipher_suite": {
-                        "description": "__Read-only__ Not applicable for HTTP configs.",
-                        "example": "recommended",
+                        "description": "__Read-only__ Not applicable for TCP configs.",
+                        "example": "none",
                         "readOnly": true,
                         "type": "string",
                         "x-linode-cli-color": {
@@ -86624,11 +85909,10 @@
                       },
                       "stickiness": {
                         "default": "none",
-                        "description": "__Read-only__ Controls how session stickiness is handled on this port.\n\nNot applicable to TCP configurations.",
+                        "description": "__Read-only__ Controls how session stickiness is handled on this port.\n\n- If set to `none`, connections will always be assigned a backend based on the algorithm configured.\n- If set to `table`, sessions from the same remote address will be routed to the same backend.",
                         "enum": [
                           "none",
-                          "table",
-                          "http_cookie"
+                          "table"
                         ],
                         "example": "none",
                         "readOnly": true,
@@ -86849,7 +86133,7 @@
                       },
                       "port": {
                         "default": 80,
-                        "description": "This is the port the NodeBalancer listens on for this configuration. Port numbers need to be unique across TCP, HTTP, and HTTPS configurations on a single NodeBalancer. However, ports assigned to TCP, HTTP, or HTTPS configurations can also be reused for UDP configurations. For example, Port 80 can simultaneously serve a TCP and a UDP configuration on the same NodeBalancer, but it can't be shared by both a TCP and an HTTP configuration. Although certain ports are traditionally associated with specific protocols, this is not strictly enforced. You may configure your NodeBalancer however is useful to you.",
+                        "description": "This is the port the NodeBalancer listens on for this configuration. Port numbers need to be unique across TCP, HTTP, and HTTPS configurations on a single NodeBalancer. However, ports assigned to TCP, HTTP, or HTTPS configurations can also be reused for UDP configurations. For example, Port 80 can simultaneously serve a TCP and a UDP configuration on the same NodeBalancer, but it can't be shared by both a TCP and an HTTP configuration. Although certain ports are traditionally associated with specific protocols, this isn't strictly enforced. You may configure your NodeBalancer however you find useful.",
                         "example": 80,
                         "maximum": 65535,
                         "minimum": 1,
@@ -86941,7 +86225,7 @@
                       },
                       "check": {
                         "default": "none",
-                        "description": "The type of check to perform against backends to ensure they are serving requests. This is used to determine if backends are up or down.\n\n- If `none` no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
+                        "description": "The type of check to perform against backends to ensure they are serving requests. The `check` is used to determine if backends are up or down.\n\n- If `none` no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
                         "enum": [
                           "none",
                           "connection",
@@ -87170,7 +86454,7 @@
                         "x-linode-cli-display": 8
                       },
                       "ssl_fingerprint": {
-                        "description": "__Read-only__ The read-only SHA1-encoded fingerprint automatically derived from the SSL certificate assigned to this NodeBalancerConfig. Please refer to this field to verify that the appropriate certificate is assigned to your NodeBalancerConfig.",
+                        "description": "__Read-only__ The read-only SHA1-encoded fingerprint automatically derived from the SSL certificate assigned to this NodeBalancer configuration. Please refer to the `ssl_fingerprint` field to verify that the appropriate certificate is assigned to your NodeBalancer configuration.",
                         "example": "00:01:02:03:04:05:06:07:08:09:0A:0B:0C:0D:0E:0F:10:11:12:13",
                         "readOnly": true,
                         "type": "string",
@@ -87376,7 +86660,7 @@
                     "x-linode-cli-display": 8
                   },
                   "ssl_fingerprint": {
-                    "description": "__Read-only__ The read-only SHA1-encoded fingerprint automatically derived from the SSL certificate assigned to this NodeBalancer config. Please refer to this field to verify that the appropriate certificate is assigned to your config.",
+                    "description": "__Read-only__ The read-only SHA1-encoded fingerprint automatically derived from the SSL certificate assigned to this NodeBalancer configuration. You can use the `ssl_fingerprint` field to verify that the appropriate certificate is assigned to your NodeBalancer configuration.",
                     "example": "00:01:02:03:04:05:06:07:08:09:0A:0B:0C:0D:0E:0F:10:11:12:13",
                     "readOnly": true,
                     "type": "string",
@@ -87437,7 +86721,7 @@
                         },
                         "check": {
                           "default": "none",
-                          "description": "The type of check to perform against backends to ensure they are serving requests. This is used to determine if backends are up or down.\n\n- If `none`, no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
+                          "description": "The type of check to perform against backends to ensure they are serving requests. This determines if backends are up or down.\n\n- If `none`, no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
                           "enum": [
                             "none",
                             "connection",
@@ -87470,13 +86754,13 @@
                         },
                         "check_passive": {
                           "default": true,
-                          "description": "If `true`, any response from this backend with a `5xx` status code will be enough for it to be considered unhealthy and taken out of rotation.",
+                          "description": "If `true`, any response from this backend with a `5xx` status code is enough for it to be considered unhealthy and taken out of rotation.",
                           "example": true,
                           "type": "boolean",
                           "x-linode-cli-display": 6
                         },
                         "check_path": {
-                          "description": "The URL path to check on each backend. If the backend does not respond to this request it is considered to be down.",
+                          "description": "The URL path to check on each backend. If the backend does not respond to this request, it's considered to be down.",
                           "example": "/test",
                           "pattern": "^[a-zA-Z0-9\\/\\-%?&=.]*$",
                           "type": "string"
@@ -87490,8 +86774,8 @@
                           "type": "integer"
                         },
                         "cipher_suite": {
-                          "description": "__Read-only__ Not applicable for HTTP configs.",
-                          "example": "recommended",
+                          "description": "__Read-only__ Not applicable for `tcp` configs.",
+                          "example": "none",
                           "readOnly": true,
                           "type": "string",
                           "x-linode-cli-color": {
@@ -87512,93 +86796,6 @@
                           "example": 12345,
                           "readOnly": true,
                           "type": "integer"
-                        },
-                        "nodes": {
-                          "description": "The NodeBalancer nodes that serve this configuration.",
-                          "items": {
-                            "additionalProperties": false,
-                            "description": "A NodeBalancer node represents a single backend serving requests for a single port of a NodeBalancer.  Nodes are specific to NodeBalancer configs, and serve traffic over their private IP.  If the same Linode is serving traffic for more than one port on the same NodeBalancer, one NodeBalancer node is required for each config (port) it should serve requests on.  For example, if you have four backends, and each should respond to both HTTP and HTTPS requests, you will need two NodeBalancer configs (port 80 and port 443) and four backends each, one for each of the Linodes serving requests for that port.",
-                            "properties": {
-                              "address": {
-                                "description": "The private IP Address where this backend can be reached. This _must_ be a private IP address.",
-                                "example": "192.168.210.120:80",
-                                "format": "ip",
-                                "type": "string",
-                                "x-linode-cli-display": 3
-                              },
-                              "config_id": {
-                                "description": "__Read-only__ The NodeBalancer Config ID that this Node belongs to.",
-                                "example": 4567,
-                                "readOnly": true,
-                                "type": "integer"
-                              },
-                              "id": {
-                                "description": "__Read-only__ This node's unique ID.",
-                                "example": 54321,
-                                "readOnly": true,
-                                "type": "integer",
-                                "x-linode-cli-display": 1
-                              },
-                              "label": {
-                                "description": "The label for this node.  This is for display purposes only.",
-                                "example": "node54321",
-                                "maxLength": 32,
-                                "minLength": 3,
-                                "pattern": "[a-zA-Z0-9-_.]{3,32}",
-                                "type": "string",
-                                "x-linode-cli-display": 2
-                              },
-                              "mode": {
-                                "description": "The mode this NodeBalancer should use when sending traffic to this backend.\n\n- If set to `accept` this backend is accepting traffic.\n- If set to `reject` this backend will not receive traffic.\n- If set to `drain` this backend will not receive _new_ traffic, but connections already pinned to it will continue to be routed to it.\n- If set to `backup`, this backend will only receive traffic if all `accept` nodes are down.",
-                                "enum": [
-                                  "accept",
-                                  "reject",
-                                  "drain",
-                                  "backup"
-                                ],
-                                "example": "accept",
-                                "type": "string",
-                                "x-linode-cli-display": 6
-                              },
-                              "nodebalancer_id": {
-                                "description": "__Read-only__ The NodeBalancer ID that this Node belongs to.",
-                                "example": 12345,
-                                "readOnly": true,
-                                "type": "integer"
-                              },
-                              "status": {
-                                "description": "__Read-only__ The current status of this node, based on the configured checks of its NodeBalancer Config.",
-                                "enum": [
-                                  "unknown",
-                                  "UP",
-                                  "DOWN"
-                                ],
-                                "example": "UP",
-                                "readOnly": true,
-                                "type": "string",
-                                "x-linode-cli-color": {
-                                  "DOWN": "red",
-                                  "UP": "green",
-                                  "default_": "white",
-                                  "unknown": "yellow"
-                                },
-                                "x-linode-cli-display": 4
-                              },
-                              "weight": {
-                                "description": "Used when picking a backend to serve a request and is not pinned to a single backend yet.  Nodes with a higher weight will receive more traffic.",
-                                "example": 50,
-                                "maximum": 255,
-                                "minimum": 1,
-                                "type": "integer",
-                                "x-linode-cli-display": 5
-                              }
-                            },
-                            "title": "TCP, HTTP, or HTTPS config",
-                            "x-akamai": {
-                              "file-path": "schemas/node-balancer-node-tcp-http-https.yaml"
-                            }
-                          },
-                          "type": "array"
                         },
                         "nodes_status": {
                           "additionalProperties": false,
@@ -87632,7 +86829,7 @@
                         },
                         "protocol": {
                           "default": "http",
-                          "description": "The protocol the port is configured to serve, `tcp` in this case.\n\nReview our guide on [Available protocols](https://techdocs.akamai.com/cloud-computing/docs/available-protocols) for information on protocol features.",
+                          "description": "The protocol the port is configured to serve, `tcp` in this case. Review our guide on [Available protocols](https://techdocs.akamai.com/cloud-computing/docs/available-protocols) for information on protocol features.",
                           "enum": [
                             "tcp"
                           ],
@@ -87699,7 +86896,7 @@
                       "title": "TCP",
                       "type": "object",
                       "x-akamai": {
-                        "file-path": "schemas/node-balancer-config-tcp.yaml"
+                        "file-path": "schemas/node-balancer-config-tcp-response.yaml"
                       }
                     },
                     {
@@ -87739,7 +86936,7 @@
                           "type": "integer"
                         },
                         "check_body": {
-                          "description": "Use when the active health `check` type is `http_body`. This value must be present in the response body of the check in order for it to pass. If this value is not present in the response body of a check request, the backend is considered to be down.",
+                          "description": "Use when the active health `check` type is `http_body`. This value needs to be in the response body of the check in order for it to pass. Otherwise the backend is considered to be down.",
                           "example": "it works",
                           "type": "string"
                         },
@@ -87773,8 +86970,8 @@
                           "type": "integer"
                         },
                         "cipher_suite": {
-                          "description": "__Read-only__ Not applicable for HTTP configs.",
-                          "example": "recommended",
+                          "description": "__Read-only__ Not applicable for `http` configs.",
+                          "example": "none",
                           "readOnly": true,
                           "type": "string",
                           "x-linode-cli-color": {
@@ -87795,93 +86992,6 @@
                           "example": 12345,
                           "readOnly": true,
                           "type": "integer"
-                        },
-                        "nodes": {
-                          "description": "The NodeBalancer nodes that serve this configuration.",
-                          "items": {
-                            "additionalProperties": false,
-                            "description": "A NodeBalancer node represents a single backend serving requests for a single port of a NodeBalancer.  Nodes are specific to NodeBalancer configs, and serve traffic over their private IP.  If the same Linode is serving traffic for more than one port on the same NodeBalancer, one NodeBalancer node is required for each config (port) it should serve requests on.  For example, if you have four backends, and each should respond to both HTTP and HTTPS requests, you will need two NodeBalancer configs (port 80 and port 443) and four backends each, one for each of the Linodes serving requests for that port.",
-                            "properties": {
-                              "address": {
-                                "description": "The private IP Address where this backend can be reached. This _must_ be a private IP address.",
-                                "example": "192.168.210.120:80",
-                                "format": "ip",
-                                "type": "string",
-                                "x-linode-cli-display": 3
-                              },
-                              "config_id": {
-                                "description": "__Read-only__ The NodeBalancer Config ID that this Node belongs to.",
-                                "example": 4567,
-                                "readOnly": true,
-                                "type": "integer"
-                              },
-                              "id": {
-                                "description": "__Read-only__ This node's unique ID.",
-                                "example": 54321,
-                                "readOnly": true,
-                                "type": "integer",
-                                "x-linode-cli-display": 1
-                              },
-                              "label": {
-                                "description": "The label for this node.  This is for display purposes only.",
-                                "example": "node54321",
-                                "maxLength": 32,
-                                "minLength": 3,
-                                "pattern": "[a-zA-Z0-9-_.]{3,32}",
-                                "type": "string",
-                                "x-linode-cli-display": 2
-                              },
-                              "mode": {
-                                "description": "The mode this NodeBalancer should use when sending traffic to this backend.\n\n- If set to `accept` this backend is accepting traffic.\n- If set to `reject` this backend will not receive traffic.\n- If set to `drain` this backend will not receive _new_ traffic, but connections already pinned to it will continue to be routed to it.\n- If set to `backup`, this backend will only receive traffic if all `accept` nodes are down.",
-                                "enum": [
-                                  "accept",
-                                  "reject",
-                                  "drain",
-                                  "backup"
-                                ],
-                                "example": "accept",
-                                "type": "string",
-                                "x-linode-cli-display": 6
-                              },
-                              "nodebalancer_id": {
-                                "description": "__Read-only__ The NodeBalancer ID that this Node belongs to.",
-                                "example": 12345,
-                                "readOnly": true,
-                                "type": "integer"
-                              },
-                              "status": {
-                                "description": "__Read-only__ The current status of this node, based on the configured checks of its NodeBalancer Config.",
-                                "enum": [
-                                  "unknown",
-                                  "UP",
-                                  "DOWN"
-                                ],
-                                "example": "UP",
-                                "readOnly": true,
-                                "type": "string",
-                                "x-linode-cli-color": {
-                                  "DOWN": "red",
-                                  "UP": "green",
-                                  "default_": "white",
-                                  "unknown": "yellow"
-                                },
-                                "x-linode-cli-display": 4
-                              },
-                              "weight": {
-                                "description": "Used when picking a backend to serve a request and is not pinned to a single backend yet.  Nodes with a higher weight will receive more traffic.",
-                                "example": 50,
-                                "maximum": 255,
-                                "minimum": 1,
-                                "type": "integer",
-                                "x-linode-cli-display": 5
-                              }
-                            },
-                            "title": "TCP, HTTP, or HTTPS config",
-                            "x-akamai": {
-                              "file-path": "schemas/node-balancer-node-tcp-http-https.yaml"
-                            }
-                          },
-                          "type": "array"
                         },
                         "nodes_status": {
                           "additionalProperties": false,
@@ -87906,7 +87016,7 @@
                         },
                         "port": {
                           "default": 80,
-                          "description": "This is the port the NodeBalancer listens on for this configuration. Port numbers need to be unique across TCP, HTTP, and HTTPS configurations on a single NodeBalancer. However, ports assigned to TCP, HTTP, or HTTPS configurations can also be reused for UDP configurations. For example, Port 80 can simultaneously serve a TCP and a UDP configuration on the same NodeBalancer, but it can't be shared by both a TCP and an HTTP configuration. Although certain ports are traditionally associated with specific protocols, this is not strictly enforced. You may configure your NodeBalancer however is useful to you.",
+                          "description": "This is the port the NodeBalancer listens on for this configuration. Port numbers need to be unique across TCP, HTTP, and HTTPS configurations on a single NodeBalancer. However, ports assigned to TCP, HTTP, or HTTPS configurations can also be reused for UDP configurations. For example, Port 80 can simultaneously serve a TCP and a UDP configuration on the same NodeBalancer, but it can't be shared by both a TCP and an HTTP configuration. Although certain ports are traditionally associated with specific protocols, this isn't strictly enforced. You may configure your NodeBalancer however you find useful.",
                           "example": 80,
                           "maximum": 65535,
                           "minimum": 1,
@@ -87915,7 +87025,7 @@
                         },
                         "protocol": {
                           "default": "http",
-                          "description": "The protocol the port is configured to serve, `http` in this case.\nReview our guide on [Available protocols](https://techdocs.akamai.com/cloud-computing/docs/available-protocols) for information on protocol features.",
+                          "description": "The protocol the port is configured to serve, `http` in this case. Review our guide on [Available protocols](https://techdocs.akamai.com/cloud-computing/docs/available-protocols) for information on protocol features.",
                           "enum": [
                             "http"
                           ],
@@ -87960,7 +87070,7 @@
                         },
                         "stickiness": {
                           "default": "table",
-                          "description": "Controls how session stickiness is handled on this port.\n\n- If set to `none`, connections will always be assigned a backend based on the algorithm configured.\n- If set to `table`, sessions from the same remote address will be routed to the same backend.\n- If set to `http_cookie`, sessions are routed to the same backend based on a cookie set by the NodeBalancer.",
+                          "description": "Controls how session stickiness is handled on this port.\n\n- If set to `none`, connections are always assigned a backend based on the algorithm configured.\n- If set to `table`, sessions from the same remote address are routed to the same backend.\n- If set to `http_cookie`, sessions are routed to the same backend based on a cookie set by the NodeBalancer.",
                           "enum": [
                             "none",
                             "table",
@@ -87977,7 +87087,7 @@
                       "title": "HTTP",
                       "type": "object",
                       "x-akamai": {
-                        "file-path": "schemas/node-balancer-config-http.yaml"
+                        "file-path": "schemas/node-balancer-config-http-response.yaml"
                       }
                     },
                     {
@@ -87998,7 +87108,7 @@
                         },
                         "check": {
                           "default": "none",
-                          "description": "The type of check to perform against backends to ensure they are serving requests. This is used to determine if backends are up or down.\n\n- If `none` no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
+                          "description": "The type of check to perform against backends to ensure they are serving requests. The `check` is used to determine if backends are up or down.\n\n- If `none` no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
                           "enum": [
                             "none",
                             "connection",
@@ -88023,7 +87133,7 @@
                         },
                         "check_interval": {
                           "default": 5,
-                          "description": "How often, in seconds, to check that backends are up and serving requests.\n\nMust be greater than `check_timeout`.",
+                          "description": "The number of seconds between each check that backends are up and serving requests.\n\nMust be greater than `check_timeout`.",
                           "example": 90,
                           "maximum": 3600,
                           "minimum": 2,
@@ -88052,7 +87162,7 @@
                         },
                         "cipher_suite": {
                           "default": "recommended",
-                          "description": "What ciphers to use for SSL connections served by this NodeBalancer.\n\n- `legacy` is considered insecure and should only be used if necessary.",
+                          "description": "What ciphers to use for SSL connections served by this NodeBalancer. The `legacy` cipher is considered insecure and should only be used if necessary. For information on recommended and legacy ciphers, see [TLS cipher suites](https://techdocs.akamai.com/cloud-computing/docs/tls-ssl-termination-on-nodebalancers#tls-cipher-suites).",
                           "enum": [
                             "recommended",
                             "legacy"
@@ -88077,93 +87187,6 @@
                           "example": 12345,
                           "readOnly": true,
                           "type": "integer"
-                        },
-                        "nodes": {
-                          "description": "The NodeBalancer nodes that serve this configuration.",
-                          "items": {
-                            "additionalProperties": false,
-                            "description": "A NodeBalancer node represents a single backend serving requests for a single port of a NodeBalancer.  Nodes are specific to NodeBalancer configs, and serve traffic over their private IP.  If the same Linode is serving traffic for more than one port on the same NodeBalancer, one NodeBalancer node is required for each config (port) it should serve requests on.  For example, if you have four backends, and each should respond to both HTTP and HTTPS requests, you will need two NodeBalancer configs (port 80 and port 443) and four backends each, one for each of the Linodes serving requests for that port.",
-                            "properties": {
-                              "address": {
-                                "description": "The private IP Address where this backend can be reached. This _must_ be a private IP address.",
-                                "example": "192.168.210.120:80",
-                                "format": "ip",
-                                "type": "string",
-                                "x-linode-cli-display": 3
-                              },
-                              "config_id": {
-                                "description": "__Read-only__ The NodeBalancer Config ID that this Node belongs to.",
-                                "example": 4567,
-                                "readOnly": true,
-                                "type": "integer"
-                              },
-                              "id": {
-                                "description": "__Read-only__ This node's unique ID.",
-                                "example": 54321,
-                                "readOnly": true,
-                                "type": "integer",
-                                "x-linode-cli-display": 1
-                              },
-                              "label": {
-                                "description": "The label for this node.  This is for display purposes only.",
-                                "example": "node54321",
-                                "maxLength": 32,
-                                "minLength": 3,
-                                "pattern": "[a-zA-Z0-9-_.]{3,32}",
-                                "type": "string",
-                                "x-linode-cli-display": 2
-                              },
-                              "mode": {
-                                "description": "The mode this NodeBalancer should use when sending traffic to this backend.\n\n- If set to `accept` this backend is accepting traffic.\n- If set to `reject` this backend will not receive traffic.\n- If set to `drain` this backend will not receive _new_ traffic, but connections already pinned to it will continue to be routed to it.\n- If set to `backup`, this backend will only receive traffic if all `accept` nodes are down.",
-                                "enum": [
-                                  "accept",
-                                  "reject",
-                                  "drain",
-                                  "backup"
-                                ],
-                                "example": "accept",
-                                "type": "string",
-                                "x-linode-cli-display": 6
-                              },
-                              "nodebalancer_id": {
-                                "description": "__Read-only__ The NodeBalancer ID that this Node belongs to.",
-                                "example": 12345,
-                                "readOnly": true,
-                                "type": "integer"
-                              },
-                              "status": {
-                                "description": "__Read-only__ The current status of this node, based on the configured checks of its NodeBalancer Config.",
-                                "enum": [
-                                  "unknown",
-                                  "UP",
-                                  "DOWN"
-                                ],
-                                "example": "UP",
-                                "readOnly": true,
-                                "type": "string",
-                                "x-linode-cli-color": {
-                                  "DOWN": "red",
-                                  "UP": "green",
-                                  "default_": "white",
-                                  "unknown": "yellow"
-                                },
-                                "x-linode-cli-display": 4
-                              },
-                              "weight": {
-                                "description": "Used when picking a backend to serve a request and is not pinned to a single backend yet.  Nodes with a higher weight will receive more traffic.",
-                                "example": 50,
-                                "maximum": 255,
-                                "minimum": 1,
-                                "type": "integer",
-                                "x-linode-cli-display": 5
-                              }
-                            },
-                            "title": "TCP, HTTP, or HTTPS config",
-                            "x-akamai": {
-                              "file-path": "schemas/node-balancer-node-tcp-http-https.yaml"
-                            }
-                          },
-                          "type": "array"
                         },
                         "nodes_status": {
                           "additionalProperties": false,
@@ -88197,7 +87220,7 @@
                         },
                         "protocol": {
                           "default": "http",
-                          "description": "The protocol the port is configured to serve, `https` in this case.\n\n- The `https` protocol is mutually required with `ssl_cert` and `ssl_key`.\n\nReview our guide on [Available protocols](https://techdocs.akamai.com/cloud-computing/docs/available-protocols) for information on protocol features.",
+                          "description": "The protocol the port is configured to serve, `https` in this case. Review our guide on [Available protocols](https://techdocs.akamai.com/cloud-computing/docs/available-protocols) for information on protocol features. The `https` protocol needs to be specified with both `ssl_cert` and `ssl_key`.",
                           "enum": [
                             "https"
                           ],
@@ -88227,7 +87250,7 @@
                           "x-linode-cli-display": 8
                         },
                         "ssl_fingerprint": {
-                          "description": "__Read-only__ The read-only SHA1-encoded fingerprint automatically derived from the SSL certificate assigned to this NodeBalancerConfig. Please refer to this field to verify that the appropriate certificate is assigned to your NodeBalancerConfig.",
+                          "description": "__Read-only__ The read-only SHA1-encoded fingerprint automatically derived from the SSL certificate assigned to this NodeBalancer configuration. Please refer to the `ssl_fingerprint` field to verify that the appropriate certificate is assigned to your NodeBalancer configuration.",
                           "example": "00:01:02:03:04:05:06:07:08:09:0A:0B:0C:0D:0E:0F:10:11:12:13",
                           "readOnly": true,
                           "type": "string",
@@ -88259,12 +87282,12 @@
                       "title": "HTTPS",
                       "type": "object",
                       "x-akamai": {
-                        "file-path": "schemas/node-balancer-config-https.yaml"
+                        "file-path": "schemas/node-balancer-config-https-response.yaml"
                       }
                     }
                   ],
                   "x-akamai": {
-                    "file-path": "schemas/node-balancer-config.yaml"
+                    "file-path": "schemas/node-balancer-config-response.yaml"
                   }
                 },
                 "x-example": {
@@ -88433,7 +87456,7 @@
                       "x-linode-cli-display": 8
                     },
                     "ssl_fingerprint": {
-                      "description": "__Read-only__ The read-only SHA1-encoded fingerprint automatically derived from the SSL certificate assigned to this NodeBalancer config. Please refer to this field to verify that the appropriate certificate is assigned to your config.",
+                      "description": "__Read-only__ The read-only SHA1-encoded fingerprint automatically derived from the SSL certificate assigned to this NodeBalancer configuration. You can use the `ssl_fingerprint` field to verify that the appropriate certificate is assigned to your NodeBalancer configuration.",
                       "example": "00:01:02:03:04:05:06:07:08:09:0A:0B:0C:0D:0E:0F:10:11:12:13",
                       "readOnly": true,
                       "type": "string",
@@ -90418,7 +89441,7 @@
                           },
                           "check": {
                             "default": "none",
-                            "description": "The type of check to perform against backends to ensure they are serving requests. This is used to determine if backends are up or down.\n\n- If `none`, no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
+                            "description": "The type of check to perform against backends to ensure they are serving requests. The `check` is used to determine if backends are up or down.\n\n- If `none`, no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
                             "enum": [
                               "none",
                               "connection",
@@ -90471,8 +89494,8 @@
                             "type": "integer"
                           },
                           "cipher_suite": {
-                            "description": "__Read-only__ Not applicable for HTTP configs.",
-                            "example": "recommended",
+                            "description": "__Read-only__ Not applicable for TCP configs.",
+                            "example": "none",
                             "readOnly": true,
                             "type": "string",
                             "x-linode-cli-color": {
@@ -90662,11 +89685,10 @@
                           },
                           "stickiness": {
                             "default": "none",
-                            "description": "__Read-only__ Controls how session stickiness is handled on this port.\n\nNot applicable to TCP configurations.",
+                            "description": "__Read-only__ Controls how session stickiness is handled on this port.\n\n- If set to `none`, connections will always be assigned a backend based on the algorithm configured.\n- If set to `table`, sessions from the same remote address will be routed to the same backend.",
                             "enum": [
                               "none",
-                              "table",
-                              "http_cookie"
+                              "table"
                             ],
                             "example": "none",
                             "readOnly": true,
@@ -90887,7 +89909,7 @@
                           },
                           "port": {
                             "default": 80,
-                            "description": "This is the port the NodeBalancer listens on for this configuration. Port numbers need to be unique across TCP, HTTP, and HTTPS configurations on a single NodeBalancer. However, ports assigned to TCP, HTTP, or HTTPS configurations can also be reused for UDP configurations. For example, Port 80 can simultaneously serve a TCP and a UDP configuration on the same NodeBalancer, but it can't be shared by both a TCP and an HTTP configuration. Although certain ports are traditionally associated with specific protocols, this is not strictly enforced. You may configure your NodeBalancer however is useful to you.",
+                            "description": "This is the port the NodeBalancer listens on for this configuration. Port numbers need to be unique across TCP, HTTP, and HTTPS configurations on a single NodeBalancer. However, ports assigned to TCP, HTTP, or HTTPS configurations can also be reused for UDP configurations. For example, Port 80 can simultaneously serve a TCP and a UDP configuration on the same NodeBalancer, but it can't be shared by both a TCP and an HTTP configuration. Although certain ports are traditionally associated with specific protocols, this isn't strictly enforced. You may configure your NodeBalancer however you find useful.",
                             "example": 80,
                             "maximum": 65535,
                             "minimum": 1,
@@ -90979,7 +90001,7 @@
                           },
                           "check": {
                             "default": "none",
-                            "description": "The type of check to perform against backends to ensure they are serving requests. This is used to determine if backends are up or down.\n\n- If `none` no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
+                            "description": "The type of check to perform against backends to ensure they are serving requests. The `check` is used to determine if backends are up or down.\n\n- If `none` no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
                             "enum": [
                               "none",
                               "connection",
@@ -91208,7 +90230,7 @@
                             "x-linode-cli-display": 8
                           },
                           "ssl_fingerprint": {
-                            "description": "__Read-only__ The read-only SHA1-encoded fingerprint automatically derived from the SSL certificate assigned to this NodeBalancerConfig. Please refer to this field to verify that the appropriate certificate is assigned to your NodeBalancerConfig.",
+                            "description": "__Read-only__ The read-only SHA1-encoded fingerprint automatically derived from the SSL certificate assigned to this NodeBalancer configuration. Please refer to the `ssl_fingerprint` field to verify that the appropriate certificate is assigned to your NodeBalancer configuration.",
                             "example": "00:01:02:03:04:05:06:07:08:09:0A:0B:0C:0D:0E:0F:10:11:12:13",
                             "readOnly": true,
                             "type": "string",
@@ -91552,7 +90574,7 @@
                     "x-linode-cli-display": 8
                   },
                   "ssl_fingerprint": {
-                    "description": "__Read-only__ The read-only SHA1-encoded fingerprint automatically derived from the SSL certificate assigned to this NodeBalancerConfig. Please refer to this field to verify that the appropriate certificate is assigned to your NodeBalancerConfig.",
+                    "description": "__Read-only__ The read-only SHA1-encoded fingerprint automatically derived from the SSL certificate assigned to this NodeBalancer configuration. Please refer to the `ssl_fingerprint` field to verify that the appropriate certificate is assigned to your NodeBalancer configuration.",
                     "example": "00:01:02:03:04:05:06:07:08:09:0A:0B:0C:0D:0E:0F:10:11:12:13",
                     "readOnly": true,
                     "type": "string",
@@ -91616,7 +90638,7 @@
                         },
                         "check": {
                           "default": "none",
-                          "description": "The type of check to perform against backends to ensure they are serving requests. This is used to determine if backends are up or down.\n\n- If `none`, no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
+                          "description": "The type of check to perform against backends to ensure they are serving requests. This determines if backends are up or down.\n\n- If `none`, no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
                           "enum": [
                             "none",
                             "connection",
@@ -91649,13 +90671,13 @@
                         },
                         "check_passive": {
                           "default": true,
-                          "description": "If `true`, any response from this backend with a `5xx` status code will be enough for it to be considered unhealthy and taken out of rotation.",
+                          "description": "If `true`, any response from this backend with a `5xx` status code is enough for it to be considered unhealthy and taken out of rotation.",
                           "example": true,
                           "type": "boolean",
                           "x-linode-cli-display": 6
                         },
                         "check_path": {
-                          "description": "The URL path to check on each backend. If the backend does not respond to this request it is considered to be down.",
+                          "description": "The URL path to check on each backend. If the backend does not respond to this request, it's considered to be down.",
                           "example": "/test",
                           "pattern": "^[a-zA-Z0-9\\/\\-%?&=.]*$",
                           "type": "string"
@@ -91669,8 +90691,8 @@
                           "type": "integer"
                         },
                         "cipher_suite": {
-                          "description": "__Read-only__ Not applicable for HTTP configs.",
-                          "example": "recommended",
+                          "description": "__Read-only__ Not applicable for `tcp` configs.",
+                          "example": "none",
                           "readOnly": true,
                           "type": "string",
                           "x-linode-cli-color": {
@@ -91691,93 +90713,6 @@
                           "example": 12345,
                           "readOnly": true,
                           "type": "integer"
-                        },
-                        "nodes": {
-                          "description": "The NodeBalancer nodes that serve this configuration.",
-                          "items": {
-                            "additionalProperties": false,
-                            "description": "A NodeBalancer node represents a single backend serving requests for a single port of a NodeBalancer.  Nodes are specific to NodeBalancer configs, and serve traffic over their private IP.  If the same Linode is serving traffic for more than one port on the same NodeBalancer, one NodeBalancer node is required for each config (port) it should serve requests on.  For example, if you have four backends, and each should respond to both HTTP and HTTPS requests, you will need two NodeBalancer configs (port 80 and port 443) and four backends each, one for each of the Linodes serving requests for that port.",
-                            "properties": {
-                              "address": {
-                                "description": "The private IP Address where this backend can be reached. This _must_ be a private IP address.",
-                                "example": "192.168.210.120:80",
-                                "format": "ip",
-                                "type": "string",
-                                "x-linode-cli-display": 3
-                              },
-                              "config_id": {
-                                "description": "__Read-only__ The NodeBalancer Config ID that this Node belongs to.",
-                                "example": 4567,
-                                "readOnly": true,
-                                "type": "integer"
-                              },
-                              "id": {
-                                "description": "__Read-only__ This node's unique ID.",
-                                "example": 54321,
-                                "readOnly": true,
-                                "type": "integer",
-                                "x-linode-cli-display": 1
-                              },
-                              "label": {
-                                "description": "The label for this node.  This is for display purposes only.",
-                                "example": "node54321",
-                                "maxLength": 32,
-                                "minLength": 3,
-                                "pattern": "[a-zA-Z0-9-_.]{3,32}",
-                                "type": "string",
-                                "x-linode-cli-display": 2
-                              },
-                              "mode": {
-                                "description": "The mode this NodeBalancer should use when sending traffic to this backend.\n\n- If set to `accept` this backend is accepting traffic.\n- If set to `reject` this backend will not receive traffic.\n- If set to `drain` this backend will not receive _new_ traffic, but connections already pinned to it will continue to be routed to it.\n- If set to `backup`, this backend will only receive traffic if all `accept` nodes are down.",
-                                "enum": [
-                                  "accept",
-                                  "reject",
-                                  "drain",
-                                  "backup"
-                                ],
-                                "example": "accept",
-                                "type": "string",
-                                "x-linode-cli-display": 6
-                              },
-                              "nodebalancer_id": {
-                                "description": "__Read-only__ The NodeBalancer ID that this Node belongs to.",
-                                "example": 12345,
-                                "readOnly": true,
-                                "type": "integer"
-                              },
-                              "status": {
-                                "description": "__Read-only__ The current status of this node, based on the configured checks of its NodeBalancer Config.",
-                                "enum": [
-                                  "unknown",
-                                  "UP",
-                                  "DOWN"
-                                ],
-                                "example": "UP",
-                                "readOnly": true,
-                                "type": "string",
-                                "x-linode-cli-color": {
-                                  "DOWN": "red",
-                                  "UP": "green",
-                                  "default_": "white",
-                                  "unknown": "yellow"
-                                },
-                                "x-linode-cli-display": 4
-                              },
-                              "weight": {
-                                "description": "Used when picking a backend to serve a request and is not pinned to a single backend yet.  Nodes with a higher weight will receive more traffic.",
-                                "example": 50,
-                                "maximum": 255,
-                                "minimum": 1,
-                                "type": "integer",
-                                "x-linode-cli-display": 5
-                              }
-                            },
-                            "title": "TCP, HTTP, or HTTPS config",
-                            "x-akamai": {
-                              "file-path": "schemas/node-balancer-node-tcp-http-https.yaml"
-                            }
-                          },
-                          "type": "array"
                         },
                         "nodes_status": {
                           "additionalProperties": false,
@@ -91811,7 +90746,7 @@
                         },
                         "protocol": {
                           "default": "http",
-                          "description": "The protocol the port is configured to serve, `tcp` in this case.\n\nReview our guide on [Available protocols](https://techdocs.akamai.com/cloud-computing/docs/available-protocols) for information on protocol features.",
+                          "description": "The protocol the port is configured to serve, `tcp` in this case. Review our guide on [Available protocols](https://techdocs.akamai.com/cloud-computing/docs/available-protocols) for information on protocol features.",
                           "enum": [
                             "tcp"
                           ],
@@ -91878,7 +90813,7 @@
                       "title": "TCP",
                       "type": "object",
                       "x-akamai": {
-                        "file-path": "schemas/node-balancer-config-tcp.yaml"
+                        "file-path": "schemas/node-balancer-config-tcp-response.yaml"
                       }
                     },
                     {
@@ -91918,7 +90853,7 @@
                           "type": "integer"
                         },
                         "check_body": {
-                          "description": "Use when the active health `check` type is `http_body`. This value must be present in the response body of the check in order for it to pass. If this value is not present in the response body of a check request, the backend is considered to be down.",
+                          "description": "Use when the active health `check` type is `http_body`. This value needs to be in the response body of the check in order for it to pass. Otherwise the backend is considered to be down.",
                           "example": "it works",
                           "type": "string"
                         },
@@ -91952,8 +90887,8 @@
                           "type": "integer"
                         },
                         "cipher_suite": {
-                          "description": "__Read-only__ Not applicable for HTTP configs.",
-                          "example": "recommended",
+                          "description": "__Read-only__ Not applicable for `http` configs.",
+                          "example": "none",
                           "readOnly": true,
                           "type": "string",
                           "x-linode-cli-color": {
@@ -91974,93 +90909,6 @@
                           "example": 12345,
                           "readOnly": true,
                           "type": "integer"
-                        },
-                        "nodes": {
-                          "description": "The NodeBalancer nodes that serve this configuration.",
-                          "items": {
-                            "additionalProperties": false,
-                            "description": "A NodeBalancer node represents a single backend serving requests for a single port of a NodeBalancer.  Nodes are specific to NodeBalancer configs, and serve traffic over their private IP.  If the same Linode is serving traffic for more than one port on the same NodeBalancer, one NodeBalancer node is required for each config (port) it should serve requests on.  For example, if you have four backends, and each should respond to both HTTP and HTTPS requests, you will need two NodeBalancer configs (port 80 and port 443) and four backends each, one for each of the Linodes serving requests for that port.",
-                            "properties": {
-                              "address": {
-                                "description": "The private IP Address where this backend can be reached. This _must_ be a private IP address.",
-                                "example": "192.168.210.120:80",
-                                "format": "ip",
-                                "type": "string",
-                                "x-linode-cli-display": 3
-                              },
-                              "config_id": {
-                                "description": "__Read-only__ The NodeBalancer Config ID that this Node belongs to.",
-                                "example": 4567,
-                                "readOnly": true,
-                                "type": "integer"
-                              },
-                              "id": {
-                                "description": "__Read-only__ This node's unique ID.",
-                                "example": 54321,
-                                "readOnly": true,
-                                "type": "integer",
-                                "x-linode-cli-display": 1
-                              },
-                              "label": {
-                                "description": "The label for this node.  This is for display purposes only.",
-                                "example": "node54321",
-                                "maxLength": 32,
-                                "minLength": 3,
-                                "pattern": "[a-zA-Z0-9-_.]{3,32}",
-                                "type": "string",
-                                "x-linode-cli-display": 2
-                              },
-                              "mode": {
-                                "description": "The mode this NodeBalancer should use when sending traffic to this backend.\n\n- If set to `accept` this backend is accepting traffic.\n- If set to `reject` this backend will not receive traffic.\n- If set to `drain` this backend will not receive _new_ traffic, but connections already pinned to it will continue to be routed to it.\n- If set to `backup`, this backend will only receive traffic if all `accept` nodes are down.",
-                                "enum": [
-                                  "accept",
-                                  "reject",
-                                  "drain",
-                                  "backup"
-                                ],
-                                "example": "accept",
-                                "type": "string",
-                                "x-linode-cli-display": 6
-                              },
-                              "nodebalancer_id": {
-                                "description": "__Read-only__ The NodeBalancer ID that this Node belongs to.",
-                                "example": 12345,
-                                "readOnly": true,
-                                "type": "integer"
-                              },
-                              "status": {
-                                "description": "__Read-only__ The current status of this node, based on the configured checks of its NodeBalancer Config.",
-                                "enum": [
-                                  "unknown",
-                                  "UP",
-                                  "DOWN"
-                                ],
-                                "example": "UP",
-                                "readOnly": true,
-                                "type": "string",
-                                "x-linode-cli-color": {
-                                  "DOWN": "red",
-                                  "UP": "green",
-                                  "default_": "white",
-                                  "unknown": "yellow"
-                                },
-                                "x-linode-cli-display": 4
-                              },
-                              "weight": {
-                                "description": "Used when picking a backend to serve a request and is not pinned to a single backend yet.  Nodes with a higher weight will receive more traffic.",
-                                "example": 50,
-                                "maximum": 255,
-                                "minimum": 1,
-                                "type": "integer",
-                                "x-linode-cli-display": 5
-                              }
-                            },
-                            "title": "TCP, HTTP, or HTTPS config",
-                            "x-akamai": {
-                              "file-path": "schemas/node-balancer-node-tcp-http-https.yaml"
-                            }
-                          },
-                          "type": "array"
                         },
                         "nodes_status": {
                           "additionalProperties": false,
@@ -92085,7 +90933,7 @@
                         },
                         "port": {
                           "default": 80,
-                          "description": "This is the port the NodeBalancer listens on for this configuration. Port numbers need to be unique across TCP, HTTP, and HTTPS configurations on a single NodeBalancer. However, ports assigned to TCP, HTTP, or HTTPS configurations can also be reused for UDP configurations. For example, Port 80 can simultaneously serve a TCP and a UDP configuration on the same NodeBalancer, but it can't be shared by both a TCP and an HTTP configuration. Although certain ports are traditionally associated with specific protocols, this is not strictly enforced. You may configure your NodeBalancer however is useful to you.",
+                          "description": "This is the port the NodeBalancer listens on for this configuration. Port numbers need to be unique across TCP, HTTP, and HTTPS configurations on a single NodeBalancer. However, ports assigned to TCP, HTTP, or HTTPS configurations can also be reused for UDP configurations. For example, Port 80 can simultaneously serve a TCP and a UDP configuration on the same NodeBalancer, but it can't be shared by both a TCP and an HTTP configuration. Although certain ports are traditionally associated with specific protocols, this isn't strictly enforced. You may configure your NodeBalancer however you find useful.",
                           "example": 80,
                           "maximum": 65535,
                           "minimum": 1,
@@ -92094,7 +90942,7 @@
                         },
                         "protocol": {
                           "default": "http",
-                          "description": "The protocol the port is configured to serve, `http` in this case.\nReview our guide on [Available protocols](https://techdocs.akamai.com/cloud-computing/docs/available-protocols) for information on protocol features.",
+                          "description": "The protocol the port is configured to serve, `http` in this case. Review our guide on [Available protocols](https://techdocs.akamai.com/cloud-computing/docs/available-protocols) for information on protocol features.",
                           "enum": [
                             "http"
                           ],
@@ -92139,7 +90987,7 @@
                         },
                         "stickiness": {
                           "default": "table",
-                          "description": "Controls how session stickiness is handled on this port.\n\n- If set to `none`, connections will always be assigned a backend based on the algorithm configured.\n- If set to `table`, sessions from the same remote address will be routed to the same backend.\n- If set to `http_cookie`, sessions are routed to the same backend based on a cookie set by the NodeBalancer.",
+                          "description": "Controls how session stickiness is handled on this port.\n\n- If set to `none`, connections are always assigned a backend based on the algorithm configured.\n- If set to `table`, sessions from the same remote address are routed to the same backend.\n- If set to `http_cookie`, sessions are routed to the same backend based on a cookie set by the NodeBalancer.",
                           "enum": [
                             "none",
                             "table",
@@ -92156,7 +91004,7 @@
                       "title": "HTTP",
                       "type": "object",
                       "x-akamai": {
-                        "file-path": "schemas/node-balancer-config-http.yaml"
+                        "file-path": "schemas/node-balancer-config-http-response.yaml"
                       }
                     },
                     {
@@ -92177,7 +91025,7 @@
                         },
                         "check": {
                           "default": "none",
-                          "description": "The type of check to perform against backends to ensure they are serving requests. This is used to determine if backends are up or down.\n\n- If `none` no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
+                          "description": "The type of check to perform against backends to ensure they are serving requests. The `check` is used to determine if backends are up or down.\n\n- If `none` no check is performed.\n- `connection` requires only a connection to the backend to succeed.\n- `http` and `http_body` rely on the backend serving HTTP, and that the response returned matches what is expected.",
                           "enum": [
                             "none",
                             "connection",
@@ -92202,7 +91050,7 @@
                         },
                         "check_interval": {
                           "default": 5,
-                          "description": "How often, in seconds, to check that backends are up and serving requests.\n\nMust be greater than `check_timeout`.",
+                          "description": "The number of seconds between each check that backends are up and serving requests.\n\nMust be greater than `check_timeout`.",
                           "example": 90,
                           "maximum": 3600,
                           "minimum": 2,
@@ -92231,7 +91079,7 @@
                         },
                         "cipher_suite": {
                           "default": "recommended",
-                          "description": "What ciphers to use for SSL connections served by this NodeBalancer.\n\n- `legacy` is considered insecure and should only be used if necessary.",
+                          "description": "What ciphers to use for SSL connections served by this NodeBalancer. The `legacy` cipher is considered insecure and should only be used if necessary. For information on recommended and legacy ciphers, see [TLS cipher suites](https://techdocs.akamai.com/cloud-computing/docs/tls-ssl-termination-on-nodebalancers#tls-cipher-suites).",
                           "enum": [
                             "recommended",
                             "legacy"
@@ -92256,93 +91104,6 @@
                           "example": 12345,
                           "readOnly": true,
                           "type": "integer"
-                        },
-                        "nodes": {
-                          "description": "The NodeBalancer nodes that serve this configuration.",
-                          "items": {
-                            "additionalProperties": false,
-                            "description": "A NodeBalancer node represents a single backend serving requests for a single port of a NodeBalancer.  Nodes are specific to NodeBalancer configs, and serve traffic over their private IP.  If the same Linode is serving traffic for more than one port on the same NodeBalancer, one NodeBalancer node is required for each config (port) it should serve requests on.  For example, if you have four backends, and each should respond to both HTTP and HTTPS requests, you will need two NodeBalancer configs (port 80 and port 443) and four backends each, one for each of the Linodes serving requests for that port.",
-                            "properties": {
-                              "address": {
-                                "description": "The private IP Address where this backend can be reached. This _must_ be a private IP address.",
-                                "example": "192.168.210.120:80",
-                                "format": "ip",
-                                "type": "string",
-                                "x-linode-cli-display": 3
-                              },
-                              "config_id": {
-                                "description": "__Read-only__ The NodeBalancer Config ID that this Node belongs to.",
-                                "example": 4567,
-                                "readOnly": true,
-                                "type": "integer"
-                              },
-                              "id": {
-                                "description": "__Read-only__ This node's unique ID.",
-                                "example": 54321,
-                                "readOnly": true,
-                                "type": "integer",
-                                "x-linode-cli-display": 1
-                              },
-                              "label": {
-                                "description": "The label for this node.  This is for display purposes only.",
-                                "example": "node54321",
-                                "maxLength": 32,
-                                "minLength": 3,
-                                "pattern": "[a-zA-Z0-9-_.]{3,32}",
-                                "type": "string",
-                                "x-linode-cli-display": 2
-                              },
-                              "mode": {
-                                "description": "The mode this NodeBalancer should use when sending traffic to this backend.\n\n- If set to `accept` this backend is accepting traffic.\n- If set to `reject` this backend will not receive traffic.\n- If set to `drain` this backend will not receive _new_ traffic, but connections already pinned to it will continue to be routed to it.\n- If set to `backup`, this backend will only receive traffic if all `accept` nodes are down.",
-                                "enum": [
-                                  "accept",
-                                  "reject",
-                                  "drain",
-                                  "backup"
-                                ],
-                                "example": "accept",
-                                "type": "string",
-                                "x-linode-cli-display": 6
-                              },
-                              "nodebalancer_id": {
-                                "description": "__Read-only__ The NodeBalancer ID that this Node belongs to.",
-                                "example": 12345,
-                                "readOnly": true,
-                                "type": "integer"
-                              },
-                              "status": {
-                                "description": "__Read-only__ The current status of this node, based on the configured checks of its NodeBalancer Config.",
-                                "enum": [
-                                  "unknown",
-                                  "UP",
-                                  "DOWN"
-                                ],
-                                "example": "UP",
-                                "readOnly": true,
-                                "type": "string",
-                                "x-linode-cli-color": {
-                                  "DOWN": "red",
-                                  "UP": "green",
-                                  "default_": "white",
-                                  "unknown": "yellow"
-                                },
-                                "x-linode-cli-display": 4
-                              },
-                              "weight": {
-                                "description": "Used when picking a backend to serve a request and is not pinned to a single backend yet.  Nodes with a higher weight will receive more traffic.",
-                                "example": 50,
-                                "maximum": 255,
-                                "minimum": 1,
-                                "type": "integer",
-                                "x-linode-cli-display": 5
-                              }
-                            },
-                            "title": "TCP, HTTP, or HTTPS config",
-                            "x-akamai": {
-                              "file-path": "schemas/node-balancer-node-tcp-http-https.yaml"
-                            }
-                          },
-                          "type": "array"
                         },
                         "nodes_status": {
                           "additionalProperties": false,
@@ -92376,7 +91137,7 @@
                         },
                         "protocol": {
                           "default": "http",
-                          "description": "The protocol the port is configured to serve, `https` in this case.\n\n- The `https` protocol is mutually required with `ssl_cert` and `ssl_key`.\n\nReview our guide on [Available protocols](https://techdocs.akamai.com/cloud-computing/docs/available-protocols) for information on protocol features.",
+                          "description": "The protocol the port is configured to serve, `https` in this case. Review our guide on [Available protocols](https://techdocs.akamai.com/cloud-computing/docs/available-protocols) for information on protocol features. The `https` protocol needs to be specified with both `ssl_cert` and `ssl_key`.",
                           "enum": [
                             "https"
                           ],
@@ -92406,7 +91167,7 @@
                           "x-linode-cli-display": 8
                         },
                         "ssl_fingerprint": {
-                          "description": "__Read-only__ The read-only SHA1-encoded fingerprint automatically derived from the SSL certificate assigned to this NodeBalancerConfig. Please refer to this field to verify that the appropriate certificate is assigned to your NodeBalancerConfig.",
+                          "description": "__Read-only__ The read-only SHA1-encoded fingerprint automatically derived from the SSL certificate assigned to this NodeBalancer configuration. Please refer to the `ssl_fingerprint` field to verify that the appropriate certificate is assigned to your NodeBalancer configuration.",
                           "example": "00:01:02:03:04:05:06:07:08:09:0A:0B:0C:0D:0E:0F:10:11:12:13",
                           "readOnly": true,
                           "type": "string",
@@ -92438,12 +91199,12 @@
                       "title": "HTTPS",
                       "type": "object",
                       "x-akamai": {
-                        "file-path": "schemas/node-balancer-config-https.yaml"
+                        "file-path": "schemas/node-balancer-config-https-response.yaml"
                       }
                     }
                   ],
                   "x-akamai": {
-                    "file-path": "schemas/node-balancer-config.yaml"
+                    "file-path": "schemas/node-balancer-config-response.yaml"
                   }
                 },
                 "x-example": {
@@ -92684,7 +91445,7 @@
                       "x-linode-cli-display": 8
                     },
                     "ssl_fingerprint": {
-                      "description": "__Read-only__ The read-only SHA1-encoded fingerprint automatically derived from the SSL certificate assigned to this NodeBalancerConfig. Please refer to this field to verify that the appropriate certificate is assigned to your NodeBalancerConfig.",
+                      "description": "__Read-only__ The read-only SHA1-encoded fingerprint automatically derived from the SSL certificate assigned to this NodeBalancer configuration. Please refer to the `ssl_fingerprint` field to verify that the appropriate certificate is assigned to your NodeBalancer configuration.",
                       "example": "00:01:02:03:04:05:06:07:08:09:0A:0B:0C:0D:0E:0F:10:11:12:13",
                       "readOnly": true,
                       "type": "string",
@@ -93034,7 +91795,7 @@
                                               "description": "A list of IPv4 addresses or networks. Addresses must be in IP/mask format. Must not be an empty list.\n\nIf `0.0.0.0/0` is included in this list, all IPv4 addresses are affected by this rule.",
                                               "example": [
                                                 "192.0.2.0/24",
-                                                "192.0.2.216/24"
+                                                "192.0.2.131/24"
                                               ],
                                               "items": {
                                                 "type": "string"
@@ -93126,7 +91887,7 @@
                                               "description": "A list of IPv4 addresses or networks. Addresses must be in IP/mask format. Must not be an empty list.\n\nIf `0.0.0.0/0` is included in this list, all IPv4 addresses are affected by this rule.",
                                               "example": [
                                                 "192.0.2.0/24",
-                                                "192.0.2.243/24"
+                                                "192.0.2.21/24"
                                               ],
                                               "items": {
                                                 "type": "string"
@@ -93558,7 +92319,7 @@
     },
     "/{apiVersion}/object-storage/buckets": {
       "post": {
-        "description": "Creates an Object Storage bucket in the specified data center ([region](https://techdocs.akamai.com/linode-api/reference/get-regions)). If the bucket already exists on your account, this operation returns a 200 response with that bucket as if the API just created it.\n\n> 📘\n>\n> - Accounts with negative balances can't access this operation.\n>\n> - The [S3 API](https://docs.ceph.com/en/latest/radosgw/s3/bucketops/#put-bucket) equivalent operation offers more detail.\n>\n> - The API still supports the `clusterId` equivalent (`us-west-1`) when setting a `region` for a new bucket, but you should use the `regionId` (`us-west`), instead.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Creates an Object Storage bucket in the specified data center ([region](https://techdocs.akamai.com/linode-api/reference/get-regions)). If the bucket already exists on your account, this operation returns a 200 response with that bucket as if the API just created it.\n\n> 📘\n>\n> - Accounts with negative balances can't access this operation.\n>\n> - The API still supports the `clusterId` equivalent (`us-west-1`) when setting a `region` for a new bucket, but you should use the `regionId` (`us-west`) instead.\n>\n> - You can use an outside API, such as the [Ceph Object Gateway S3 API](https://docs.ceph.com/en/latest/radosgw/s3/bucketops/#put-bucket) for more options.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/post-object-storage-bucket"
@@ -93572,7 +92333,7 @@
                 "properties": {
                   "acl": {
                     "default": "private",
-                    "description": "The Access Control Level of the bucket using a canned ACL string. For more fine-grained control of ACLs, use the S3 API directly.",
+                    "description": "The S3 predefined collection of grantees and permissions set for the bucket, also referred to as a [Canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl).",
                     "enum": [
                       "private",
                       "public-read",
@@ -93583,12 +92344,12 @@
                     "type": "string"
                   },
                   "cors_enabled": {
-                    "description": "If set to `false`, CORS is disabled for all origins in the bucket. For more fine-grained controls of CORS, use the S3 API directly.",
+                    "description": "If set to `false`, cross-origin resource sharing (CORS) is disabled for all origins in the bucket.",
                     "example": "{{cors_enabled}}",
                     "type": "boolean"
                   },
                   "endpoint_type": {
-                    "description": "The type of `s3_endpoint` available to the active `user` in this `region`. See [Endpoint types](https://techdocs.akamai.com/cloud-computing/docs/object-storage#endpoint-type) for more information.",
+                    "description": "The type of `s3_endpoint` available to the active `user` in this `region`. See [Endpoint types](https://techdocs.akamai.com/cloud-computing/docs/object-storage#endpoint-types) for more information.",
                     "enum": [
                       "E0",
                       "E1",
@@ -93610,7 +92371,7 @@
                     "type": "string"
                   },
                   "s3_endpoint": {
-                    "description": "The active user's s3 endpoint URL, based on the `endpoint_type` and `region`.",
+                    "description": "The active user's S3-compatible endpoint URL, based on the `endpoint_type` and `region`.",
                     "example": "{{s3_endpoint}}",
                     "type": "string"
                   }
@@ -93637,7 +92398,7 @@
               "application/json": {
                 "schema": {
                   "additionalProperties": false,
-                  "description": "An Object Storage bucket. You should access this through the [S3 API](https://docs.ceph.com/en/latest/radosgw/s3/#api).",
+                  "description": "An Object Storage bucket.",
                   "properties": {
                     "cluster": {
                       "deprecated": true,
@@ -93655,7 +92416,7 @@
                       "type": "string"
                     },
                     "endpoint_type": {
-                      "description": "The type of `s3_endpoint` available to the active `user` in this `region`. See [Endpoint types](https://techdocs.akamai.com/cloud-computing/docs/object-storage#endpoint-type) for more information.",
+                      "description": "The type of `s3_endpoint` available to the active `user` in this `region`. See [Endpoint types](https://techdocs.akamai.com/cloud-computing/docs/object-storage#endpoint-types) for more information.",
                       "enum": [
                         "E0",
                         "E1",
@@ -93686,7 +92447,7 @@
                       "type": "string"
                     },
                     "s3_endpoint": {
-                      "description": "The active user's s3 endpoint URL, based on the `endpoint_type` and `region`.",
+                      "description": "The active user's S3-compatible endpoint URL, based on the `endpoint_type` and `region`.",
                       "example": "us-east-12.linodeobjects.com",
                       "type": "string"
                     },
@@ -93776,7 +92537,7 @@
         "x-linode-cli-skip": true
       },
       "get": {
-        "description": "Returns a paginated list of all Object Storage buckets available in your account.\n\n> 📘\n>\n> The [S3 API](https://docs.ceph.com/en/latest/radosgw/s3/serviceops/#list-buckets) equivalent operation offers more detail.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Returns a paginated list of all Object Storage buckets available in your account.\n\n> 📘\n>\n> You can use an outside API, such as the [Ceph Object Gateway S3 API](https://docs.ceph.com/en/latest/radosgw/s3/serviceops/#list-buckets) for more options.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-object-storage-buckets"
@@ -93792,7 +92553,7 @@
                     "data": {
                       "items": {
                         "additionalProperties": false,
-                        "description": "An Object Storage bucket. You should access this through the [S3 API](https://docs.ceph.com/en/latest/radosgw/s3/#api).",
+                        "description": "An Object Storage bucket.",
                         "properties": {
                           "cluster": {
                             "deprecated": true,
@@ -93810,7 +92571,7 @@
                             "type": "string"
                           },
                           "endpoint_type": {
-                            "description": "The type of `s3_endpoint` available to the active `user` in this `region`. See [Endpoint types](https://techdocs.akamai.com/cloud-computing/docs/object-storage#endpoint-type) for more information.",
+                            "description": "The type of `s3_endpoint` available to the active `user` in this `region`. See [Endpoint types](https://techdocs.akamai.com/cloud-computing/docs/object-storage#endpoint-types) for more information.",
                             "enum": [
                               "E0",
                               "E1",
@@ -93841,7 +92602,7 @@
                             "type": "string"
                           },
                           "s3_endpoint": {
-                            "description": "The active user's s3 endpoint URL, based on the `endpoint_type` and `region`.",
+                            "description": "The active user's S3-compatible endpoint URL, based on the `endpoint_type` and `region`.",
                             "example": "us-east-12.linodeobjects.com",
                             "type": "string"
                           },
@@ -93982,7 +92743,7 @@
     },
     "/{apiVersion}/object-storage/buckets/{regionId}": {
       "get": {
-        "description": "Returns a list of buckets on your account, in the specified region.\n\n> 📘\n>\n> The [S3 API](https://docs.ceph.com/en/latest/radosgw/s3/bucketops/#get-bucket) equivalent operation offers more detail.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Returns a list of buckets on your account, in the specified region.\n\n> 📘\n>\n> You can use the [Ceph Object Gateway S3 API](https://docs.ceph.com/en/latest/radosgw/s3/bucketops/#get-bucket) for more options.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-object-storage-bucketin-cluster"
@@ -93998,7 +92759,7 @@
                     "data": {
                       "items": {
                         "additionalProperties": false,
-                        "description": "An Object Storage bucket. You should access this through the [S3 API](https://docs.ceph.com/en/latest/radosgw/s3/#api).",
+                        "description": "An Object Storage bucket.",
                         "properties": {
                           "cluster": {
                             "deprecated": true,
@@ -94016,7 +92777,7 @@
                             "type": "string"
                           },
                           "endpoint_type": {
-                            "description": "The type of `s3_endpoint` available to the active `user` in this `region`. See [Endpoint types](https://techdocs.akamai.com/cloud-computing/docs/object-storage#endpoint-type) for more information.",
+                            "description": "The type of `s3_endpoint` available to the active `user` in this `region`. See [Endpoint types](https://techdocs.akamai.com/cloud-computing/docs/object-storage#endpoint-types) for more information.",
                             "enum": [
                               "E0",
                               "E1",
@@ -94047,7 +92808,7 @@
                             "type": "string"
                           },
                           "s3_endpoint": {
-                            "description": "The active user's s3 endpoint URL, based on the `endpoint_type` and `region`.",
+                            "description": "The active user's S3-compatible endpoint URL, based on the `endpoint_type` and `region`.",
                             "example": "us-east-12.linodeobjects.com",
                             "type": "string"
                           },
@@ -94202,7 +92963,7 @@
     },
     "/{apiVersion}/object-storage/buckets/{regionId}/{bucket}": {
       "get": {
-        "description": "Returns a single Object Storage bucket.\n\n> 📘\n>\n> The [S3 API](https://docs.ceph.com/en/latest/radosgw/s3/bucketops/#get-bucket) equivalent operation offers more detail.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Returns a single Object Storage bucket.\n\n> 📘\n>\n> You can use an outside API, such as the [Ceph Object Gateway S3 API](https://docs.ceph.com/en/latest/radosgw/s3/bucketops/#get-bucket) for more options.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-object-storage-bucket"
@@ -94214,7 +92975,7 @@
               "application/json": {
                 "schema": {
                   "additionalProperties": false,
-                  "description": "An Object Storage bucket. You should access this through the [S3 API](https://docs.ceph.com/en/latest/radosgw/s3/#api).",
+                  "description": "An Object Storage bucket.",
                   "properties": {
                     "cluster": {
                       "deprecated": true,
@@ -94232,7 +92993,7 @@
                       "type": "string"
                     },
                     "endpoint_type": {
-                      "description": "The type of `s3_endpoint` available to the active `user` in this `region`. See [Endpoint types](https://techdocs.akamai.com/cloud-computing/docs/object-storage#endpoint-type) for more information.",
+                      "description": "The type of `s3_endpoint` available to the active `user` in this `region`. See [Endpoint types](https://techdocs.akamai.com/cloud-computing/docs/object-storage#endpoint-types) for more information.",
                       "enum": [
                         "E0",
                         "E1",
@@ -94263,7 +93024,7 @@
                       "type": "string"
                     },
                     "s3_endpoint": {
-                      "description": "The active user's s3 endpoint URL, based on the `endpoint_type` and `region`.",
+                      "description": "The active user's S3-compatible endpoint URL, based on the `endpoint_type` and `region`.",
                       "example": "us-east-12.linodeobjects.com",
                       "type": "string"
                     },
@@ -94353,7 +93114,7 @@
         "x-linode-cli-skip": true
       },
       "delete": {
-        "description": "Removes a single bucket.\n\n> 📘\n>\n> - You need to remove all objects from a bucket before you can delete it. While you *can* delete a bucket using the [s3cmd command-line tool](https://www.linode.com/docs/products/storage/object-storage/guides/s3cmd/#delete-a-bucket), this operation fails if the bucket contains too many objects. The best way to empty large buckets is to use the [S3 API to configure lifecycle policies](https://docs.ceph.com/en/latest/radosgw/bucketpolicy/#). Set a policy to remove all objects, wait a day or more for the system to remove all objects, then delete the bucket.\n>\n> - The [S3 API](https://docs.ceph.com/en/latest/radosgw/s3/bucketops/#delete-bucket) equivalent operation offers more detail.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Removes a single bucket.\n\n> 📘\n>\n> - You need to remove all objects from a bucket before you can delete it. While you can delete a bucket using the [CLI](https://www.linode.com/docs/products/storage/object-storage/guides/s3cmd/#delete-a-bucket), this operation fails if the bucket contains too many objects. The best way to empty large buckets is to configure lifecycle policies with an outside API, such as the [Ceph Object Gateway S3 API](https://docs.ceph.com/en/latest/radosgw/bucketpolicy/#). Set a policy to remove all objects, wait a day or more for the system to remove all objects, then delete the bucket.\n>\n> - You can use an outside API, such as the [Ceph Object Gateway S3 API](https://docs.ceph.com/en/latest/radosgw/s3/bucketops/#delete-bucket) for more options.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/delete-object-storage-bucket"
@@ -94498,7 +93259,7 @@
     },
     "/{apiVersion}/object-storage/buckets/{regionId}/{bucket}/access": {
       "post": {
-        "description": "Apply basic Cross-origin Resource Sharing (CORS) and Access Control Level (ACL) settings. You can configure CORS for all origins and set canned ACL settings.\n\n> 📘\n>\n> For more fine-grained control of both systems, use the [S3 API](https://docs.ceph.com/en/latest/radosgw/s3/bucketops/#put-bucket-acl).\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Apply basic cross-origin resource sharing (CORS) and [S3 canned access control list (ACL)](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl) settings.\n\n> 📘\n>\n> You can use the S3 API for more fine-grained control of the [CORS](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enabling-cors-examples.html) or [S3 canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/managing-acls.html) settings.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/post-object-storage-bucket-access"
@@ -94511,7 +93272,7 @@
                 "additionalProperties": false,
                 "properties": {
                   "acl": {
-                    "description": "The Access Control Level of the bucket, as a canned ACL string. For more fine-grained control of ACLs, use the S3 API directly.",
+                    "description": "The S3 predefined collection of grantees and permissions set for the bucket, also referred to as a [Canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl).",
                     "enum": [
                       "private",
                       "public-read",
@@ -94523,7 +93284,7 @@
                     "type": "string"
                   },
                   "cors_enabled": {
-                    "description": "If `true`, the bucket will be created with CORS enabled for all origins. For more fine-grained controls of CORS, use the S3 API directly.",
+                    "description": "If `true`, cross-origin resource sharing (CORS) is enabled for all origins in the bucket.",
                     "example": "{{cors_enabled}}",
                     "type": "boolean"
                   }
@@ -94537,8 +93298,7 @@
                 "x-ref": "../examples/post-object-storage-bucket-access.json"
               }
             }
-          },
-          "description": "The changes to make to the bucket's access controls."
+          }
         },
         "responses": {
           "200": {
@@ -94611,7 +93371,7 @@
             "url": "https://api.linode.com/v4"
           }
         ],
-        "summary": "Modify access to an Object Storage bucket",
+        "summary": "Allow access to an Object Storage bucket",
         "tags": [
           "Bucket access"
         ],
@@ -94626,8 +93386,131 @@
         },
         "x-linode-cli-skip": true
       },
+      "get": {
+        "description": "View the cross-origin resource sharing (CORS) and [S3 canned access control (ACL)](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl) settings for a specific Object Storage bucket.\n\n> 📘\n>\n> You can use the S3 API to view more details on [CORS](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enabling-cors-examples.html) or [S3 canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/managing-acls.html) settings.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "externalDocs": {
+          "description": "See documentation for this operation in Akamai's Linode API",
+          "url": "https://techdocs.akamai.com/linode-api/reference/get-object-storage-bucket-access"
+        },
+        "operationId": "get-object-storage-bucket-access",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "acl": {
+                      "description": "The S3 predefined collection of grantees and permissions set for the bucket, also referred to as a [Canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl).",
+                      "enum": [
+                        "private",
+                        "public-read",
+                        "authenticated-read",
+                        "public-read-write",
+                        "custom"
+                      ],
+                      "example": "public-read",
+                      "type": "string"
+                    },
+                    "acl_xml": {
+                      "description": "The full XML of the object's ACL policy.",
+                      "example": "<AccessControlPolicy>...</AccessControlPolicy>",
+                      "type": "string"
+                    },
+                    "cors_enabled": {
+                      "description": "If `true`, cross-origin resource sharing (CORS) is enabled for all origins in the bucket. Returned as `null` for `E2` and `E3` [endpoint types](https://techdocs.akamai.com/cloud-computing/docs/object-storage#endpoint-types) because CORS is not supported.",
+                      "example": true,
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "cors_xml": {
+                      "description": "The full XML of the bucket's CORS policy. Returned as an empty object if `cors_enabled` is `false`, and `null` for `E2` and `E3` [endpoint types](https://techdocs.akamai.com/cloud-computing/docs/object-storage#endpoint-types). CORS is not supported with these endpoint types.",
+                      "example": "<CORSConfiguration>...</CORSConfiguration>",
+                      "nullable": true,
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-akamai": {
+                    "file-path": "schemas/get-object-storage-bucket-access-200.yaml"
+                  }
+                },
+                "x-example": {
+                  "x-ref": "../examples/get-object-storage-bucket-access-200.json"
+                }
+              }
+            },
+            "description": "Access settings for the specific bucket."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "errors": {
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "An object for describing a single error that occurred during the processing of a request.",
+                        "properties": {
+                          "field": {
+                            "description": "The field in the request that caused this error. This may be a path, separated by periods in the case of nested fields. In some cases this may come back as `null` if the error is not specific to any single element of the request.",
+                            "example": "fieldname",
+                            "type": "string"
+                          },
+                          "reason": {
+                            "description": "What happened to cause this error. In most cases, this can be fixed immediately by changing the data you sent in the request, but in some cases you will be instructed to [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) or perform some other action before you can complete the request successfully.",
+                            "example": "fieldname must be a valid value",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-akamai": {
+                          "file-path": "schemas/error-object.yaml"
+                        }
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "See [Errors](https://techdocs.akamai.com/linode-api/reference/errors) for the range of possible error response codes."
+          }
+        },
+        "security": [
+          {
+            "personalAccessToken": []
+          },
+          {
+            "oauth": [
+              "object_storage:read_only"
+            ]
+          }
+        ],
+        "servers": [
+          {
+            "url": "https://api.linode.com/v4"
+          }
+        ],
+        "summary": "Get Object Storage bucket access",
+        "tags": [
+          "Bucket access"
+        ],
+        "x-akamai": {
+          "tabs": [
+            {
+              "syntax": "object_storage:read_only",
+              "title": "OAuth scopes",
+              "url": "https://techdocs.akamai.com/linode-api/reference/get-started#oauth"
+            }
+          ]
+        },
+        "x-linode-cli-skip": true
+      },
       "put": {
-        "description": "Update basic Cross-origin Resource Sharing (CORS) and Access Control Level (ACL) settings. You can configure CORS for all origins and set canned ACL settings.\n\n> 📘\n>\n> For more fine-grained control of both systems, use the [S3 API](https://docs.ceph.com/en/latest/radosgw/s3/bucketops/#put-bucket-acl).\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Update basic cross-origin resource sharing (CORS) and [S3 canned access control list (ACL)](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl) settings.\n\n> 📘\n>\n> You can use the S3 API for more fine-grained control of the [CORS](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enabling-cors-examples.html) or [S3 canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/managing-acls.html) settings.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/put-storage-bucket-access"
@@ -94640,7 +93523,7 @@
                 "additionalProperties": false,
                 "properties": {
                   "acl": {
-                    "description": "The Access Control Level of the bucket, as a canned ACL string. For more fine-grained control of ACLs, use the S3 API directly.",
+                    "description": "The S3 predefined collection of grantees and permissions set for the bucket, also referred to as a [Canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl).",
                     "enum": [
                       "private",
                       "public-read",
@@ -94652,7 +93535,7 @@
                     "type": "string"
                   },
                   "cors_enabled": {
-                    "description": "If `true`, the API creates the bucket with CORS enabled for all origins. For more fine-grained controls of CORS, use the S3 API directly.",
+                    "description": "If `true`, the API enables cross-origin resource sharing for all origins on the bucket.",
                     "example": "{{cors_enabled}}",
                     "type": "boolean"
                   }
@@ -94807,7 +93690,7 @@
     },
     "/{apiVersion}/object-storage/buckets/{regionId}/{bucket}/object-acl": {
       "get": {
-        "description": "View an Object's configured Access Control List (ACL) in this Object Storage bucket. ACLs define who can access your buckets and objects and specify the level of access granted to those users.\n\n> 📘\n>\n> The [S3 API](https://docs.ceph.com/en/latest/radosgw/s3/objectops/#get-object-acl) equivalent operation offers more detail.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "View a specific object's access control list (ACL) settings. ACLs define who can access your buckets and objects and specify the level of access granted to those users.\n\n> 📘\n>\n> You can use an outside API, such as the [Ceph Object Gateway S3 API](https://docs.ceph.com/en/latest/radosgw/s3/objectops/#get-object-acl) for more options.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-object-storage-bucket-acl"
@@ -94815,7 +93698,7 @@
         "operationId": "get-object-storage-bucket-acl",
         "parameters": [
           {
-            "description": "The `name` of the object for which to retrieve its Access Control List (ACL). Run the [List Object Storage bucket contents](https://techdocs.akamai.com/linode-api/reference/get-object-storage-bucket-content) operation to access all object names in a bucket.",
+            "description": "The name of a specific object to get its access control list (ACL) details. Run the [List Object Storage bucket contents](https://techdocs.akamai.com/linode-api/reference/get-object-storage-bucket-content) operation to access all object names in a bucket.",
             "example": "{{name}}",
             "in": "query",
             "name": "name",
@@ -94836,7 +93719,7 @@
                   "additionalProperties": false,
                   "properties": {
                     "acl": {
-                      "description": "The Access Control Level of the bucket, as a canned ACL string. For more fine-grained control of ACLs, use the S3 API directly.",
+                      "description": "The S3 predefined collection of grantees and permissions set for the bucket, also referred to as a [Canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl).",
                       "enum": [
                         "private",
                         "public-read",
@@ -94917,7 +93800,7 @@
             "url": "https://api.linode.com/v4"
           }
         ],
-        "summary": "Get an Object Storage object ACL config",
+        "summary": "Get an Object Storage object ACL configuration",
         "tags": [
           "ACL configurations"
         ],
@@ -94933,7 +93816,7 @@
         "x-linode-cli-skip": true
       },
       "put": {
-        "description": "Update an object's configured access control level (ACL) in this Object Storage bucket. ACLs define who can access your buckets and objects, and specify the level of access granted to those users.\n\n> 📘\n>\n> The [S3 API](https://docs.ceph.com/en/latest/radosgw/s3/objectops/#set-object-acl) equivalent operation offers more detail.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Update a specific object's access control list (ACL) settings. ACLs define who can access your buckets and objects, and specify the level of access granted to those users.\n\n> 📘\n>\n> You can use an outside API, such as the [Ceph Object Gateway S3 API](https://docs.ceph.com/en/latest/radosgw/s3/objectops/#set-object-acl) for more options.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/put-object-storage-bucket-acl"
@@ -94946,7 +93829,7 @@
                 "additionalProperties": false,
                 "properties": {
                   "acl": {
-                    "description": "The Access Control Level of the bucket, as a canned ACL string. For more fine-grained control of ACLs, use the S3 API directly.",
+                    "description": "The S3 predefined collection of grantees and permissions set for the bucket, also referred to as a [Canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl).",
                     "enum": [
                       "private",
                       "public-read",
@@ -94958,7 +93841,7 @@
                     "type": "string"
                   },
                   "name": {
-                    "description": "The `name` of the object for which to update its Access Control List (ACL). Run the [List Object Storage bucket contents](https://techdocs.akamai.com/linode-api/reference/get-object-storage-bucket-content) operation to access all object names in a bucket.",
+                    "description": "The name of the object where access control list (ACL) settings will be updated. Run the [List Object Storage bucket contents](https://techdocs.akamai.com/linode-api/reference/get-object-storage-bucket-content) operation to access all object names in a bucket.",
                     "example": "{{name}}",
                     "type": "string"
                   }
@@ -94995,7 +93878,7 @@
                 }
               }
             },
-            "description": "The ACL config was updated."
+            "description": "The ACL configuration was updated."
           },
           "default": {
             "content": {
@@ -95049,7 +93932,7 @@
             "url": "https://api.linode.com/v4"
           }
         ],
-        "summary": "Update an object's ACL config",
+        "summary": "Update an object's ACL configuration",
         "tags": [
           "ACL configurations"
         ],
@@ -95117,7 +94000,7 @@
     },
     "/{apiVersion}/object-storage/buckets/{regionId}/{bucket}/object-list": {
       "get": {
-        "description": "Returns the contents of a bucket. The contents are paginated using a `marker`, that's the name of the last object on the previous page.  Objects can also be filtered by `prefix` and `delimiter`. See [Filtering and sorting](https://techdocs.akamai.com/linode-api/reference/filtering-and-sorting) for more information.\n\n> 📘\n>\n> The [S3 API](https://docs.ceph.com/en/latest/radosgw/s3/objectops/#get-object) equivalent operation offers more detail.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Returns the contents of a bucket. The contents are paginated using a `marker`, that's the name of the last object on the previous page. Objects can also be filtered by `prefix` and `delimiter`. See [Filtering and sorting](https://techdocs.akamai.com/linode-api/reference/filtering-and-sorting) for more information.\n\n> 📘\n>\n> You can use an outside API, such as the [Ceph Object Gateway S3 API](https://docs.ceph.com/en/latest/radosgw/s3/objectops/#get-object) for more options.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-object-storage-bucket-content"
@@ -95370,7 +94253,7 @@
     },
     "/{apiVersion}/object-storage/buckets/{regionId}/{bucket}/object-url": {
       "post": {
-        "description": "Creates a pre-signed URL to access a single object in a bucket. Use it to share, create, or delete objects by using the appropriate HTTP method in your request body's `method` parameter.\n\n> 📘\n>\n> The [S3 API](https://docs.ceph.com/en/latest/radosgw/s3/) equivalent operation offers more detail.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Creates a pre-signed URL to access a single object in a bucket. Use it to share, create, or delete objects by using the appropriate HTTP method in your request body's `method` parameter.\n\n> 📘\n>\n> You can use an outside API, such as the [Ceph Object Gateway S3 API](https://docs.ceph.com/en/latest/radosgw/s3/) for more options.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/post-object-storage-object-url"
@@ -95967,7 +94850,7 @@
     },
     "/{apiVersion}/object-storage/cancel": {
       "post": {
-        "description": "Cancel Object Storage on an Account.\n\n__Warning__. This removes all buckets and their contents from your Account. This data is irretrievable once removed.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli object-storage cancel\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Cancel Object Storage on an Account.\n\n> 🚧\n>\n> This removes all buckets and their contents from your Account. This data is irretrievable once removed.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli object-storage cancel\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/post-cancel-object-storage"
@@ -96092,7 +94975,7 @@
     "/{apiVersion}/object-storage/clusters": {
       "get": {
         "deprecated": true,
-        "description": "__Deprecated__ Returns a paginated list of available Object Storage legacy clusters.\n\n> 📘\n>\n> This displays deprecated `clusterId` values that represent regions used with older versions of the API. It's maintained for backward compatibility. Run [Get a region](https://techdocs.akamai.com/linode-api/reference/get-region), instead.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli object-storage clusters-list\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)",
+        "description": "__Deprecated__ Returns a paginated list of available Object Storage legacy clusters.\n\n> 📘\n>\n> This displays deprecated `clusterId` values that represent regions used with older versions of the API. It's maintained for backward compatibility. Run [Get a region](https://techdocs.akamai.com/linode-api/reference/get-region) instead.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli object-storage clusters-list\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-object-storage-clusters"
@@ -96264,7 +95147,7 @@
     "/{apiVersion}/object-storage/clusters/{clusterId}": {
       "get": {
         "deprecated": true,
-        "description": "__Deprecated__ Returns a single Object Storage cluster.\n\n> 📘\n>\n> This displays deprecated `clusterId` values that represent regions used with older versions of the API. It's maintained for backward compatibility. Run [Get a region](https://techdocs.akamai.com/linode-api/reference/get-region), instead.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli object-storage clusters-view us-east-1\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)",
+        "description": "__Deprecated__ Returns a single Object Storage cluster.\n\n> 📘\n>\n> This displays deprecated `clusterId` values that represent regions used with older versions of the API. It's maintained for backward compatibility. Run [Get a region](https://techdocs.akamai.com/linode-api/reference/get-region) instead.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli object-storage clusters-view us-east-1\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-object-storage-cluster"
@@ -96419,7 +95302,7 @@
     },
     "/{apiVersion}/object-storage/endpoints": {
       "get": {
-        "description": "Returns a paginated list of all Object Storage endpoints available in your account.",
+        "description": "Returns a paginated list of all Object Storage endpoints available in your account.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli object-storage endpoints-list\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-object-storage-endpoints"
@@ -96440,7 +95323,7 @@
                             "description": "Object Storage endpoints object.",
                             "properties": {
                               "endpoint_type": {
-                                "description": "__Read-only__ The type of `s3_endpoint` available to the active `user` in this `region`. See [Endpoint types](https://techdocs.akamai.com/cloud-computing/docs/object-storage#endpoint-type) for more information.",
+                                "description": "The type of `s3_endpoint` available to the active `user` in this `region`. See [Endpoint types](https://techdocs.akamai.com/cloud-computing/docs/object-storage#endpoint-types) for more information.",
                                 "enum": [
                                   "E0",
                                   "E1",
@@ -96448,26 +95331,25 @@
                                   "E3"
                                 ],
                                 "example": "E1",
-                                "readOnly": true,
-                                "type": "string"
+                                "type": "string",
+                                "x-linode-cli-display": 2
                               },
                               "region": {
-                                "description": "__Read-only__ The Akamai cloud computing region, represented by its slug value. Run the [List regions](https://techdocs.akamai.com/linode-api/reference/get-regions) operation to view all regions and their slugs.",
+                                "description": "The Akamai cloud computing region, represented by its slug value. Run the [List regions](https://techdocs.akamai.com/linode-api/reference/get-regions) operation to view all regions and their slugs.",
                                 "example": "us-iad",
-                                "readOnly": true,
                                 "type": "string"
                               },
                               "s3_endpoint": {
-                                "description": "__Read-only__ Your s3 endpoint URL, based on the `endpoint_type` and `region`. Displayed as `null` if you haven't assigned an endpoint for your user.",
+                                "description": "Your S3-compatible endpoint URL, based on the `endpoint_type` and `region`. Displayed as `null` if you haven't assigned an endpoint for your user.",
                                 "example": "us-iad-1.linodeobjects.com",
                                 "nullable": true,
-                                "readOnly": true,
-                                "type": "string"
+                                "type": "string",
+                                "x-linode-cli-display": 1
                               }
                             },
                             "type": "object",
                             "x-akamai": {
-                              "file-path": "schemas/object-storage-endpoints.yaml"
+                              "file-path": "schemas/object-storage-endpoint.yaml"
                             }
                           },
                           "type": "array"
@@ -96507,6 +95389,9 @@
                   "x-akamai": {
                     "file-path": "schemas/added-get-object-storage-endpoints-200.yaml"
                   }
+                },
+                "x-example": {
+                  "x-ref": "../examples/added-get-object-storage-endpoints-200.json"
                 }
               }
             },
@@ -96549,6 +95434,16 @@
             "description": "See [Errors](https://techdocs.akamai.com/linode-api/reference/errors) for the range of possible error response codes."
           }
         },
+        "security": [
+          {
+            "personalAccessToken": []
+          },
+          {
+            "oauth": [
+              "object_storage:read_only"
+            ]
+          }
+        ],
         "servers": [
           {
             "url": "https://api.linode.com/v4"
@@ -96558,13 +95453,21 @@
         "tags": [
           "Endpoints"
         ],
-        "x-code-samples": [
-          {
-            "lang": "Shell",
-            "source": "curl https://api.linode.com/v4/object-storage/endpoints"
-          }
-        ],
-        "x-linode-cli-skip": true
+        "x-akamai": {
+          "tabs": [
+            {
+              "syntax": "linode-cli object-storage endpoints-list",
+              "title": "CLI",
+              "url": "https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli"
+            },
+            {
+              "syntax": "object_storage:read_only",
+              "title": "OAuth scopes",
+              "url": "https://techdocs.akamai.com/linode-api/reference/get-started#oauth"
+            }
+          ]
+        },
+        "x-linode-cli-action": "endpoints"
       },
       "parameters": [
         {
@@ -96592,7 +95495,7 @@
     },
     "/{apiVersion}/object-storage/keys": {
       "post": {
-        "description": "Provisions a new Object Storage key for authenticating to the Object Storage S3 API. A successful request triggers an `obj_access_key_create` [event](https://techdocs.akamai.com/linode-api/reference/get-events).\n\n> 📘\n>\n> Accounts with negative balances can't access this operation.\n\n**The `regions` and `region` parameters**\n\nWhen creating an Object Storage key, specify one or more data centers ([regions](https://techdocs.akamai.com/linode-api/reference/get-regions)) where you want to create and manage Object Storage buckets.\n\n- **The `regions` array**. Populate it with `regionId` values. The resulting Object Storage key grants access to list and create new buckets in these regions. This *doesn't* give access to manage content in these buckets. To address this, you can:\n\n  - Use the `bucket_access` array instead to grant management access, per bucket.\n\n  - Use [bucket policies](https://www.linode.com/docs/products/storage/object-storage/guides/bucket-policies/) to change the access for this key.\n\n- **The `bucket_access` array**. This optional array lets you set up limited keys. Include individual objects naming a `regionId`, the target `bucket_name`, and the `permissions` for the Object Storage key. Use the resulting key to manage content in the `bucket_name`, based on the permission level set. You can also use the key to create new buckets in the named region. However, the key doesn't have access to manage content in the newly created bucket. You can grant it this access using [bucket policies](https://www.linode.com/docs/products/storage/object-storage/guides/bucket-policies/).\n\n- **Combine the two to apply varying levels of access in the key**. For example, set `regions` to `us-west` to give the key bucket list and create access in that region. Then, set up the `bucket_access` array to give access to a specific `bucket_name` in the `us-east` region. The key has access to manage content in that `bucket_name` and list and create buckets in the `us-east` region, too. If you include the same region in both, the settings applied in the `bucket_access` array take precedence. For example, assume you include `us-east` in the `regions` array, expecting to only give bucket list and creation access to that region. If you also set `us-east` as a `region` in the `bucket_access` array, the Object Storage key gives access to manage content in the specified `bucket_name`, and lets you list and create buckets in that region.\n\n**The `cluster` parameter (legacy)**\n\nFor backward compatibility, include the `cluster` parameter to create an Object Storage key. Use the `clusterId` equivalent (us-west-1) instead of the `regionId` (us-west). Leave the `regions` array out. If including the `bucket_access` array to limit access, omit `region` from each object. Use the resulting key in clusters in all supported regions.\n\n> 📘\n>\n> While the API supports this method, you should use the `regions` parameters, instead.\n\n- **Unlimited access**. Omit the `bucket_access` array. The Object Storage key has unlimited cluster access to all buckets, with all permissions.\n\n- **Limited access**. Include the `bucket_access` array. Set the target `bucket_name` and the level of `permissions` for access to that bucket. Use the resulting key to manage content in the named bucket. A limited Object Storage key can [list all buckets](https://techdocs.akamai.com/linode-api/reference/get-object-storage-buckets) and [create a new bucket](https://techdocs.akamai.com/linode-api/reference/post-object-storage-bucket). However, you can't use the key to perform any actions on a bucket, unless the key has access to it. You can use [bucket policies](https://www.linode.com/docs/products/storage/object-storage/guides/bucket-policies/) to modify a key's access.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli object-storage keys-create \\\n  --label \"my-object-storage-key\" \\\n  --bucket_access '[{\"region\": \"ap-south\", \"bucket_name\": \"bucket-example-1\", \"permissions\": \"read_write\" }]'\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Provisions a new Object Storage key for authentication. A successful request triggers an `obj_access_key_create` [event](https://techdocs.akamai.com/linode-api/reference/get-events).\n\n> 📘\n>\n> Accounts with negative balances can't access this operation.\n\n**The `regions` and `region` parameters**\n\nWhen creating an Object Storage key, specify one or more data centers ([regions](https://techdocs.akamai.com/linode-api/reference/get-regions)) where you want to create and manage Object Storage buckets.\n\n- **The `regions` array**. Populate it with `regionId` values. The resulting Object Storage key grants access to list and create new buckets in these regions. This *doesn't* give access to manage content in these buckets. To address this, you can:\n\n  - Use the `bucket_access` array instead to grant management access, per bucket.\n\n  - Use [bucket policies](https://www.linode.com/docs/products/storage/object-storage/guides/bucket-policies/) to change the access for this key.\n\n- **The `bucket_access` array**. This optional array lets you set up limited keys. Include individual objects naming a `regionId`, the target `bucket_name`, and the `permissions` for the Object Storage key. Use the resulting key to manage content in the `bucket_name`, based on the permission level set. You can also use the key to create new buckets in the named region. However, the key doesn't have access to manage content in the newly created bucket. You can grant it this access using [bucket policies](https://www.linode.com/docs/products/storage/object-storage/guides/bucket-policies/).\n\n- **Combine the two to apply varying levels of access in the key**. For example, set `regions` to `us-west` to give the key bucket list and create access in that region. Then, set up the `bucket_access` array to give access to a specific `bucket_name` in the `us-east` region. The key has access to manage content in that `bucket_name` and list and create buckets in the `us-east` region, too. If you include the same region in both, the settings applied in the `bucket_access` array take precedence. For example, assume you include `us-east` in the `regions` array, expecting to only give bucket list and creation access to that region. If you also set `us-east` as a `region` in the `bucket_access` array, the Object Storage key gives access to manage content in the specified `bucket_name`, and lets you list and create buckets in that region.\n\n**The `cluster` parameter (legacy)**\n\nFor backward compatibility, include the `cluster` parameter to create an Object Storage key. Use the `clusterId` equivalent (us-west-1) instead of the `regionId` (us-west). Leave the `regions` array out. If including the `bucket_access` array to limit access, omit `region` from each object. Use the resulting key in clusters in all supported regions.\n\n> 📘\n>\n> While the API supports this method, you should use the `regions` parameters, instead.\n\n- **Unlimited access**. Omit the `bucket_access` array. The Object Storage key has unlimited cluster access to all buckets, with all permissions.\n\n- **Limited access**. Include the `bucket_access` array. Set the target `bucket_name` and the level of `permissions` for access to that bucket. Use the resulting key to manage content in the named bucket. A limited Object Storage key can [list all buckets](https://techdocs.akamai.com/linode-api/reference/get-object-storage-buckets) and [create a new bucket](https://techdocs.akamai.com/linode-api/reference/post-object-storage-bucket). However, you can't use the key to perform any actions on a bucket, unless the key has access to it. You can use [bucket policies](https://www.linode.com/docs/products/storage/object-storage/guides/bucket-policies/) to modify a key's access.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli object-storage keys-create \\\n  --label \"my-object-storage-key\" \\\n  --bucket_access '[{\"region\": \"ap-south\", \"bucket_name\": \"bucket-example-1\", \"permissions\": \"read_write\" }]'\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/post-object-storage-keys"
@@ -96667,10 +95570,10 @@
               "application/json": {
                 "schema": {
                   "additionalProperties": false,
-                  "description": "A key used to communicate with the Object Storage S3 API.",
+                  "description": "A key used to validate requests to an S3 API.",
                   "properties": {
                     "access_key": {
-                      "description": "__Read-only__ A unique string chosen by the API to identify this key. Used as a username to identify this key when making requests to the S3 API.",
+                      "description": "__Read-only__ A unique string chosen by the API to identify this key. Used as a username to identify this key when making requests an S3 API, such as the Amazon S3 API or Ceph Object Gateway S3 API.",
                       "example": "KVAKUTGBA4WTR2NSJQ81",
                       "readOnly": true,
                       "type": "string"
@@ -96732,7 +95635,7 @@
                         "additionalProperties": false,
                         "properties": {
                           "endpoint_type": {
-                            "description": "The type of `s3_endpoint` available to the active `user` in this `region`. See [Endpoint types](https://techdocs.akamai.com/cloud-computing/docs/object-storage#endpoint-type) for more information.",
+                            "description": "The type of `s3_endpoint` available to the active `user` in this `region`. See [Endpoint types](https://techdocs.akamai.com/cloud-computing/docs/object-storage#endpoint-types) for more information.",
                             "enum": [
                               "E0",
                               "E1",
@@ -96758,7 +95661,7 @@
                       "type": "array"
                     },
                     "secret_key": {
-                      "description": "__Read-only__ This Object Storage key's secret key. Used as a password to validate this key when making requests to the S3 API. This value is only revealed in a response after creating or modifying a key.",
+                      "description": "__Read-only__ This Object Storage key's secret key. Used as a password to validate this key when making requests an S3 API, such as the Amazon S3 API or Ceph Object Gateway S3 API. This value is only revealed in a response after creating or modifying a key.",
                       "readOnly": true,
                       "type": "string"
                     }
@@ -96848,7 +95751,7 @@
         "x-linode-cli-action": "keys-create"
       },
       "get": {
-        "description": "Returns a paginated list of Object Storage keys for authenticating to the Object Storage S3 API.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli object-storage keys-list\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Returns a paginated list of Object Storage keys for authentication.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli object-storage keys-list\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-object-storage-keys"
@@ -96864,10 +95767,10 @@
                     "data": {
                       "items": {
                         "additionalProperties": false,
-                        "description": "A key used to communicate with the Object Storage S3 API.",
+                        "description": "A key used to validate requests to an S3 API.",
                         "properties": {
                           "access_key": {
-                            "description": "__Read-only__ A unique string chosen by the API to identify this key. Used as a username to identify this key when making requests to the S3 API.",
+                            "description": "__Read-only__ A unique string chosen by the API to identify this key. Used as a username to identify this key when making requests an S3 API, such as the Amazon S3 API or Ceph Object Gateway S3 API.",
                             "example": "KVAKUTGBA4WTR2NSJQ81",
                             "readOnly": true,
                             "type": "string"
@@ -96929,7 +95832,7 @@
                               "additionalProperties": false,
                               "properties": {
                                 "endpoint_type": {
-                                  "description": "The type of `s3_endpoint` available to the active `user` in this `region`. See [Endpoint types](https://techdocs.akamai.com/cloud-computing/docs/object-storage#endpoint-type) for more information.",
+                                  "description": "The type of `s3_endpoint` available to the active `user` in this `region`. See [Endpoint types](https://techdocs.akamai.com/cloud-computing/docs/object-storage#endpoint-types) for more information.",
                                   "enum": [
                                     "E0",
                                     "E1",
@@ -96955,7 +95858,7 @@
                             "type": "array"
                           },
                           "secret_key": {
-                            "description": "__Read-only__ This Object Storage key's secret key. Used as a password to validate this key when making requests to the S3 API. This value is only revealed in a response after creating or modifying a key.",
+                            "description": "__Read-only__ This Object Storage key's secret key. Used as a password to validate this key when making requests an S3 API, such as the Amazon S3 API or Ceph Object Gateway S3 API. This value is only revealed in a response after creating or modifying a key.",
                             "readOnly": true,
                             "type": "string"
                           }
@@ -97109,10 +96012,10 @@
               "application/json": {
                 "schema": {
                   "additionalProperties": false,
-                  "description": "A key used to communicate with the Object Storage S3 API.",
+                  "description": "A key used to validate requests to an S3 API.",
                   "properties": {
                     "access_key": {
-                      "description": "__Read-only__ A unique string chosen by the API to identify this key. Used as a username to identify this key when making requests to the S3 API.",
+                      "description": "__Read-only__ A unique string chosen by the API to identify this key. Used as a username to identify this key when making requests an S3 API, such as the Amazon S3 API or Ceph Object Gateway S3 API.",
                       "example": "KVAKUTGBA4WTR2NSJQ81",
                       "readOnly": true,
                       "type": "string"
@@ -97174,7 +96077,7 @@
                         "additionalProperties": false,
                         "properties": {
                           "endpoint_type": {
-                            "description": "The type of `s3_endpoint` available to the active `user` in this `region`. See [Endpoint types](https://techdocs.akamai.com/cloud-computing/docs/object-storage#endpoint-type) for more information.",
+                            "description": "The type of `s3_endpoint` available to the active `user` in this `region`. See [Endpoint types](https://techdocs.akamai.com/cloud-computing/docs/object-storage#endpoint-types) for more information.",
                             "enum": [
                               "E0",
                               "E1",
@@ -97200,7 +96103,7 @@
                       "type": "array"
                     },
                     "secret_key": {
-                      "description": "__Read-only__ This Object Storage key's secret key. Used as a password to validate this key when making requests to the S3 API. This value is only revealed in a response after creating or modifying a key.",
+                      "description": "__Read-only__ This Object Storage key's secret key. Used as a password to validate this key when making requests an S3 API, such as the Amazon S3 API or Ceph Object Gateway S3 API. This value is only revealed in a response after creating or modifying a key.",
                       "readOnly": true,
                       "type": "string"
                     }
@@ -97337,10 +96240,10 @@
               "application/json": {
                 "schema": {
                   "additionalProperties": false,
-                  "description": "An updated Object Storage key used to communicate with the Object Storage S3 API.",
+                  "description": "An updated Object Storage key used for authentication.",
                   "properties": {
                     "access_key": {
-                      "description": "__Read-only__ A unique string chosen by the API to identify this key. Used as a username to identify this key when making requests to the S3 API.",
+                      "description": "__Read-only__ A unique string chosen by the API to identify this key. Used as a username to identify this key when making requests an S3 API, such as the Amazon S3 API or Ceph Object Gateway S3 API.",
                       "example": "KVAKUTGBA4WTR2NSJQ81",
                       "readOnly": true,
                       "type": "string"
@@ -97383,7 +96286,7 @@
                       "type": "array"
                     },
                     "secret_key": {
-                      "description": "__Read-only__ This Object Storage key's secret key. Used as a password to validate this key when making requests to the S3 API. This value is only revealed in a response after creating or modifying a key.",
+                      "description": "__Read-only__ This Object Storage key's secret key. Used as a password to validate this key when making requests an S3 API, such as the Amazon S3 API or Ceph Object Gateway S3 API. This value is only revealed in a response after creating or modifying a key.",
                       "example": "OiA6F5r0niLs3QA2stbyq7mY5VCV7KqOzcmitmHw",
                       "readOnly": true,
                       "type": "string"
@@ -97474,7 +96377,7 @@
         "x-linode-cli-action": "keys-update"
       },
       "delete": {
-        "description": "Revokes an Object Storage Key. This keypair will no longer be usable by third-party clients.\n\n- A successful request triggers an `obj_access_key_delete` event.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli object-storage keys-delete 12345\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Revokes an Object Storage Key. This keypair will no longer be usable by third-party clients. A successful request triggers an `obj_access_key_delete` [event](https://techdocs.akamai.com/linode-api/reference/get-events).\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli object-storage keys-delete 12345\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/delete-object-storage-key"
@@ -97612,7 +96515,7 @@
     },
     "/{apiVersion}/object-storage/transfer": {
       "get": {
-        "description": "The amount of outbound data transfer used by your account's Object Storage buckets. Object Storage adds 1 terabyte of outbound data transfer to your data transfer pool. See the [Object Storage Overview](https://www.linode.com/docs/products/storage/object-storage/#pricing) guide for details on Object Storage transfer quotas.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "The amount of outbound data transfer used by your account's Object Storage buckets. Object Storage adds 1 terabyte of outbound data transfer to your data transfer pool. See the [Object Storage Overview](https://www.linode.com/docs/products/storage/object-storage/#pricing) guide for details on Object Storage transfer quotas.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)\n\n- __CLI__.\n\n    ```\n    linode-cli object-storage transfer\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-object-storage-transfer"
@@ -97629,7 +96532,8 @@
                       "description": "__Read-only__ The amount of outbound data transfer used by your account's Object Storage buckets, in bytes, for the current month's billing cycle.",
                       "example": 12956600198,
                       "readOnly": true,
-                      "type": "integer"
+                      "type": "integer",
+                      "x-linode-cli-display": 1
                     }
                   },
                   "type": "object",
@@ -97706,10 +96610,14 @@
               "syntax": "object_storage:read_only",
               "title": "OAuth scopes",
               "url": "https://techdocs.akamai.com/linode-api/reference/get-started#oauth"
+            },
+            {
+              "syntax": "linode-cli object-storage transfer",
+              "title": "CLI",
+              "url": "https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli"
             }
           ]
-        },
-        "x-linode-cli-skip": true
+        }
       },
       "parameters": [
         {
@@ -99563,7 +98471,7 @@
     },
     "/{apiVersion}/profile": {
       "get": {
-        "description": "Returns information about the current User. This can be used to see who is acting in applications where more than one token is managed. For example, in third-party OAuth applications.\n\nThis operation is always accessible, no matter what OAuth scopes the acting token has.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli profile view\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)",
+        "description": "Returns information about the current user. Use this to see who is acting in applications where more than one token is managed, such as a third-party OAuth application.\n\n> 📘\n>\n> A third-party OAuth application accessing a profile with this operation has full access to all aspects of that profile.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli profile view\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-profile"
@@ -99575,10 +98483,10 @@
               "application/json": {
                 "schema": {
                   "additionalProperties": false,
-                  "description": "A Profile represents your User in our system. This is where you can change information about your User. This information is available to any OAuth Client regardless of requested scopes, and can be used to populate User information in third-party applications.",
+                  "description": "A profile represents your user in our system. This is where you can change information about your user. This information is available to any OAuth client regardless of requested scopes, and you can use it to populate user information in third-party applications.",
                   "properties": {
                     "authentication_type": {
-                      "description": "__Read-only__ This account's Cloud Manager authentication type. Authentication types are chosen through Cloud Manager and authorized when logging into your account. These authentication types are either the user's password (in conjunction with their username), or the name of their identity provider such as GitHub. For example, if a user:\n\n- Has never used Third-Party Authentication, their authentication type will be `password`.\n- Is using Third-Party Authentication, their authentication type will be the name of their Identity Provider (eg. `github`).\n- Has used Third-Party Authentication and has since revoked it, their authentication type will be `password`.\n\n__Note__. This functionality may not yet be available in Cloud Manager. See the [Cloud Manager Changelog](https://www.linode.com/docs/products/tools/cloud-manager/release-notes/) for the latest updates.",
+                      "description": "__Read-only__ This account's Cloud Manager authentication type. You choose an authentication type in Cloud Manager and Akamai authorizes it when you log into your account. Authentication types include your user's password (in conjunction with your username), or the name of your identity provider, such as GitHub. Here are some examples:\n\n- If a user has never used third-party authentication, the authentication type will be `password`.\n\n- If a user is using third-party authentication, the name of their identity provider is used for the authentication type, for example, `github`.\n\n- If a user has used third-party authentication and has since revoked it, the authentication type is `password`.",
                       "enum": [
                         "password",
                         "github"
@@ -99588,7 +98496,7 @@
                       "type": "string"
                     },
                     "authorized_keys": {
-                      "description": "The list of SSH Keys authorized to use Lish for your User. This value is ignored if `lish_auth_method` is `disabled`.",
+                      "description": "Your user can use these SSH Keys to access Lish. This value is ignored if `lish_auth_method` is `disabled`.",
                       "example": null,
                       "items": {
                         "format": "ssh-key",
@@ -99598,25 +98506,25 @@
                       "type": "array"
                     },
                     "email": {
-                      "description": "Your email address.  This address will be used for communication with Linode as necessary.",
+                      "description": "Your email address. We use this address for Akamai Cloud Computing-related communication.",
                       "example": "example-user@gmail.com",
                       "format": "email",
                       "type": "string",
                       "x-linode-cli-display": 2
                     },
                     "email_notifications": {
-                      "description": "If `true`, you will receive email notifications about account activity.  If `false`, you may still receive business-critical communications through email.",
+                      "description": "When set to `true`, you will receive email notifications about account activity. When `false`, you may still receive business-critical communications through email.",
                       "example": true,
                       "type": "boolean"
                     },
                     "ip_whitelist_enabled": {
                       "deprecated": true,
-                      "description": "If `true`, logins for your User will only be allowed from whitelisted IPs. This setting is currently deprecated, and cannot be enabled. If you disable this setting, you will not be able to re-enable it.",
+                      "description": "When set to `true`, your user logins are only allowed from whitelisted IPs. This setting is deprecated, and can't be enabled. If you disable this setting, you won't be able to re-enable it.",
                       "example": false,
                       "type": "boolean"
                     },
                     "lish_auth_method": {
-                      "description": "The authentication methods that are allowed when connecting to [the Linode Shell (Lish)](https://www.linode.com/docs/guides/lish/).\n\n- `keys_only` is the most secure if you intend to use Lish.\n- `disabled` is recommended if you do not intend to use Lish at all.\n- If this account's Cloud Manager authentication type is set to a Third-Party Authentication method, `password_keys` cannot be used as your Lish authentication method. To view this account's Cloud Manager `authentication_type` field, send a request to the [Get a profile](https://techdocs.akamai.com/linode-api/reference/get-profile) operation.",
+                      "description": "The authentication methods that you can use when connecting to the [Linode Shell (Lish)](https://www.linode.com/docs/guides/lish/).\n\n- `keys_only` is the most secure if you intend to use Lish.\n\n- `disabled` is recommended if you don't want to use Lish.\n\n- If this account's Cloud Manager authentication type is set to a third-party authentication method, you can't use `password_keys` as your Lish authentication method. Run the [Get a profile](https://techdocs.akamai.com/linode-api/reference/get-profile) operation to view your account's Cloud Manager `authentication_type` field.",
                       "enum": [
                         "password_keys",
                         "keys_only",
@@ -99627,28 +98535,28 @@
                     },
                     "referrals": {
                       "additionalProperties": false,
-                      "description": "__Read-only__ Information about your status in our referral program.\n\nThis information becomes accessible after this Profile's Account has established at least $25.00 USD of total payments.",
+                      "description": "__Read-only__ Information about your status in our referral program. The API makes this information available after this profile's account has established at least $25.00 USD of total payments.",
                       "properties": {
                         "code": {
-                          "description": "__Read-only__ Your referral code.  If others use this when signing up for Linode, you will receive account credit.",
+                          "description": "__Read-only__ Your referral code. If others use this when signing up for Linode, you receive an account credit.",
                           "example": "871be32f49c1411b14f29f618aaf0c14637fb8d3",
                           "readOnly": true,
                           "type": "string"
                         },
                         "completed": {
-                          "description": "__Read-only__ The number of completed signups with your referral code.",
+                          "description": "__Read-only__ The number of completed sign-ups that used your referral code.",
                           "example": 0,
                           "readOnly": true,
                           "type": "integer"
                         },
                         "credit": {
-                          "description": "__Read-only__ The amount of account credit in US Dollars issued to you through the referral program.",
+                          "description": "__Read-only__ Your referral program account credit in US dollars.",
                           "example": 0,
                           "readOnly": true,
                           "type": "integer"
                         },
                         "pending": {
-                          "description": "__Read-only__ The number of pending signups with your referral code.  You will not receive credit for these signups until they are completed.",
+                          "description": "__Read-only__ The number of pending sign-ups that used your referral code. Akamai gives you credit for these sign-ups once they've completed.",
                           "example": 0,
                           "readOnly": true,
                           "type": "integer"
@@ -99660,7 +98568,7 @@
                           "type": "integer"
                         },
                         "url": {
-                          "description": "__Read-only__ Your referral url, used to direct others to sign up for Linode with your referral code.",
+                          "description": "__Read-only__ The referral URL that Akamai uses to direct others to sign up for Akamai Cloud Computing with your referral code.",
                           "example": "https://www.linode.com/?r=871be32f49c1411b14f29f618aaf0c14637fb8d3",
                           "format": "url",
                           "readOnly": true,
@@ -99671,24 +98579,24 @@
                       "type": "object"
                     },
                     "restricted": {
-                      "description": "If `true`, your User has restrictions on what can be accessed on your Account. To get details on what entities/actions you can access/perform, run [List grants](https://techdocs.akamai.com/linode-api/reference/get-profile-grants).",
+                      "description": "When set to `true`, there are restrictions on what your user can access on your account. Run [List grants](https://techdocs.akamai.com/linode-api/reference/get-profile-grants) to get details on what entities and actions you can access and perform.",
                       "example": false,
                       "type": "boolean",
                       "x-linode-cli-display": 3
                     },
                     "timezone": {
-                      "description": "The timezone you prefer to see times in. This is not used by the API directly. It is provided for the benefit of clients such as the Linode Cloud Manager and other clients built on the API. All times returned by the API are in UTC.",
+                      "description": "The time zone you want to display for your Linode assets. This API doesn't directly use this time zone. It's provided for the benefit of clients such as the Akamai Cloud Manager and other clients built on the API. All times returned by the API are in UTC.",
                       "example": "US/Eastern",
                       "type": "string"
                     },
                     "two_factor_auth": {
-                      "description": "If `true`, logins from untrusted computers will require Two Factor Authentication.  Run [Create a two factor secret](https://techdocs.akamai.com/linode-api/reference/post-tfa-enable) to enable Two Factor Authentication.",
+                      "description": "When set to `true`, a login from an untrusted computer requires two-factor authentication. You also need to run [Create a two factor secret](https://techdocs.akamai.com/linode-api/reference/post-tfa-enable) to enable two-factor authentication.",
                       "example": true,
                       "type": "boolean",
                       "x-linode-cli-display": 4
                     },
                     "uid": {
-                      "description": "__Read-only__ Your unique ID in our system. This value will never change, and can safely be used to identify your User.",
+                      "description": "__Read-only__ Your unique ID in our system. This value will never change, and can safely be used to identify your user.",
                       "example": 1234,
                       "readOnly": true,
                       "type": "integer"
@@ -99701,7 +98609,7 @@
                       "x-linode-cli-display": 1
                     },
                     "verified_phone_number": {
-                      "description": "__Read-only__ The phone number verified for this Profile with the [Verify a phone number](https://techdocs.akamai.com/linode-api/reference/post-profile-phone-number-verify) operation.\n\n`null` if this Profile has no verified phone number.",
+                      "description": "__Read-only__ The phone number verified for this profile with the [Verify a phone number](https://techdocs.akamai.com/linode-api/reference/post-profile-phone-number-verify) operation. Displayed as `null` if the profile doesn't have a verified phone number.",
                       "example": "+5555555555",
                       "format": "phone",
                       "nullable": true,
@@ -99782,7 +98690,7 @@
         "x-linode-cli-action": "view"
       },
       "put": {
-        "description": "Update information in your Profile.  This operation requires the `account:read_write` OAuth Scope.\n\n__Parent and child accounts__\n\nIn a [parent and child account](https://www.linode.com/docs/guides/parent-child-accounts/) environment, the following apply:\n\n- You can't edit the `email` for a child account parent user (proxy user). This value is fixed and set when you provision this environment.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli profile update \\\n  --email example-user@gmail.com \\\n  --timezone US/Eastern \\\n  --email_notifications true \\\n  --list_auth_method keys_only \\\n  --two_factor_auth true \\\n  --restricted false\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Update information in your profile. You need the `account:read_write` [OAuth scope](https://techdocs.akamai.com/linode-api/reference/get-started#oauth-reference) to use this operation.\n\n**Parent and child accounts**\n\nIn a [parent and child account](https://www.linode.com/docs/guides/parent-child-accounts/) environment, you can't edit the `email` for a child account parent user (proxy user). This value is fixed and set when you provision this environment.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli profile update \\\n  --email example-user@gmail.com \\\n  --timezone US/Eastern \\\n  --email_notifications true \\\n  --list_auth_method keys_only \\\n  --two_factor_auth true \\\n  --restricted false\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/put-profile"
@@ -99793,10 +98701,10 @@
             "application/json": {
               "schema": {
                 "additionalProperties": false,
-                "description": "A Profile represents your User in our system. This is where you can change information about your User. This information is available to any OAuth Client regardless of requested scopes, and can be used to populate User information in third-party applications.",
+                "description": "A profile represents your user in our system. This is where you can change information about your user. This information is available to any OAuth client regardless of requested scopes, and you can use it to populate user information in third-party applications.",
                 "properties": {
                   "authentication_type": {
-                    "description": "__Read-only__ This account's Cloud Manager authentication type. Authentication types are chosen through Cloud Manager and authorized when logging into your account. These authentication types are either the user's password (in conjunction with their username), or the name of their identity provider such as GitHub. For example, if a user:\n\n- Has never used Third-Party Authentication, their authentication type will be `password`.\n- Is using Third-Party Authentication, their authentication type will be the name of their Identity Provider (eg. `github`).\n- Has used Third-Party Authentication and has since revoked it, their authentication type will be `password`.\n\n__Note__. This functionality may not yet be available in Cloud Manager. See the [Cloud Manager Changelog](https://www.linode.com/docs/products/tools/cloud-manager/release-notes/) for the latest updates.",
+                    "description": "__Read-only__ This account's Cloud Manager authentication type. You choose an authentication type in Cloud Manager and Akamai authorizes it when you log into your account. Authentication types include your user's password (in conjunction with your username), or the name of your identity provider, such as GitHub. Here are some examples:\n\n- If a user has never used third-party authentication, the authentication type will be `password`.\n\n- If a user is using third-party authentication, the name of their identity provider is used for the authentication type, for example, `github`.\n\n- If a user has used third-party authentication and has since revoked it, the authentication type is `password`.",
                     "enum": [
                       "password",
                       "github"
@@ -99806,7 +98714,7 @@
                     "type": "string"
                   },
                   "authorized_keys": {
-                    "description": "The list of SSH Keys authorized to use Lish for your User. This value is ignored if `lish_auth_method` is `disabled`.",
+                    "description": "Your user can use these SSH Keys to access Lish. This value is ignored if `lish_auth_method` is `disabled`.",
                     "example": null,
                     "items": {
                       "format": "ssh-key",
@@ -99816,25 +98724,25 @@
                     "type": "array"
                   },
                   "email": {
-                    "description": "Your email address.  This address will be used for communication with Linode as necessary.",
+                    "description": "Your email address. We use this address for Akamai Cloud Computing-related communication.",
                     "example": "{{email}}",
                     "format": "email",
                     "type": "string",
                     "x-linode-cli-display": 2
                   },
                   "email_notifications": {
-                    "description": "If `true`, you will receive email notifications about account activity.  If `false`, you may still receive business-critical communications through email.",
+                    "description": "When set to `true`, you will receive email notifications about account activity. When `false`, you may still receive business-critical communications through email.",
                     "example": "{{email_notifications}}",
                     "type": "boolean"
                   },
                   "ip_whitelist_enabled": {
                     "deprecated": true,
-                    "description": "If `true`, logins for your User will only be allowed from whitelisted IPs. This setting is currently deprecated, and cannot be enabled. If you disable this setting, you will not be able to re-enable it.",
+                    "description": "When set to `true`, your user logins are only allowed from whitelisted IPs. This setting is deprecated, and can't be enabled. If you disable this setting, you won't be able to re-enable it.",
                     "example": "{{ip_whitelist_enabled}}",
                     "type": "boolean"
                   },
                   "lish_auth_method": {
-                    "description": "The authentication methods that are allowed when connecting to [the Linode Shell (Lish)](https://www.linode.com/docs/guides/lish/).\n\n- `keys_only` is the most secure if you intend to use Lish.\n- `disabled` is recommended if you do not intend to use Lish at all.\n- If this account's Cloud Manager authentication type is set to a Third-Party Authentication method, `password_keys` cannot be used as your Lish authentication method. To view this account's Cloud Manager `authentication_type` field, send a request to the [Get a profile](https://techdocs.akamai.com/linode-api/reference/get-profile) operation.",
+                    "description": "The authentication methods that you can use when connecting to the [Linode Shell (Lish)](https://www.linode.com/docs/guides/lish/).\n\n- `keys_only` is the most secure if you intend to use Lish.\n\n- `disabled` is recommended if you don't want to use Lish.\n\n- If this account's Cloud Manager authentication type is set to a third-party authentication method, you can't use `password_keys` as your Lish authentication method. Run the [Get a profile](https://techdocs.akamai.com/linode-api/reference/get-profile) operation to view your account's Cloud Manager `authentication_type` field.",
                     "enum": [
                       "password_keys",
                       "keys_only",
@@ -99845,28 +98753,28 @@
                   },
                   "referrals": {
                     "additionalProperties": false,
-                    "description": "__Read-only__ Information about your status in our referral program.\n\nThis information becomes accessible after this Profile's Account has established at least $25.00 USD of total payments.",
+                    "description": "__Read-only__ Information about your status in our referral program. The API makes this information available after this profile's account has established at least $25.00 USD of total payments.",
                     "properties": {
                       "code": {
-                        "description": "__Read-only__ Your referral code.  If others use this when signing up for Linode, you will receive account credit.",
+                        "description": "__Read-only__ Your referral code. If others use this when signing up for Linode, you receive an account credit.",
                         "example": "871be32f49c1411b14f29f618aaf0c14637fb8d3",
                         "readOnly": true,
                         "type": "string"
                       },
                       "completed": {
-                        "description": "__Read-only__ The number of completed signups with your referral code.",
+                        "description": "__Read-only__ The number of completed sign-ups that used your referral code.",
                         "example": 0,
                         "readOnly": true,
                         "type": "integer"
                       },
                       "credit": {
-                        "description": "__Read-only__ The amount of account credit in US Dollars issued to you through the referral program.",
+                        "description": "__Read-only__ Your referral program account credit in US dollars.",
                         "example": 0,
                         "readOnly": true,
                         "type": "integer"
                       },
                       "pending": {
-                        "description": "__Read-only__ The number of pending signups with your referral code.  You will not receive credit for these signups until they are completed.",
+                        "description": "__Read-only__ The number of pending sign-ups that used your referral code. Akamai gives you credit for these sign-ups once they've completed.",
                         "example": 0,
                         "readOnly": true,
                         "type": "integer"
@@ -99878,7 +98786,7 @@
                         "type": "integer"
                       },
                       "url": {
-                        "description": "__Read-only__ Your referral url, used to direct others to sign up for Linode with your referral code.",
+                        "description": "__Read-only__ The referral URL that Akamai uses to direct others to sign up for Akamai Cloud Computing with your referral code.",
                         "example": "https://www.linode.com/?r=871be32f49c1411b14f29f618aaf0c14637fb8d3",
                         "format": "url",
                         "readOnly": true,
@@ -99889,24 +98797,24 @@
                     "type": "object"
                   },
                   "restricted": {
-                    "description": "If `true`, your User has restrictions on what can be accessed on your Account. To get details on what entities/actions you can access/perform, run [List grants](https://techdocs.akamai.com/linode-api/reference/get-profile-grants).",
+                    "description": "When set to `true`, there are restrictions on what your user can access on your account. Run [List grants](https://techdocs.akamai.com/linode-api/reference/get-profile-grants) to get details on what entities and actions you can access and perform.",
                     "example": "{{restricted}}",
                     "type": "boolean",
                     "x-linode-cli-display": 3
                   },
                   "timezone": {
-                    "description": "The timezone you prefer to see times in. This is not used by the API directly. It is provided for the benefit of clients such as the Linode Cloud Manager and other clients built on the API. All times returned by the API are in UTC.",
+                    "description": "The time zone you want to display for your Linode assets. This API doesn't directly use this time zone. It's provided for the benefit of clients such as the Akamai Cloud Manager and other clients built on the API. All times returned by the API are in UTC.",
                     "example": "{{timezone}}",
                     "type": "string"
                   },
                   "two_factor_auth": {
-                    "description": "If `true`, logins from untrusted computers will require Two Factor Authentication.  Run [Create a two factor secret](https://techdocs.akamai.com/linode-api/reference/post-tfa-enable) to enable Two Factor Authentication.",
+                    "description": "When set to `true`, a login from an untrusted computer requires two-factor authentication. You also need to run [Create a two factor secret](https://techdocs.akamai.com/linode-api/reference/post-tfa-enable) to enable two-factor authentication.",
                     "example": "{{two_factor_auth}}",
                     "type": "boolean",
                     "x-linode-cli-display": 4
                   },
                   "uid": {
-                    "description": "__Read-only__ Your unique ID in our system. This value will never change, and can safely be used to identify your User.",
+                    "description": "__Read-only__ Your unique ID in our system. This value will never change, and can safely be used to identify your user.",
                     "example": "{{uid}}",
                     "readOnly": true,
                     "type": "integer"
@@ -99919,7 +98827,7 @@
                     "x-linode-cli-display": 1
                   },
                   "verified_phone_number": {
-                    "description": "__Read-only__ The phone number verified for this Profile with the [Verify a phone number](https://techdocs.akamai.com/linode-api/reference/post-profile-phone-number-verify) operation.\n\n`null` if this Profile has no verified phone number.",
+                    "description": "__Read-only__ The phone number verified for this profile with the [Verify a phone number](https://techdocs.akamai.com/linode-api/reference/post-profile-phone-number-verify) operation. Displayed as `null` if the profile doesn't have a verified phone number.",
                     "example": "{{verified_phone_number}}",
                     "format": "phone",
                     "nullable": true,
@@ -99946,10 +98854,10 @@
               "application/json": {
                 "schema": {
                   "additionalProperties": false,
-                  "description": "A Profile represents your User in our system. This is where you can change information about your User. This information is available to any OAuth Client regardless of requested scopes, and can be used to populate User information in third-party applications.",
+                  "description": "A profile represents your user in our system. This is where you can change information about your user. This information is available to any OAuth client regardless of requested scopes, and you can use it to populate user information in third-party applications.",
                   "properties": {
                     "authentication_type": {
-                      "description": "__Read-only__ This account's Cloud Manager authentication type. Authentication types are chosen through Cloud Manager and authorized when logging into your account. These authentication types are either the user's password (in conjunction with their username), or the name of their identity provider such as GitHub. For example, if a user:\n\n- Has never used Third-Party Authentication, their authentication type will be `password`.\n- Is using Third-Party Authentication, their authentication type will be the name of their Identity Provider (eg. `github`).\n- Has used Third-Party Authentication and has since revoked it, their authentication type will be `password`.\n\n__Note__. This functionality may not yet be available in Cloud Manager. See the [Cloud Manager Changelog](https://www.linode.com/docs/products/tools/cloud-manager/release-notes/) for the latest updates.",
+                      "description": "__Read-only__ This account's Cloud Manager authentication type. You choose an authentication type in Cloud Manager and Akamai authorizes it when you log into your account. Authentication types include your user's password (in conjunction with your username), or the name of your identity provider, such as GitHub. Here are some examples:\n\n- If a user has never used third-party authentication, the authentication type will be `password`.\n\n- If a user is using third-party authentication, the name of their identity provider is used for the authentication type, for example, `github`.\n\n- If a user has used third-party authentication and has since revoked it, the authentication type is `password`.",
                       "enum": [
                         "password",
                         "github"
@@ -99959,7 +98867,7 @@
                       "type": "string"
                     },
                     "authorized_keys": {
-                      "description": "The list of SSH Keys authorized to use Lish for your User. This value is ignored if `lish_auth_method` is `disabled`.",
+                      "description": "Your user can use these SSH Keys to access Lish. This value is ignored if `lish_auth_method` is `disabled`.",
                       "example": null,
                       "items": {
                         "format": "ssh-key",
@@ -99969,25 +98877,25 @@
                       "type": "array"
                     },
                     "email": {
-                      "description": "Your email address.  This address will be used for communication with Linode as necessary.",
+                      "description": "Your email address. We use this address for Akamai Cloud Computing-related communication.",
                       "example": "example-user@gmail.com",
                       "format": "email",
                       "type": "string",
                       "x-linode-cli-display": 2
                     },
                     "email_notifications": {
-                      "description": "If `true`, you will receive email notifications about account activity.  If `false`, you may still receive business-critical communications through email.",
+                      "description": "When set to `true`, you will receive email notifications about account activity. When `false`, you may still receive business-critical communications through email.",
                       "example": true,
                       "type": "boolean"
                     },
                     "ip_whitelist_enabled": {
                       "deprecated": true,
-                      "description": "If `true`, logins for your User will only be allowed from whitelisted IPs. This setting is currently deprecated, and cannot be enabled. If you disable this setting, you will not be able to re-enable it.",
+                      "description": "When set to `true`, your user logins are only allowed from whitelisted IPs. This setting is deprecated, and can't be enabled. If you disable this setting, you won't be able to re-enable it.",
                       "example": false,
                       "type": "boolean"
                     },
                     "lish_auth_method": {
-                      "description": "The authentication methods that are allowed when connecting to [the Linode Shell (Lish)](https://www.linode.com/docs/guides/lish/).\n\n- `keys_only` is the most secure if you intend to use Lish.\n- `disabled` is recommended if you do not intend to use Lish at all.\n- If this account's Cloud Manager authentication type is set to a Third-Party Authentication method, `password_keys` cannot be used as your Lish authentication method. To view this account's Cloud Manager `authentication_type` field, send a request to the [Get a profile](https://techdocs.akamai.com/linode-api/reference/get-profile) operation.",
+                      "description": "The authentication methods that you can use when connecting to the [Linode Shell (Lish)](https://www.linode.com/docs/guides/lish/).\n\n- `keys_only` is the most secure if you intend to use Lish.\n\n- `disabled` is recommended if you don't want to use Lish.\n\n- If this account's Cloud Manager authentication type is set to a third-party authentication method, you can't use `password_keys` as your Lish authentication method. Run the [Get a profile](https://techdocs.akamai.com/linode-api/reference/get-profile) operation to view your account's Cloud Manager `authentication_type` field.",
                       "enum": [
                         "password_keys",
                         "keys_only",
@@ -99998,28 +98906,28 @@
                     },
                     "referrals": {
                       "additionalProperties": false,
-                      "description": "__Read-only__ Information about your status in our referral program.\n\nThis information becomes accessible after this Profile's Account has established at least $25.00 USD of total payments.",
+                      "description": "__Read-only__ Information about your status in our referral program. The API makes this information available after this profile's account has established at least $25.00 USD of total payments.",
                       "properties": {
                         "code": {
-                          "description": "__Read-only__ Your referral code.  If others use this when signing up for Linode, you will receive account credit.",
+                          "description": "__Read-only__ Your referral code. If others use this when signing up for Linode, you receive an account credit.",
                           "example": "871be32f49c1411b14f29f618aaf0c14637fb8d3",
                           "readOnly": true,
                           "type": "string"
                         },
                         "completed": {
-                          "description": "__Read-only__ The number of completed signups with your referral code.",
+                          "description": "__Read-only__ The number of completed sign-ups that used your referral code.",
                           "example": 0,
                           "readOnly": true,
                           "type": "integer"
                         },
                         "credit": {
-                          "description": "__Read-only__ The amount of account credit in US Dollars issued to you through the referral program.",
+                          "description": "__Read-only__ Your referral program account credit in US dollars.",
                           "example": 0,
                           "readOnly": true,
                           "type": "integer"
                         },
                         "pending": {
-                          "description": "__Read-only__ The number of pending signups with your referral code.  You will not receive credit for these signups until they are completed.",
+                          "description": "__Read-only__ The number of pending sign-ups that used your referral code. Akamai gives you credit for these sign-ups once they've completed.",
                           "example": 0,
                           "readOnly": true,
                           "type": "integer"
@@ -100031,7 +98939,7 @@
                           "type": "integer"
                         },
                         "url": {
-                          "description": "__Read-only__ Your referral url, used to direct others to sign up for Linode with your referral code.",
+                          "description": "__Read-only__ The referral URL that Akamai uses to direct others to sign up for Akamai Cloud Computing with your referral code.",
                           "example": "https://www.linode.com/?r=871be32f49c1411b14f29f618aaf0c14637fb8d3",
                           "format": "url",
                           "readOnly": true,
@@ -100042,24 +98950,24 @@
                       "type": "object"
                     },
                     "restricted": {
-                      "description": "If `true`, your User has restrictions on what can be accessed on your Account. To get details on what entities/actions you can access/perform, run [List grants](https://techdocs.akamai.com/linode-api/reference/get-profile-grants).",
+                      "description": "When set to `true`, there are restrictions on what your user can access on your account. Run [List grants](https://techdocs.akamai.com/linode-api/reference/get-profile-grants) to get details on what entities and actions you can access and perform.",
                       "example": false,
                       "type": "boolean",
                       "x-linode-cli-display": 3
                     },
                     "timezone": {
-                      "description": "The timezone you prefer to see times in. This is not used by the API directly. It is provided for the benefit of clients such as the Linode Cloud Manager and other clients built on the API. All times returned by the API are in UTC.",
+                      "description": "The time zone you want to display for your Linode assets. This API doesn't directly use this time zone. It's provided for the benefit of clients such as the Akamai Cloud Manager and other clients built on the API. All times returned by the API are in UTC.",
                       "example": "US/Eastern",
                       "type": "string"
                     },
                     "two_factor_auth": {
-                      "description": "If `true`, logins from untrusted computers will require Two Factor Authentication.  Run [Create a two factor secret](https://techdocs.akamai.com/linode-api/reference/post-tfa-enable) to enable Two Factor Authentication.",
+                      "description": "When set to `true`, a login from an untrusted computer requires two-factor authentication. You also need to run [Create a two factor secret](https://techdocs.akamai.com/linode-api/reference/post-tfa-enable) to enable two-factor authentication.",
                       "example": true,
                       "type": "boolean",
                       "x-linode-cli-display": 4
                     },
                     "uid": {
-                      "description": "__Read-only__ Your unique ID in our system. This value will never change, and can safely be used to identify your User.",
+                      "description": "__Read-only__ Your unique ID in our system. This value will never change, and can safely be used to identify your user.",
                       "example": 1234,
                       "readOnly": true,
                       "type": "integer"
@@ -100072,7 +98980,7 @@
                       "x-linode-cli-display": 1
                     },
                     "verified_phone_number": {
-                      "description": "__Read-only__ The phone number verified for this Profile with the [Verify a phone number](https://techdocs.akamai.com/linode-api/reference/post-profile-phone-number-verify) operation.\n\n`null` if this Profile has no verified phone number.",
+                      "description": "__Read-only__ The phone number verified for this profile with the [Verify a phone number](https://techdocs.akamai.com/linode-api/reference/post-profile-phone-number-verify) operation. Displayed as `null` if the profile doesn't have a verified phone number.",
                       "example": "+5555555555",
                       "format": "phone",
                       "nullable": true,
@@ -100792,7 +99700,7 @@
                           },
                           "last_remote_addr": {
                             "description": "__Read-only__ The last IP Address to successfully authenticate with this TrustedDevice.",
-                            "example": "192.0.2.139",
+                            "example": "192.0.2.134",
                             "readOnly": true,
                             "type": "string"
                           },
@@ -100978,7 +99886,7 @@
                     },
                     "last_remote_addr": {
                       "description": "__Read-only__ The last IP Address to successfully authenticate with this TrustedDevice.",
-                      "example": "192.0.2.239",
+                      "example": "192.0.2.91",
                       "readOnly": true,
                       "type": "string"
                     },
@@ -101370,10 +100278,6 @@
                           "example": true,
                           "type": "boolean"
                         },
-                        "add_placement_groups": {
-                          "description": "If `true`, this User may add Placement Groups.",
-                          "type": "boolean"
-                        },
                         "add_stackscripts": {
                           "description": "If `true`, this User may add StackScripts.",
                           "example": true,
@@ -101515,41 +100419,6 @@
                     },
                     "nodebalancer": {
                       "description": "The grants this User has for each NodeBalancer that is owned by this Account.",
-                      "items": {
-                        "additionalProperties": false,
-                        "description": "Represents the level of access a restricted User has to a specific resource on the Account.",
-                        "properties": {
-                          "id": {
-                            "description": "The ID of the entity this grant applies to.",
-                            "example": 123,
-                            "type": "integer"
-                          },
-                          "label": {
-                            "description": "__Read-only__ The current label of the entity this grant applies to, for display purposes.",
-                            "example": "example-entity",
-                            "readOnly": true,
-                            "type": "string"
-                          },
-                          "permissions": {
-                            "description": "The level of access this User has to this entity.  If `null`, this User has no access.",
-                            "enum": [
-                              "read_only",
-                              "read_write"
-                            ],
-                            "example": "read_only",
-                            "nullable": true,
-                            "type": "string"
-                          }
-                        },
-                        "type": "object",
-                        "x-akamai": {
-                          "file-path": "schemas/grant.yaml"
-                        }
-                      },
-                      "type": "array"
-                    },
-                    "placement_group": {
-                      "description": "The grants this User has for each Placement Group that is owned by this Account.",
                       "items": {
                         "additionalProperties": false,
                         "description": "Represents the level of access a restricted User has to a specific resource on the Account.",
@@ -102791,7 +101660,7 @@
     },
     "/{apiVersion}/profile/security-questions": {
       "post": {
-        "description": "Adds security question responses for your User.\n\nRequires exactly three unique questions.\n\nPrevious responses are overwritten if answered or reset to `null` if unanswered.\n\n__Note__. Security questions must be answered for your User prior to accessing the [Create a two factor secret](https://techdocs.akamai.com/linode-api/reference/post-tfa-enable) operation.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    account:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Adds security question responses for your user. You need to use exactly three unique questions. Previous responses are overwritten if answered, or they're reset to `null` if unanswered.\n\n> 📘\n>\n> You need to answer these security questions before you can access the [Create a two factor secret](https://techdocs.akamai.com/linode-api/reference/post-tfa-enable) operation.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    account:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/post-security-questions"
@@ -103789,7 +102658,7 @@
         "x-linode-cli-action": "update"
       },
       "delete": {
-        "description": "Deletes an SSH Key you have access to.\n\n__Note__. deleting an SSH Key will _not_ remove it from any Linode or Disk that was deployed with `authorized_keys`. In those cases, the keys must be manually deleted on the Linode or Disk. This operation will only delete the key's association from your Profile.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli sshkeys delete 42\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Deletes an SSH Key you have access to.\n\n> 📘\n>\n> This operation only deletes a key's association from your profile. It doesn't remove it from any Linode or disk that was deployed with `authorized_keys`. You need to manually delete the key on the Linode or disk.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli sshkeys delete 42\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/delete-ssh-key"
@@ -108433,7 +107302,7 @@
                                   "ipv4": {
                                     "description": "__Filterable__, __Read-only__ This Linode's IPv4 Addresses. Each Linode is assigned a single public IPv4 address upon creation, and may get a single private IPv4 address if needed. You may need to [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) to get additional IPv4 addresses.\n\nIPv4 addresses may be reassigned between your Linodes, or shared with other Linodes. See the [networking](https://techdocs.akamai.com/linode-api/reference/post-firewalls) operations for details.",
                                     "example": [
-                                      "192.0.2.20",
+                                      "192.0.2.148",
                                       "192.0.2.1"
                                     ],
                                     "format": "ipv4",
@@ -108452,7 +107321,7 @@
                                   },
                                   "ipv6": {
                                     "description": "__Read-only__ This Linode's IPv6 SLAAC address. This address is specific to a Linode, and may not be shared. If the Linode has not been assigned an IPv6 address, the return value will be `null`.",
-                                    "example": "2001:db8:db5:b34c:a305:d7c:af82:db2/32",
+                                    "example": "2001:db8:3781:ad92:bf12:e807:fc6a:7a11/32",
                                     "format": "ipv6/128",
                                     "nullable": true,
                                     "readOnly": true,
@@ -108664,7 +107533,7 @@
                                 "description": "A domain zonefile in our DNS system.  You must own the domain name and tell your registrar to use Linode's nameservers in order for a domain in our system to be treated as authoritative.",
                                 "properties": {
                                   "axfr_ips": {
-                                    "description": "The list of IPs that may perform a zone transfer for this Domain. The total combined length of all data within this array cannot exceed 1000 characters.\n\n__Note__. This is potentially dangerous, and should be set to an empty list unless you intend to use it.",
+                                    "description": "The list of IPs that may perform a zone transfer for this domain. The total combined length of all data within this array cannot exceed 1000 characters.\n\n> 📘\n>\n> This is potentially dangerous, and should be set to an empty list unless you intend to use it.",
                                     "example": [],
                                     "items": {
                                       "format": "ip",
@@ -108673,7 +107542,7 @@
                                     "type": "array"
                                   },
                                   "description": {
-                                    "description": "A description for this Domain. This is for display purposes only.",
+                                    "description": "A description for this domain. This is for display purposes only.",
                                     "example": null,
                                     "maxLength": 253,
                                     "minLength": 1,
@@ -108681,7 +107550,7 @@
                                     "type": "string"
                                   },
                                   "domain": {
-                                    "description": "__Filterable__ The domain this Domain represents. Domain labels cannot be longer than 63 characters and must conform to [RFC1035](https://tools.ietf.org/html/rfc1035). Domains must be unique on Linode's platform, including across different Linode accounts; there cannot be two Domains representing the same domain.",
+                                    "description": "__Filterable__ The domain this domain represents. domain labels cannot be longer than 63 characters and must conform to [RFC1035](https://tools.ietf.org/html/rfc1035). domains must be unique on Linode's platform, including across different Linode accounts; there cannot be two domains representing the same domain.",
                                     "example": "example.org",
                                     "maxLength": 253,
                                     "minLength": 1,
@@ -108697,13 +107566,13 @@
                                   },
                                   "expire_sec": {
                                     "default": 0,
-                                    "description": "The amount of time in seconds that may pass before this Domain is no longer authoritative.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 1209600.",
+                                    "description": "The amount of time in seconds that may pass before this domain is no longer authoritative.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 1209600.",
                                     "example": 300,
                                     "type": "integer"
                                   },
                                   "group": {
                                     "deprecated": true,
-                                    "description": "__Filterable__ The group this Domain belongs to.  This is for display purposes only.",
+                                    "description": "__Filterable__ The group this domain belongs to.  This is for display purposes only.",
                                     "example": null,
                                     "maxLength": 50,
                                     "minLength": 1,
@@ -108717,14 +107586,14 @@
                                     "x-linode-filterable": true
                                   },
                                   "id": {
-                                    "description": "__Read-only__ This Domain's unique ID.",
+                                    "description": "__Read-only__ This domain's unique ID.",
                                     "example": 1234,
                                     "readOnly": true,
                                     "type": "integer",
                                     "x-linode-cli-display": 1
                                   },
                                   "master_ips": {
-                                    "description": "The IP addresses representing the master DNS for this Domain. At least one value is required for `type` slave Domains. The total combined length of all data within this array cannot exceed 1000 characters.",
+                                    "description": "The IP addresses representing the master DNS for this domain. At least one value is required for `type` slave domains. The total combined length of all data within this array cannot exceed 1000 characters.",
                                     "example": [],
                                     "items": {
                                       "format": "ip",
@@ -108734,7 +107603,7 @@
                                   },
                                   "refresh_sec": {
                                     "default": 0,
-                                    "description": "The amount of time in seconds before this Domain should be refreshed.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 14400.",
+                                    "description": "The amount of time in seconds before this domain should be refreshed.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 14400.",
                                     "example": 300,
                                     "type": "integer"
                                   },
@@ -108745,7 +107614,7 @@
                                     "type": "integer"
                                   },
                                   "soa_email": {
-                                    "description": "Start of Authority email address. This is required for `type` master Domains.",
+                                    "description": "Start of Authority email address. This is required for `type` master domains.",
                                     "example": "admin@example.org",
                                     "format": "email",
                                     "type": "string",
@@ -108753,7 +107622,7 @@
                                   },
                                   "status": {
                                     "default": "active",
-                                    "description": "Used to control whether this Domain is currently being rendered.",
+                                    "description": "Used to control whether this domain is currently being rendered.",
                                     "enum": [
                                       "disabled",
                                       "active"
@@ -108787,12 +107656,12 @@
                                   },
                                   "ttl_sec": {
                                     "default": 0,
-                                    "description": "\"Time to Live\" - the amount of time in seconds that this Domain's records may be cached by resolvers or other domain servers.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n- Any other value is rounded up to the nearest valid value.\n- A value of 0 is equivalent to the default value of 86400.",
+                                    "description": "\"Time to Live\" - the amount of time in seconds that this domain's records may be cached by resolvers or other domain servers.\n\n- Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200.\n\n- Any other value is rounded up to the nearest valid value.\n\n- A value of 0 is equivalent to the default value of 86400.",
                                     "example": 300,
                                     "type": "integer"
                                   },
                                   "type": {
-                                    "description": "Whether this Domain represents the authoritative source of information for the domain it describes (`master`), or whether it is a read-only copy of a master (`slave`).",
+                                    "description": "Whether this domain represents the authoritative source of information for the domain it describes (`master`), or whether it is a read-only copy of a master (`slave`).",
                                     "enum": [
                                       "master",
                                       "slave"
@@ -108961,7 +107830,7 @@
                                     "maximum": 20,
                                     "minimum": 0,
                                     "type": "integer",
-                                    "x-linode-cli-display": 7
+                                    "x-linode-cli-display": 9
                                   },
                                   "created": {
                                     "description": "__Read-only__ When this NodeBalancer was created.",
@@ -108975,7 +107844,7 @@
                                     "example": "192.0.2.1.ip.linodeusercontent.com",
                                     "readOnly": true,
                                     "type": "string",
-                                    "x-linode-cli-display": 4
+                                    "x-linode-cli-display": 5
                                   },
                                   "id": {
                                     "description": "__Read-only__ This NodeBalancer's unique ID.",
@@ -108986,7 +107855,7 @@
                                   },
                                   "ipv4": {
                                     "description": "__Filterable__, __Read-only__ This NodeBalancer's public IPv4 address.",
-                                    "example": "192.0.2.111",
+                                    "example": "192.0.2.223",
                                     "format": "ip",
                                     "readOnly": true,
                                     "type": "string",
@@ -108995,7 +107864,7 @@
                                         "Filterable"
                                       ]
                                     },
-                                    "x-linode-cli-display": 5,
+                                    "x-linode-cli-display": 6,
                                     "x-linode-filterable": true
                                   },
                                   "ipv6": {
@@ -109005,7 +107874,7 @@
                                     "nullable": true,
                                     "readOnly": true,
                                     "type": "string",
-                                    "x-linode-cli-display": 6
+                                    "x-linode-cli-display": 7
                                   },
                                   "label": {
                                     "description": "__Filterable__ This NodeBalancer's label. These must be unique on your Account.",
@@ -109021,6 +107890,36 @@
                                     },
                                     "x-linode-cli-display": 2,
                                     "x-linode-filterable": true
+                                  },
+                                  "lke_cluster": {
+                                    "description": "__Read-only__ This NodeBalancer's related LKE Cluster, if any. The value is `null` if this NodeBalancer isn't related to an LKE Cluster.",
+                                    "nullable": true,
+                                    "properties": {
+                                      "id": {
+                                        "description": "The ID of the related LKE Cluster.",
+                                        "example": 12345,
+                                        "type": "string"
+                                      },
+                                      "label": {
+                                        "description": "The label of the related LKE Cluster.",
+                                        "example": "lkecluster12345",
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "description": "__Read-only__ The type for LKE Clusters.",
+                                        "example": "lkecluster",
+                                        "readOnly": true,
+                                        "type": "string"
+                                      },
+                                      "url": {
+                                        "description": "The URL where you can access the related LKE Cluster.",
+                                        "example": "/v4/lke/clusters/12345",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "readOnly": true,
+                                    "type": "object",
+                                    "x-linode-cli-display": 8
                                   },
                                   "region": {
                                     "description": "__Filterable__, __Read-only__ The Region where this NodeBalancer is located. NodeBalancers only support backends in the same Region.",
@@ -109080,6 +107979,16 @@
                                     },
                                     "readOnly": true,
                                     "type": "object"
+                                  },
+                                  "type": {
+                                    "description": "__Read-only__ The type of NodeBalancer.",
+                                    "enum": [
+                                      "common"
+                                    ],
+                                    "example": "common",
+                                    "readOnly": true,
+                                    "type": "string",
+                                    "x-linode-cli-display": 4
                                   },
                                   "updated": {
                                     "description": "__Read-only__ When this NodeBalancer was last updated.",
@@ -112195,7 +111104,7 @@
                             },
                             "ipv4": {
                               "description": "IPv4 range in CIDR canonical form.\n\n- The range must belong to a private address space as defined in [RFC1918](https://datatracker.ietf.org/doc/html/rfc1918).\n- Allowed prefix lengths: 1-29.\n- The range must not overlap with 192.168.128.0/17.\n- The range must not overlap with other Subnets on the same VPC.",
-                              "example": "192.0.2.2/24",
+                              "example": "192.0.2.149/24",
                               "format": "ip",
                               "type": "string",
                               "x-linode-cli-display": 3
@@ -112408,7 +111317,7 @@
                           },
                           "ipv4": {
                             "description": "IPv4 range in CIDR canonical form.\n\n- The range must belong to a private address space as defined in [RFC1918](https://datatracker.ietf.org/doc/html/rfc1918).\n- Allowed prefix lengths: 1-29.\n- The range must not overlap with 192.168.128.0/17.\n- The range must not overlap with other Subnets on the same VPC.",
-                            "example": "192.0.2.80/24",
+                            "example": "192.0.2.98/24",
                             "format": "ip",
                             "type": "string",
                             "x-linode-cli-display": 3
@@ -112797,7 +111706,7 @@
                                     },
                                     "ipv4": {
                                       "description": "IPv4 range in CIDR canonical form.\n\n- The range must belong to a private address space as defined in [RFC1918](https://datatracker.ietf.org/doc/html/rfc1918).\n- Allowed prefix lengths: 1-29.\n- The range must not overlap with 192.168.128.0/17.\n- The range must not overlap with other Subnets on the same VPC.",
-                                      "example": "192.0.2.16/24",
+                                      "example": "192.0.2.114/24",
                                       "format": "ip",
                                       "type": "string",
                                       "x-linode-cli-display": 3
@@ -113003,7 +111912,7 @@
     },
     "/{apiVersion}/vpcs/ips": {
       "get": {
-        "description": "Returns a paginated list of all VPC IP addresses and address ranges on your account.\n\n__Note__. If a Linode has several configuration profiles that include a VPC interface, address information for all of them is listed in the response. Since VPCs can use the same address space, you may see duplicate IP addresses.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli vpcs ips-all-list\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    ips:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Returns a paginated list of all VPC IP addresses and address ranges on your account.\n\n> 📘\n>\n> If a Linode has several configuration profiles that include a VPC interface, address information for all of them is listed in the response. Since VPCs can use the same address space, you may see duplicate IP addresses.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli vpcs ips-all-list\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    ips:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-vpcs-ips"
@@ -113175,7 +112084,7 @@
                               },
                               "nat_1_1": {
                                 "description": "__Read-only__ The public IP address used for NAT 1:1 with the VPC. This is empty if NAT 1:1 isn't used.",
-                                "example": "192.0.2.12",
+                                "example": "192.0.2.177",
                                 "format": "ip",
                                 "readOnly": true,
                                 "type": "string"
@@ -113209,7 +112118,7 @@
                               },
                               "subnet_mask": {
                                 "description": "__Read-only__ The mask that separates host bits from network bits for the `address` or `address_range`.",
-                                "example": "192.0.2.181",
+                                "example": "192.0.2.108",
                                 "format": "ip",
                                 "readOnly": true,
                                 "type": "string"
@@ -113458,7 +112367,7 @@
                           },
                           "ipv4": {
                             "description": "IPv4 range in CIDR canonical form.\n\n- The range must belong to a private address space as defined in [RFC1918](https://datatracker.ietf.org/doc/html/rfc1918).\n- Allowed prefix lengths: 1-29.\n- The range must not overlap with 192.168.128.0/17.\n- The range must not overlap with other Subnets on the same VPC.",
-                            "example": "192.0.2.100/24",
+                            "example": "192.0.2.222/24",
                             "format": "ip",
                             "type": "string",
                             "x-linode-cli-display": 3
@@ -113780,7 +112689,7 @@
                           },
                           "ipv4": {
                             "description": "IPv4 range in CIDR canonical form.\n\n- The range must belong to a private address space as defined in [RFC1918](https://datatracker.ietf.org/doc/html/rfc1918).\n- Allowed prefix lengths: 1-29.\n- The range must not overlap with 192.168.128.0/17.\n- The range must not overlap with other Subnets on the same VPC.",
-                            "example": "192.0.2.163/24",
+                            "example": "192.0.2.23/24",
                             "format": "ip",
                             "type": "string",
                             "x-linode-cli-display": 3
@@ -114270,7 +113179,7 @@
                               },
                               "nat_1_1": {
                                 "description": "__Read-only__ The public IP address used for NAT 1:1 with the VPC. This is empty if NAT 1:1 isn't used.",
-                                "example": "192.0.2.219",
+                                "example": "192.0.2.39",
                                 "format": "ip",
                                 "readOnly": true,
                                 "type": "string"
@@ -114304,7 +113213,7 @@
                               },
                               "subnet_mask": {
                                 "description": "__Read-only__ The mask that separates host bits from network bits for the `address` or `address_range`.",
-                                "example": "192.0.2.62",
+                                "example": "192.0.2.63",
                                 "format": "ip",
                                 "readOnly": true,
                                 "type": "string"
@@ -114546,7 +113455,7 @@
                     },
                     "ipv4": {
                       "description": "IPv4 range in CIDR canonical form.\n\n- The range must belong to a private address space as defined in [RFC1918](https://datatracker.ietf.org/doc/html/rfc1918).\n- Allowed prefix lengths: 1-29.\n- The range must not overlap with 192.168.128.0/17.\n- The range must not overlap with other Subnets on the same VPC.",
-                      "example": "192.0.2.121/24",
+                      "example": "192.0.2.86/24",
                       "format": "ip",
                       "type": "string",
                       "x-linode-cli-display": 3
@@ -114837,7 +113746,7 @@
                               },
                               "ipv4": {
                                 "description": "IPv4 range in CIDR canonical form.\n\n- The range must belong to a private address space as defined in [RFC1918](https://datatracker.ietf.org/doc/html/rfc1918).\n- Allowed prefix lengths: 1-29.\n- The range must not overlap with 192.168.128.0/17.\n- The range must not overlap with other Subnets on the same VPC.",
-                                "example": "192.0.2.158/24",
+                                "example": "192.0.2.9/24",
                                 "format": "ip",
                                 "type": "string",
                                 "x-linode-cli-display": 3
@@ -115077,7 +113986,7 @@
                     },
                     "ipv4": {
                       "description": "IPv4 range in CIDR canonical form.\n\n- The range must belong to a private address space as defined in [RFC1918](https://datatracker.ietf.org/doc/html/rfc1918).\n- Allowed prefix lengths: 1-29.\n- The range must not overlap with 192.168.128.0/17.\n- The range must not overlap with other Subnets on the same VPC.",
-                      "example": "192.0.2.196/24",
+                      "example": "192.0.2.90/24",
                       "format": "ip",
                       "type": "string",
                       "x-linode-cli-display": 3
@@ -115303,7 +114212,7 @@
                     },
                     "ipv4": {
                       "description": "IPv4 range in CIDR canonical form.\n\n- The range must belong to a private address space as defined in [RFC1918](https://datatracker.ietf.org/doc/html/rfc1918).\n- Allowed prefix lengths: 1-29.\n- The range must not overlap with 192.168.128.0/17.\n- The range must not overlap with other Subnets on the same VPC.",
-                      "example": "192.0.2.147/24",
+                      "example": "192.0.2.194/24",
                       "format": "ip",
                       "type": "string",
                       "x-linode-cli-display": 3
@@ -115460,7 +114369,7 @@
         "x-linode-grant": "read_write"
       },
       "delete": {
-        "description": "Delete a single VPC Subnet.\n\nThe user accessing this operation must have `read_write` grants to the VPC. A successful request triggers a `subnet_delete` event.\n\n__Note__. You need to delete all the Configuration Profile Interfaces that this Subnet is assigned to before you can delete it. If those Interfaces are active, the associated Linode needs to be shut down before they can be removed.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli vpcs subnet-delete $vpcId $vpcSubnetId\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    vpc:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Delete a single VPC Subnet.\n\nThe user accessing this operation must have `read_write` grants to the VPC. A successful request triggers a `subnet_delete` event.\n\n> 📘\n>\n> You need to delete all the Configuration Profile Interfaces that this subnet is assigned to before you can delete it. If those interfaces are active, the associated Linode needs to be shut down before they can be removed.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli vpcs subnet-delete $vpcId $vpcSubnetId\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    vpc:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/delete-vpc-subnet"


### PR DESCRIPTION
# Added

- **Get Object Storage bucket access** ([GET /object-storage/buckets/{regionId}/{bucket}/access](https://techdocs.akamai.com/linode-api/reference/get-object-storage-bucket-access)). This operation was introduced in a previous API release.

# Changed

- **NodeBalancers**.  Added read-only `type`  and `lke_cluster` fields to the responses for the listed API endpoints:
  - **Create a NodeBalancer** ([POST /nodebalancers](https://techdocs.akamai.com/linode-api/reference/post-node-balancer))
  - **List NodeBalancers** ([GET /nodebalancers](https://techdocs.akamai.com/linode-api/reference/get-node-balancers))
  - **Get a NodeBalancer** ([GET /nodebalancers/{nodeBalancerId}](https://techdocs.akamai.com/linode-api/reference/get-node-balancer))
  - **Update a NodeBalancer** ([PUT /nodebalancers/{nodeBalancerId}](https://techdocs.akamai.com/linode-api/reference/put-node-balancer))
- **Accounts**. Updated endpoints to accommodate tax identification number requirements for countries that require them, as well as billing agreement acknowledgement for the same.
  - **Update your account** ([PUT /account](https://techdocs.akamai.com/linode-api/reference/put-account))
  - **Get your account** ([PUT /account](https://techdocs.akamai.com/linode-api/reference/put-account))
  - **Acknowledge agreements** ([POST /account/agreements](https://techdocs.akamai.com/linode-api/reference/post-account-agreements)). 
  - **List agreements** ([GET /account/agreements](https://techdocs.akamai.com/linode-api/reference/get-account-agreements))

# Fixed

- Several Object Storage-related operations incorrectly called out "Access Control Level," when it should be "Access Control List," as used by Amazon S3 in their buckets.
- Various Object Storage-related operations link out to more robust Amazon S3 versions of the operation. Verified and corrected links to current resources.
- Several fixes to Object Storage-related operations' docs to ensure that the related CLI operations were properly covered.