### PR TITLE
release-4.200.0

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1592,6 +1592,14 @@
                     "community_question_reply",
                     "community_like",
                     "credit_card_updated",
+                    "database_create",
+                    "database_delete",
+                    "database_update",
+                    "database_resize",
+                    "database_resize_create",
+                    "database_upgrade",
+                    "database_suspend",
+                    "database_resume",
                     "disk_create",
                     "disk_delete",
                     "disk_update",
@@ -4341,6 +4349,14 @@
               "community_question_reply",
               "community_like",
               "credit_card_updated",
+              "database_create",
+              "database_delete",
+              "database_update",
+              "database_resize",
+              "database_resize_create",
+              "database_upgrade",
+              "database_suspend",
+              "database_resume",
               "disk_create",
               "disk_delete",
               "disk_update",
@@ -6611,7 +6627,7 @@
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
     "title": "Akamai: Linode API",
-    "version": "4.199.0"
+    "version": "4.200.0"
   },
   "openapi": "3.0.1",
   "paths": {
@@ -11137,6 +11153,14 @@
                               "community_question_reply",
                               "community_like",
                               "credit_card_updated",
+                              "database_create",
+                              "database_delete",
+                              "database_update",
+                              "database_resize",
+                              "database_resize_create",
+                              "database_upgrade",
+                              "database_suspend",
+                              "database_resume",
                               "disk_create",
                               "disk_delete",
                               "disk_update",
@@ -11656,6 +11680,14 @@
                         "community_question_reply",
                         "community_like",
                         "credit_card_updated",
+                        "database_create",
+                        "database_delete",
+                        "database_update",
+                        "database_resize",
+                        "database_resize_create",
+                        "database_upgrade",
+                        "database_suspend",
+                        "database_resume",
                         "disk_create",
                         "disk_delete",
                         "disk_update",
@@ -23332,7 +23364,7 @@
                               },
                               "fork": {
                                 "additionalProperties": false,
-                                "description": "Details on the database that was the target of the fork. Only exists if the database was forked from another.",
+                                "description": "Details on the database that was the target of the fork. This only exists if the database was restored by creating a fork from another [MySQL](https://techdocs.akamai.com/linode-api/reference/post-databases-mysql-instances) or [PostgreSQL](https://techdocs.akamai.com/linode-api/reference/post-databases-postgre-sql-instances) database.",
                                 "properties": {
                                   "restore_time": {
                                     "description": "The database timestamp from which it was restored. This is _not_ when the fork was created.",
@@ -23547,7 +23579,7 @@
                                       "properties": {
                                         "deadline": {
                                           "description": "The time when a mandatory update needs to be applied.",
-                                          "example": "2024-10-14 19:55:12",
+                                          "example": "2024-10-14T19:55:12",
                                           "format": "date-time",
                                           "nullable": true,
                                           "type": "string"
@@ -23559,7 +23591,7 @@
                                         },
                                         "planned_for": {
                                           "description": "The date and time a maintenance update will be applied.",
-                                          "example": "2024-10-14 19:55:12",
+                                          "example": "2024-10-14T19:55:12",
                                           "format": "date-time",
                                           "nullable": true,
                                           "type": "string"
@@ -23707,9 +23739,1161 @@
       },
       "x-linode-cli-command": "databases"
     },
+    "/{apiVersion}/databases/mysql/config": {
+      "get": {
+        "description": "All advanced parameters you can apply to a MySQL Managed Database, via our partner [Aiven](https://aiven.io/docs/products/mysql/reference/advanced-params).\n\n> \ud83d\udcd8\n>\n> Aiven may offer other parameters, but Akamai Managed Databases only supports the ones listed in this operation.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli databases mysql-config\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    databases:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "externalDocs": {
+          "description": "See documentation for this operation in Akamai's Linode API",
+          "url": "https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-config"
+        },
+        "operationId": "get-databases-mysql-config",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "binlog_retention_period": {
+                    "description": "The minimum amount of time in seconds to keep binlog entries before deletion. This may be extended for services that require binlog entries for longer than the default for example if using the MySQL Debezium Kafka connector.",
+                    "example": 600,
+                    "maximum": 86400,
+                    "minimum": 600,
+                    "requires_restart": false,
+                    "type": "integer"
+                  },
+                  "mysql": {
+                    "connect_timeout": {
+                      "description": "The number of seconds that the mysqld server waits for a connect packet before responding with Bad handshake",
+                      "example": 10,
+                      "maximum": 3600,
+                      "minimum": 2,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "default_time_zone": {
+                      "description": "Default server time zone as an offset from UTC (from -12:00 to +12:00), a time zone name, or 'SYSTEM' to use the MySQL server default.",
+                      "example": "+03:00",
+                      "maxLength": 100,
+                      "minLength": 2,
+                      "pattern": "^([-+][\\d:]*|[\\w/]*)$",
+                      "requires_restart": false,
+                      "type": "string"
+                    },
+                    "group_concat_max_len": {
+                      "description": "The maximum permitted result length in bytes for the GROUP_CONCAT() function.",
+                      "example": 1024,
+                      "maximum": 18446744073709552000,
+                      "minimum": 4,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "information_schema_stats_expiry": {
+                      "description": "The time, in seconds, before cached statistics expire",
+                      "example": 86400,
+                      "maximum": 31536000,
+                      "minimum": 900,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "innodb_change_buffer_max_size": {
+                      "description": "Maximum size for the InnoDB change buffer, as a percentage of the total size of the buffer pool. Default is 25",
+                      "example": 30,
+                      "maximum": 50,
+                      "minimum": 0,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "innodb_flush_neighbors": {
+                      "description": "Specifies whether flushing a page from the InnoDB buffer pool also flushes other dirty pages in the same extent (default is 1): 0 - dirty pages in the same extent are not flushed, 1 - flush contiguous dirty pages in the same extent, 2 - flush dirty pages in the same extent",
+                      "example": 0,
+                      "maximum": 2,
+                      "minimum": 0,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "innodb_ft_min_token_size": {
+                      "description": "Minimum length of words that are stored in an InnoDB FULLTEXT index. Changing this parameter will lead to a restart of the MySQL service.",
+                      "example": 3,
+                      "maximum": 16,
+                      "minimum": 0,
+                      "requires_restart": true,
+                      "type": "integer"
+                    },
+                    "innodb_ft_server_stopword_table": {
+                      "description": "This option is used to specify your own InnoDB FULLTEXT index stopword list for all InnoDB tables.",
+                      "example": "db_name/table_name",
+                      "maxLength": 1024,
+                      "pattern": "^.+/.+$",
+                      "requires_restart": false,
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "innodb_lock_wait_timeout": {
+                      "description": "The length of time in seconds an InnoDB transaction waits for a row lock before giving up. Default is 120.",
+                      "example": 50,
+                      "maximum": 3600,
+                      "minimum": 1,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "innodb_log_buffer_size": {
+                      "description": "The size in bytes of the buffer that InnoDB uses to write to the log files on disk.",
+                      "example": 16777216,
+                      "maximum": 4294967295,
+                      "minimum": 1048576,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "innodb_online_alter_log_max_size": {
+                      "description": "The upper limit in bytes on the size of the temporary log files used during online DDL operations for InnoDB tables.",
+                      "example": 134217728,
+                      "maximum": 1099511627776,
+                      "minimum": 65536,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "innodb_read_io_threads": {
+                      "description": "The number of I/O threads for read operations in InnoDB. Default is 4. Changing this parameter will lead to a restart of the MySQL service.",
+                      "example": 10,
+                      "maximum": 64,
+                      "minimum": 1,
+                      "requires_restart": true,
+                      "type": "integer"
+                    },
+                    "innodb_rollback_on_timeout": {
+                      "description": "When enabled a transaction timeout causes InnoDB to abort and roll back the entire transaction. Changing this parameter will lead to a restart of the MySQL service.",
+                      "example": true,
+                      "requires_restart": true,
+                      "type": "boolean"
+                    },
+                    "innodb_thread_concurrency": {
+                      "description": "Defines the maximum number of threads permitted inside of InnoDB. Default is 0 (infinite concurrency - no limit)",
+                      "example": 10,
+                      "maximum": 1000,
+                      "minimum": 0,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "innodb_write_io_threads": {
+                      "description": "The number of I/O threads for write operations in InnoDB. Default is 4. Changing this parameter will lead to a restart of the MySQL service.",
+                      "example": 10,
+                      "maximum": 64,
+                      "minimum": 1,
+                      "requires_restart": true,
+                      "type": "integer"
+                    },
+                    "interactive_timeout": {
+                      "description": "The number of seconds the server waits for activity on an interactive connection before closing it.",
+                      "example": 3600,
+                      "maximum": 604800,
+                      "minimum": 30,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "internal_tmp_mem_storage_engine": {
+                      "description": "The storage engine for in-memory internal temporary tables.",
+                      "enum": [
+                        "TempTable",
+                        "MEMORY"
+                      ],
+                      "example": "TempTable",
+                      "requires_restart": false,
+                      "type": "string"
+                    },
+                    "max_allowed_packet": {
+                      "description": "Size of the largest message in bytes that can be received by the server. Default is 67108864 (64M)",
+                      "example": 67108864,
+                      "maximum": 1073741824,
+                      "minimum": 102400,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "max_heap_table_size": {
+                      "description": "Limits the size of internal in-memory tables. Also set tmp_table_size. Default is 16777216 (16M)",
+                      "example": 16777216,
+                      "maximum": 1073741824,
+                      "minimum": 1048576,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "net_buffer_length": {
+                      "description": "Start sizes of connection buffer and result buffer. Default is 16384 (16K). Changing this parameter will lead to a restart of the MySQL service.",
+                      "example": 16384,
+                      "maximum": 1048576,
+                      "minimum": 1024,
+                      "requires_restart": true,
+                      "type": "integer"
+                    },
+                    "net_read_timeout": {
+                      "description": "The number of seconds to wait for more data from a connection before aborting the read.",
+                      "example": 30,
+                      "maximum": 3600,
+                      "minimum": 1,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "net_write_timeout": {
+                      "description": "The number of seconds to wait for a block to be written to a connection before aborting the write.",
+                      "example": 30,
+                      "maximum": 3600,
+                      "minimum": 1,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "sort_buffer_size": {
+                      "description": "Sort buffer size in bytes for ORDER BY optimization. Default is 262144 (256K)",
+                      "example": 262144,
+                      "maximum": 1073741824,
+                      "minimum": 32768,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "sql_mode": {
+                      "description": "Global SQL mode. Set to empty to use MySQL server defaults. When creating a new service and not setting this field Akamai default SQL mode (strict, SQL standard compliant) will be assigned.",
+                      "example": "ANSI,TRADITIONAL",
+                      "maxLength": 1024,
+                      "pattern": "^[A-Z_]*(,[A-Z_]+)*$",
+                      "requires_restart": false,
+                      "type": "string"
+                    },
+                    "sql_require_primary_key": {
+                      "description": "Require primary key to be defined for new tables or old tables modified with ALTER TABLE and fail if missing. It is recommended to always have primary keys because various functionality may break if any large table is missing them.",
+                      "example": true,
+                      "requires_restart": false,
+                      "type": "boolean"
+                    },
+                    "tmp_table_size": {
+                      "description": "Limits the size of internal in-memory tables. Also set max_heap_table_size. Default is 16777216 (16M)",
+                      "example": 16777216,
+                      "maximum": 1073741824,
+                      "minimum": 1048576,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "wait_timeout": {
+                      "description": "The number of seconds the server waits for activity on a noninteractive connection before closing it.",
+                      "example": 28800,
+                      "maximum": 2147483,
+                      "minimum": 1,
+                      "requires_restart": false,
+                      "type": "integer"
+                    }
+                  }
+                },
+                "schema": {
+                  "additionalProperties": false,
+                  "description": "Available [advanced parameters](https://aiven.io/docs/products/mysql/reference/advanced-params) for a MySQL Managed Database.",
+                  "properties": {
+                    "binlog_retention_period": {
+                      "additionalProperties": false,
+                      "description": "Settings available to configure a `binlog_retention_period`, per Aiven's specifications.",
+                      "type": "integer"
+                    },
+                    "mysql": {
+                      "additionalProperties": false,
+                      "description": "Parameters available to configure a MySQL Managed Database.",
+                      "properties": {
+                        "connect_timeout": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `connect_timeout`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the MySQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "default_time_zone": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `connect_timeout`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter, using the required `pattern`.",
+                              "type": "string"
+                            },
+                            "maxLength": {
+                              "description": "The maximum character length for this parameter.",
+                              "type": "integer"
+                            },
+                            "minLength": {
+                              "description": "The minimum character length for this parameter.",
+                              "type": "integer"
+                            },
+                            "pattern": {
+                              "description": "The pattern to follow when defining this parameter.",
+                              "type": "string"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the MySQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "group_concat_max_len": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `group_concat_max_len`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the MySQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "information_schema_stats_expiry": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `information_schema_stats_expiry`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the MySQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "innodb_change_buffer_max_size": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `innodb_change_buffer_max_size`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the MySQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "innodb_flush_neighbors": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `innodb_flush_neighbors`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the MySQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "innodb_ft_min_token_size": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `innodb_ft_min_token_size`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the MySQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "innodb_ft_server_stopword_table": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure your own `innodb_ft_server_stopword_table`, per Aiven's specifications. Set to `null` for no value.",
+                          "nullable": true,
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter, using the required `pattern`, or `null` for no value.",
+                              "type": "string"
+                            },
+                            "maxLength": {
+                              "description": "The maximum character length for this parameter.",
+                              "type": "integer"
+                            },
+                            "pattern": {
+                              "description": "The pattern to follow when defining this parameter.",
+                              "type": "string"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the MySQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "innodb_lock_wait_timeout": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `innodb_lock_wait_timeout`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the MySQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "innodb_log_buffer_size": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `innodb_log_buffer_size`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the MySQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "innodb_online_alter_log_max_size": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `innodb_online_alter_log_max_size`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the MySQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "innodb_read_io_threads": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `innodb_read_io_threads`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the MySQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "innodb_rollback_on_timeout": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `innodb_rollback_on_timeout`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example boolean value for this parameter.",
+                              "type": "string"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the MySQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "innodb_thread_concurrency": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `innodb_thread_concurrency`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the MySQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "innodb_write_io_threads": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `innodb_write_io_threads`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the MySQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "interactive_timeout": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `interactive_timeout`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the MySQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "internal_tmp_mem_storage_engine": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `internal_tmp_mem_storage_engine`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "enum": {
+                              "description": "Specific values available for use as this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "One of the `enum` values available for use.",
+                              "type": "string"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the MySQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "max_allowed_packet": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `max_allowed_packet`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the MySQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "max_heap_table_size": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `max_heap_table_size`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the MySQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "net_buffer_length": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `net_buffer_length`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the MySQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "net_read_timeout": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `net_read_timeout`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the MySQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "net_write_timeout": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `net_write_timeout`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the MySQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "sql_mode": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `sql_mode`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter, using the required `pattern`.",
+                              "type": "string"
+                            },
+                            "maxLength": {
+                              "description": "The maximum character length for this parameter.",
+                              "type": "integer"
+                            },
+                            "pattern": {
+                              "description": "The pattern to follow when defining this parameter.",
+                              "type": "string"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the MySQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "sql_require_primary_key": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `sql_require_primary_key`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example boolean value for this parameter.",
+                              "type": "string"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the MySQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "tmp_table_size": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `tmp_table_size`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the MySQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "wait_timeout": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `wait_timeout`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the MySQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "x-akamai": {
+                    "file-path": "schemas/database-mysql-config-200.yaml"
+                  }
+                }
+              }
+            },
+            "description": "MySQL Managed Database advanced parameters."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "errors": {
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "An object for describing a single error that occurred during the processing of a request.",
+                        "properties": {
+                          "field": {
+                            "description": "The field in the request that caused this error. This may be a path, separated by periods in the case of nested fields. In some cases this may come back as `null` if the error is not specific to any single element of the request.",
+                            "example": "fieldname",
+                            "type": "string"
+                          },
+                          "reason": {
+                            "description": "What happened to cause this error. In most cases, this can be fixed immediately by changing the data you sent in the request, but in some cases you will be instructed to [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) or perform some other action before you can complete the request successfully.",
+                            "example": "fieldname must be a valid value",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-akamai": {
+                          "file-path": "schemas/error-object.yaml"
+                        }
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "See [Errors](https://techdocs.akamai.com/linode-api/reference/errors) for the range of possible error response codes."
+          }
+        },
+        "security": [
+          {
+            "personalAccessToken": []
+          },
+          {
+            "oauth": [
+              "databases:read_only"
+            ]
+          }
+        ],
+        "summary": "List MySQL Managed Database advanced parameters",
+        "tags": [
+          "Advanced parameters"
+        ],
+        "x-akamai": {
+          "tabs": [
+            {
+              "syntax": "linode-cli databases mysql-config",
+              "title": "CLI",
+              "url": "https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli"
+            },
+            {
+              "syntax": "databases:read_only",
+              "title": "OAuth scopes",
+              "url": "https://techdocs.akamai.com/linode-api/reference/get-started#oauth"
+            }
+          ]
+        },
+        "x-linode-cli-action": "mysql-config-view",
+        "x-linode-grant": "read_only"
+      },
+      "parameters": [
+        {
+          "description": "__Enum__ Call either the `v4` URL, or `v4beta` for operations still in Beta.",
+          "example": "{{apiVersion}}",
+          "in": "path",
+          "name": "apiVersion",
+          "required": true,
+          "schema": {
+            "enum": [
+              "v4",
+              "v4beta"
+            ],
+            "type": "string"
+          },
+          "x-akamai": {
+            "file-path": "parameters/api-version-path.yaml"
+          }
+        }
+      ],
+      "x-akamai": {
+        "file-path": "paths/mysql-config.yaml",
+        "path-info": "/{apiVersion}/databases/mysql/config"
+      },
+      "x-linode-cli-command": "databases"
+    },
     "/{apiVersion}/databases/mysql/instances": {
       "post": {
-        "description": "**Provision a MySQL Managed Database**\n\nUse this operation to create a new MySQL Managed Database.\n\n- Restricted users need the `add_databases` [user grant](https://techdocs.akamai.com/linode-api/reference/get-user-grants).\n\n- New instances can take 10 to 15 minutes to deploy.\n\n- All Managed Databases include automatic, daily backups. Up to seven backups are automatically stored for each Managed Database, providing restore points for each day of the past week.\n\n- All Managed Databases include automatic updates, which apply security patches to the underlying operating system of the MySQL Managed Database. Configure the maintenance window for these updates with the [Update a managed MySQL database](https://techdocs.akamai.com/linode-api/reference/put-databases-mysql-instance) operation.\n\n- If your database cluster is configured with a single node, downtime occurs during maintenance updates. You should adjust the window to match a time that's the least disruptive to your application and users. Also consider upgrading to a [high availability](https://techdocs.akamai.com/cloud-computing/docs/managed-databases#high-availability) plan to avoid any maintenance downtime.\n\n- Major upgrades are optional until the service reaches end of service, and can be done in place.\n\n**Restore a MySQL Managed Database**\n\nDo this by creating a `fork` from a backup. A user needs `read_write` access to the database and its status can be `active`, `degraded`, or `failed`.\n\n> \ud83d\udcd8\n>\n> Restoring from a backup creates a second running cluster, which incurs billing. Delete the first cluster after the restore is complete, to avoid this billing.\n\n\n<<LB>>\n\n---\n\n\n- __CLI for create operation__.\n\n    ```\n    linode-cli databases mysql-create \\\n  --label example-db1 \\\n  --region us-east \\\n  --type g6-dedicated-2 \\\n  --cluster_size 3 \\\n  --engine mysql/8.0.26 \\\n  --ssl_connection true \\\n  --allow_list 203.0.113.1 \\\n  --allow_list 192.0.1.0/24\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    databases:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "**Provision a MySQL Managed Database**\n\nUse this operation to create a new MySQL Managed Database.\n\n- Restricted users need the `add_databases` [user grant](https://techdocs.akamai.com/linode-api/reference/get-user-grants).\n\n- New instances can take 10 to 15 minutes to deploy.\n\n- When you create a new MySQL Managed Database, our partner [Aiven](https://aiven.io/docs/platform/concepts/cloud-security#data-encryption) automatically enables disk encryption on each cluster.\n\n- All Managed Databases include automatic, daily backups. Up to seven backups are automatically stored for each Managed Database, providing restore points for each day of the past week.\n\n- All Managed Databases include automatic updates, which apply security patches to the underlying operating system of the MySQL Managed Database. Configure the maintenance window for these updates with the [Update a managed MySQL database](https://techdocs.akamai.com/linode-api/reference/put-databases-mysql-instance) operation.\n\n- If your database cluster is configured with a single node, downtime occurs during maintenance updates. You should adjust the window to match a time that's the least disruptive to your application and users. Also consider upgrading to a [high availability](https://techdocs.akamai.com/cloud-computing/docs/managed-databases#high-availability) plan to avoid any maintenance downtime.\n\n- Major upgrades are optional until the service reaches end of service, and can be done in place.\n\n- A successful request triggers a `database_create` [event](https://techdocs.akamai.com/linode-api/reference/get-events).\n\n**Restore a MySQL Managed Database**\n\nInclude the `fork` object in the request to target a backed-up database. Your user needs `read_write` access to the target database and its status can be `active`, `degraded`, or `failed`.\n\n> \ud83d\udcd8\n>\n> Restoring from a backup creates a second running cluster, which incurs billing. Delete the first cluster after the restore is complete, to avoid this billing.\n\n\n<<LB>>\n\n---\n\n\n- __CLI for create operation__.\n\n    ```\n    linode-cli databases mysql-create \\\n  --label example-db1 \\\n  --region us-east \\\n  --type g6-dedicated-2 \\\n  --cluster_size 3 \\\n  --engine mysql/8.0.26 \\\n  --engine_config.binlog_retention_period 60 \\\n  --engine_config.mysql.connect_timeout 10 \\\n  --engine_config.mysql.default_time_zone +03:00 \\\n  --ssl_connection true \\\n  --allow_list 203.0.113.1 \\\n  --allow_list 192.0.1.0/24\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    databases:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/post-databases-mysql-instances"
@@ -23718,6 +24902,80 @@
         "requestBody": {
           "content": {
             "application/json": {
+              "example": {
+                "allow_list": [
+                  "192.0.2.152/24",
+                  "192.0.2.229/24"
+                ],
+                "cluster_size": 3,
+                "created": "2022-01-01T00:01:01",
+                "encrypted": true,
+                "engine": "mysql",
+                "engine_config": {
+                  "binlog_retention_period": 600,
+                  "mysql": {
+                    "connect_timeout": 10,
+                    "default_time_zone": "+03:00",
+                    "group_concat_max_len": 1024,
+                    "information_schema_stats_expiry": 86400,
+                    "innodb_change_buffer_max_size": 30,
+                    "innodb_flush_neighbors": 0,
+                    "innodb_ft_min_token_size": 3,
+                    "innodb_ft_server_stopword_table": "db_name/table_name",
+                    "innodb_lock_wait_timeout": 50,
+                    "innodb_log_buffer_size": 16777216,
+                    "innodb_online_alter_log_max_size": 134217728,
+                    "innodb_read_io_threads": 10,
+                    "innodb_rollback_on_timeout": true,
+                    "innodb_thread_concurrency": 10,
+                    "innodb_write_io_threads": 10,
+                    "interactive_timeout": 3600,
+                    "internal_tmp_mem_storage_engine": "TempTable",
+                    "max_allowed_packet": 67108864,
+                    "max_heap_table_size": 16777216,
+                    "net_buffer_length": 16384,
+                    "net_read_timeout": 30,
+                    "net_write_timeout": 30,
+                    "sort_buffer_size": 262144,
+                    "sql_mode": "ANSI,TRADITIONAL",
+                    "sql_require_primary_key": true,
+                    "tmp_table_size": 16777216,
+                    "wait_timeout": 28800
+                  }
+                },
+                "fork": {
+                  "restore_time": "2024-10-14T19:55:12",
+                  "source": 176881
+                },
+                "hosts": {
+                  "primary": "lin-123-456-mysql-mysql-primary.servers.linodedb.net",
+                  "secondary": "lin-123-456-mysql-primary-private.servers.linodedb.net"
+                },
+                "id": 123,
+                "label": "example-db",
+                "members": {
+                  "45.56.110.70": "primary",
+                  "45.79.159.239": "failover"
+                },
+                "oldest_restore_time": "2024-10-03T20:48:05",
+                "platform": "rdbms-default",
+                "port": 3306,
+                "region": "us-east",
+                "ssl_connection": true,
+                "status": "active",
+                "total_disk_size_gb": 15,
+                "type": "g6-dedicated-2",
+                "updated": "2022-01-01T00:01:01",
+                "updates": {
+                  "day_of_week": 1,
+                  "duration": 3,
+                  "frequency": "weekly",
+                  "hour_of_day": 0,
+                  "pending": []
+                },
+                "used_disk_size_gb": 2,
+                "version": "8.0.26"
+              },
               "schema": {
                 "additionalProperties": false,
                 "description": "Managed MySQL Database request object.",
@@ -23752,34 +25010,242 @@
                     "example": "{{engine}}",
                     "type": "string"
                   },
-                  "fork": {
-                    "allOf": [
-                      {
+                  "engine_config": {
+                    "additionalProperties": false,
+                    "description": "Advanced parameters you can apply to a MySQL Managed Database, via our partner [Aiven's specification](https://aiven.io/docs/products/mysql/reference/advanced-params). Only include the objects for parameters you want to set in your database. Omit objects for parameters you don't want to define or change.\n\n> \ud83d\udcd8\n>\n> Aiven may offer additional parameters in their specification. Currently, only those listed here are supported for use in a MySQL Managed Database. You can also run the [List MySQL Managed Database advanced parameters](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-config) operation to see an up-to-date list.",
+                    "properties": {
+                      "binlog_retention_period": {
+                        "description": "The minimum amount of time in seconds to keep `binlog` entries before deletion. This may be extended for services that require `binlog` entries for longer than the default, for example if using the MySQL Debezium Kafka connector.",
+                        "example": 600,
+                        "maximum": 86400,
+                        "minimum": 600,
+                        "type": "integer"
+                      },
+                      "mysql": {
                         "additionalProperties": false,
-                        "description": "Details on the database that was the target of the fork. Only exists if the database was forked from another.",
+                        "description": "MySQL-specific advanced configuration parameters.",
                         "properties": {
-                          "restore_time": {
-                            "description": "The database timestamp from which it was restored. This is _not_ when the fork was created.",
-                            "example": "2024-10-14 19:55:12",
-                            "format": "date-time",
+                          "connect_timeout": {
+                            "description": "The number of seconds that the `mysqld` server waits for a connect packet before responding with bad handshake.",
+                            "example": 10,
+                            "maximum": 3600,
+                            "minimum": 2,
+                            "type": "integer"
+                          },
+                          "default_time_zone": {
+                            "description": "Default server time zone as an offset from UTC (from -12:00 to +12:00), a time zone name, or `SYSTEM` to use the MySQL server default.",
+                            "example": "+03:00",
+                            "maxLength": 100,
+                            "minLength": 2,
+                            "pattern": "^([-+][\\\\d:]*|[\\\\w/]*)$",
                             "type": "string"
                           },
-                          "source": {
-                            "description": "The instance id of the database that was forked from.",
-                            "example": 176881,
+                          "group_concat_max_len": {
+                            "description": "The maximum permitted result length in bytes for the `GROUP_CONCAT()` function.",
+                            "example": 1024,
+                            "maximum": 18446744073709552000,
+                            "minimum": 4,
+                            "type": "integer"
+                          },
+                          "information_schema_stats_expiry": {
+                            "description": "The time, in seconds, before cached statistics expire.",
+                            "example": 86400,
+                            "maximum": 31536000,
+                            "minimum": 900,
+                            "type": "integer"
+                          },
+                          "innodb_change_buffer_max_size": {
+                            "default": 25,
+                            "description": "Maximum size for the InnoDB change buffer, as a percentage of the total size of the buffer pool.",
+                            "example": 30,
+                            "maximum": 50,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "innodb_flush_neighbors": {
+                            "default": 1,
+                            "description": "Specifies whether flushing a page from the InnoDB buffer pool also flushes other dirty pages in the same extent: `0` - dirty pages in the same extent are not flushed, `1` - flush contiguous dirty pages in the same extent, `2` - flush dirty pages in the same extent.",
+                            "example": 0,
+                            "maximum": 2,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "innodb_ft_min_token_size": {
+                            "description": "Minimum length of words that are stored in an InnoDB `-1FULLTEXT` index. Changing this parameter will lead to a restart of the MySQL service.",
+                            "example": 3,
+                            "maximum": 16,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "innodb_ft_server_stopword_table": {
+                            "description": "This option is used to specify your own InnoDB `FULLTEXT` index `stopword` list for all InnoDB tables. Set to `null` for no value.",
+                            "example": "db_name/table_name",
+                            "maxLength": 1024,
+                            "nullable": true,
+                            "pattern": "^.+/.+$",
+                            "type": "string"
+                          },
+                          "innodb_lock_wait_timeout": {
+                            "default": 120,
+                            "description": "The length of time in seconds an InnoDB transaction waits for a row lock before giving up.",
+                            "example": 50,
+                            "maximum": 3600,
+                            "minimum": 1,
+                            "type": "integer"
+                          },
+                          "innodb_log_buffer_size": {
+                            "description": "The size in bytes of the buffer that InnoDB uses to write to the log files on disk.",
+                            "example": 16777216,
+                            "maximum": 4294967295,
+                            "minimum": 1048576,
+                            "type": "integer"
+                          },
+                          "innodb_online_alter_log_max_size": {
+                            "description": "The upper limit in bytes on the size of the temporary log files used during online DDL operations for InnoDB tables.",
+                            "example": 134217728,
+                            "maximum": 1099511627776,
+                            "minimum": 65536,
+                            "type": "integer"
+                          },
+                          "innodb_read_io_threads": {
+                            "default": 4,
+                            "description": "The number of I/O threads for read operations in InnoDB. Changing this parameter will lead to a restart of the MySQL service.",
+                            "example": 10,
+                            "maximum": 64,
+                            "minimum": 1,
+                            "type": "integer"
+                          },
+                          "innodb_rollback_on_timeout": {
+                            "description": "When enabled a transaction timeout causes InnoDB to abort and roll back the entire transaction. Changing this parameter will lead to a restart of the MySQL service.",
+                            "example": true,
+                            "type": "boolean"
+                          },
+                          "innodb_thread_concurrency": {
+                            "default": 0,
+                            "description": "Defines the maximum number of threads permitted inside of InnoDB. A value of `0` indicates infinite concurrency, or no limit.",
+                            "example": 10,
+                            "maximum": 1000,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "innodb_write_io_threads": {
+                            "default": 4,
+                            "description": "The number of I/O threads for write operations in InnoDB. Changing this parameter will lead to a restart of the MySQL service.",
+                            "example": 10,
+                            "maximum": 64,
+                            "minimum": 1,
+                            "type": "integer"
+                          },
+                          "interactive_timeout": {
+                            "description": "The number of seconds the server waits for activity on an interactive connection before closing it.",
+                            "example": 3600,
+                            "maximum": 604800,
+                            "minimum": 30,
+                            "type": "integer"
+                          },
+                          "internal_tmp_mem_storage_engine": {
+                            "description": "The storage engine for in-memory internal temporary tables.",
+                            "enum": [
+                              "TempTable",
+                              "MEMORY"
+                            ],
+                            "example": "TempTable",
+                            "type": "string"
+                          },
+                          "max_allowed_packet": {
+                            "default": 7108864,
+                            "description": "Size of the largest message in bytes that can be received by the server.",
+                            "example": 67108864,
+                            "maximum": 1073741824,
+                            "minimum": 102400,
+                            "type": "integer"
+                          },
+                          "max_heap_table_size": {
+                            "default": 16777216,
+                            "description": "Limits the size of internal in-memory tables. Also set `tmp_table_size`.",
+                            "example": 16777216,
+                            "maximum": 1073741824,
+                            "minimum": 1048576,
+                            "type": "integer"
+                          },
+                          "net_buffer_length": {
+                            "default": 16384,
+                            "description": "Start sizes of connection buffer and result buffer. Changing this parameter will lead to a restart of the MySQL service.",
+                            "example": 16384,
+                            "maximum": 1048576,
+                            "minimum": 1024,
+                            "type": "integer"
+                          },
+                          "net_read_timeout": {
+                            "description": "The number of seconds to wait for more data from a connection before aborting the read.",
+                            "example": 30,
+                            "maximum": 3600,
+                            "minimum": 1,
+                            "type": "integer"
+                          },
+                          "net_write_timeout": {
+                            "description": "The number of seconds to wait for a block to be written to a connection before aborting the write.",
+                            "example": 30,
+                            "maximum": 3600,
+                            "minimum": 1,
+                            "type": "integer"
+                          },
+                          "sql_mode": {
+                            "description": "Global SQL mode. Set to empty to use MySQL server defaults. When creating a new service and not setting this field, Akamai defaults to SQL mode which is strict, SQL standard compliant.",
+                            "example": "ANSI,TRADITIONAL",
+                            "maxLength": 1024,
+                            "pattern": "^[A-Z_]*(,[A-Z_]+)*$",
+                            "type": "string"
+                          },
+                          "sql_require_primary_key": {
+                            "description": "Require primary key to be defined for new tables or old tables modified with `ALTER TABLE` and fail if missing. You should always have primary keys because various functionality may break if any large table is missing them.",
+                            "example": true,
+                            "type": "boolean"
+                          },
+                          "tmp_table_size": {
+                            "default": 16777216,
+                            "description": "Limits the size of internal in-memory tables. This also requires a `max_heap_table_size`.",
+                            "example": 16777216,
+                            "maximum": 1073741824,
+                            "minimum": 1048576,
+                            "type": "integer"
+                          },
+                          "wait_timeout": {
+                            "description": "The number of seconds the server waits for activity on a non-interactive connection before closing it.",
+                            "example": 28800,
+                            "maximum": 2147483,
+                            "minimum": 1,
                             "type": "integer"
                           }
                         },
                         "type": "object"
-                      },
-                      {
-                        "description": "Information about a database to fork from. If specified, all other fields will become optional.",
-                        "required": [
-                          "source"
-                        ]
                       }
+                    },
+                    "type": "object",
+                    "x-akamai": {
+                      "file-path": "schemas/database-mysql-engine-config.yaml"
+                    }
+                  },
+                  "fork": {
+                    "additionalProperties": false,
+                    "description": "Include this object to restore a Managed Database by forking from a backup.\n\n- If you include this object, all other fields are optional.\n\n- Don't include this object if you're creating a new Managed Database.",
+                    "properties": {
+                      "restore_time": {
+                        "description": "A specific database timestamp to restore from.",
+                        "example": "2024-10-14T19:55:12",
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "source": {
+                        "description": "The unique instance id for the database to fork from. Run the [List Managed Databases](https://techdocs.akamai.com/linode-api/reference/get-databases-instances) operation and store the unique `id` for the target Managed Database.",
+                        "example": 176881,
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "source"
                     ],
-                    "example": "{{fork}}",
+                    "type": "object",
                     "x-akamai": {
                       "file-path": "schemas/database-restore-fork.yaml"
                     }
@@ -23812,7 +25278,7 @@
                   },
                   "ssl_connection": {
                     "default": true,
-                    "description": "Currently required to be `true`. Whether to require SSL credentials to establish a connection to the Managed Database.\n\nRun the [Get managed MySQL database credentials](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-instance-credentials) operation for access information.",
+                    "description": "Currently required to be `true`. Whether to require SSL credentials to establish a connection to the Managed Database. Run the [Get managed MySQL database credentials](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-instance-credentials) operation for access information.",
                     "example": "{{ssl_connection}}",
                     "type": "boolean"
                   },
@@ -23839,9 +25305,6 @@
                 "x-akamai": {
                   "file-path": "schemas/database-mysql-request.yaml"
                 }
-              },
-              "x-example": {
-                "x-ref": "../examples/post-databases-mysql-instances.json"
               }
             }
           },
@@ -23856,6 +25319,80 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "allow_list": [
+                    "192.0.2.250/24",
+                    "192.0.2.131/24"
+                  ],
+                  "cluster_size": 3,
+                  "created": "2022-01-01T00:01:01",
+                  "encrypted": true,
+                  "engine": "mysql",
+                  "engine_config": {
+                    "binlog_retention_period": 600,
+                    "mysql": {
+                      "connect_timeout": 10,
+                      "default_time_zone": "+03:00",
+                      "group_concat_max_len": 1024,
+                      "information_schema_stats_expiry": 86400,
+                      "innodb_change_buffer_max_size": 30,
+                      "innodb_flush_neighbors": 0,
+                      "innodb_ft_min_token_size": 3,
+                      "innodb_ft_server_stopword_table": "db_name/table_name",
+                      "innodb_lock_wait_timeout": 50,
+                      "innodb_log_buffer_size": 16777216,
+                      "innodb_online_alter_log_max_size": 134217728,
+                      "innodb_read_io_threads": 10,
+                      "innodb_rollback_on_timeout": true,
+                      "innodb_thread_concurrency": 10,
+                      "innodb_write_io_threads": 10,
+                      "interactive_timeout": 3600,
+                      "internal_tmp_mem_storage_engine": "TempTable",
+                      "max_allowed_packet": 67108864,
+                      "max_heap_table_size": 16777216,
+                      "net_buffer_length": 16384,
+                      "net_read_timeout": 30,
+                      "net_write_timeout": 30,
+                      "sort_buffer_size": 262144,
+                      "sql_mode": "ANSI,TRADITIONAL",
+                      "sql_require_primary_key": true,
+                      "tmp_table_size": 16777216,
+                      "wait_timeout": 28800
+                    }
+                  },
+                  "fork": {
+                    "restore_time": "2024-10-14T19:55:12",
+                    "source": 176881
+                  },
+                  "hosts": {
+                    "primary": "lin-123-456-mysql-mysql-primary.servers.linodedb.net",
+                    "secondary": "lin-123-456-mysql-primary-private.servers.linodedb.net"
+                  },
+                  "id": 123,
+                  "label": "example-db",
+                  "members": {
+                    "45.56.110.70": "primary",
+                    "45.79.159.239": "failover"
+                  },
+                  "oldest_restore_time": "2024-10-03T20:48:05",
+                  "platform": "rdbms-default",
+                  "port": 3306,
+                  "region": "us-east",
+                  "ssl_connection": true,
+                  "status": "active",
+                  "total_disk_size_gb": 15,
+                  "type": "g6-dedicated-2",
+                  "updated": "2022-01-01T00:01:01",
+                  "updates": {
+                    "day_of_week": 1,
+                    "duration": 3,
+                    "frequency": "weekly",
+                    "hour_of_day": 0,
+                    "pending": []
+                  },
+                  "used_disk_size_gb": 2,
+                  "version": "8.0.26"
+                },
                 "schema": {
                   "additionalProperties": false,
                   "description": "Managed MySQL Databases object.",
@@ -23912,9 +25449,226 @@
                       "x-linode-cli-display": 8,
                       "x-linode-filterable": true
                     },
+                    "engine_config": {
+                      "additionalProperties": false,
+                      "description": "Advanced parameters you can apply to a MySQL Managed Database, via our partner [Aiven's specification](https://aiven.io/docs/products/mysql/reference/advanced-params). Only include the objects for parameters you want to set in your database. Omit objects for parameters you don't want to define or change.\n\n> \ud83d\udcd8\n>\n> Aiven may offer additional parameters in their specification. Currently, only those listed here are supported for use in a MySQL Managed Database. You can also run the [List MySQL Managed Database advanced parameters](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-config) operation to see an up-to-date list.",
+                      "properties": {
+                        "binlog_retention_period": {
+                          "description": "The minimum amount of time in seconds to keep `binlog` entries before deletion. This may be extended for services that require `binlog` entries for longer than the default, for example if using the MySQL Debezium Kafka connector.",
+                          "example": 600,
+                          "maximum": 86400,
+                          "minimum": 600,
+                          "type": "integer"
+                        },
+                        "mysql": {
+                          "additionalProperties": false,
+                          "description": "MySQL-specific advanced configuration parameters.",
+                          "properties": {
+                            "connect_timeout": {
+                              "description": "The number of seconds that the `mysqld` server waits for a connect packet before responding with bad handshake.",
+                              "example": 10,
+                              "maximum": 3600,
+                              "minimum": 2,
+                              "type": "integer"
+                            },
+                            "default_time_zone": {
+                              "description": "Default server time zone as an offset from UTC (from -12:00 to +12:00), a time zone name, or `SYSTEM` to use the MySQL server default.",
+                              "example": "+03:00",
+                              "maxLength": 100,
+                              "minLength": 2,
+                              "pattern": "^([-+][\\\\d:]*|[\\\\w/]*)$",
+                              "type": "string"
+                            },
+                            "group_concat_max_len": {
+                              "description": "The maximum permitted result length in bytes for the `GROUP_CONCAT()` function.",
+                              "example": 1024,
+                              "maximum": 18446744073709552000,
+                              "minimum": 4,
+                              "type": "integer"
+                            },
+                            "information_schema_stats_expiry": {
+                              "description": "The time, in seconds, before cached statistics expire.",
+                              "example": 86400,
+                              "maximum": 31536000,
+                              "minimum": 900,
+                              "type": "integer"
+                            },
+                            "innodb_change_buffer_max_size": {
+                              "default": 25,
+                              "description": "Maximum size for the InnoDB change buffer, as a percentage of the total size of the buffer pool.",
+                              "example": 30,
+                              "maximum": 50,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "innodb_flush_neighbors": {
+                              "default": 1,
+                              "description": "Specifies whether flushing a page from the InnoDB buffer pool also flushes other dirty pages in the same extent: `0` - dirty pages in the same extent are not flushed, `1` - flush contiguous dirty pages in the same extent, `2` - flush dirty pages in the same extent.",
+                              "example": 0,
+                              "maximum": 2,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "innodb_ft_min_token_size": {
+                              "description": "Minimum length of words that are stored in an InnoDB `-1FULLTEXT` index. Changing this parameter will lead to a restart of the MySQL service.",
+                              "example": 3,
+                              "maximum": 16,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "innodb_ft_server_stopword_table": {
+                              "description": "This option is used to specify your own InnoDB `FULLTEXT` index `stopword` list for all InnoDB tables. Set to `null` for no value.",
+                              "example": "db_name/table_name",
+                              "maxLength": 1024,
+                              "nullable": true,
+                              "pattern": "^.+/.+$",
+                              "type": "string"
+                            },
+                            "innodb_lock_wait_timeout": {
+                              "default": 120,
+                              "description": "The length of time in seconds an InnoDB transaction waits for a row lock before giving up.",
+                              "example": 50,
+                              "maximum": 3600,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "innodb_log_buffer_size": {
+                              "description": "The size in bytes of the buffer that InnoDB uses to write to the log files on disk.",
+                              "example": 16777216,
+                              "maximum": 4294967295,
+                              "minimum": 1048576,
+                              "type": "integer"
+                            },
+                            "innodb_online_alter_log_max_size": {
+                              "description": "The upper limit in bytes on the size of the temporary log files used during online DDL operations for InnoDB tables.",
+                              "example": 134217728,
+                              "maximum": 1099511627776,
+                              "minimum": 65536,
+                              "type": "integer"
+                            },
+                            "innodb_read_io_threads": {
+                              "default": 4,
+                              "description": "The number of I/O threads for read operations in InnoDB. Changing this parameter will lead to a restart of the MySQL service.",
+                              "example": 10,
+                              "maximum": 64,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "innodb_rollback_on_timeout": {
+                              "description": "When enabled a transaction timeout causes InnoDB to abort and roll back the entire transaction. Changing this parameter will lead to a restart of the MySQL service.",
+                              "example": true,
+                              "type": "boolean"
+                            },
+                            "innodb_thread_concurrency": {
+                              "default": 0,
+                              "description": "Defines the maximum number of threads permitted inside of InnoDB. A value of `0` indicates infinite concurrency, or no limit.",
+                              "example": 10,
+                              "maximum": 1000,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "innodb_write_io_threads": {
+                              "default": 4,
+                              "description": "The number of I/O threads for write operations in InnoDB. Changing this parameter will lead to a restart of the MySQL service.",
+                              "example": 10,
+                              "maximum": 64,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "interactive_timeout": {
+                              "description": "The number of seconds the server waits for activity on an interactive connection before closing it.",
+                              "example": 3600,
+                              "maximum": 604800,
+                              "minimum": 30,
+                              "type": "integer"
+                            },
+                            "internal_tmp_mem_storage_engine": {
+                              "description": "The storage engine for in-memory internal temporary tables.",
+                              "enum": [
+                                "TempTable",
+                                "MEMORY"
+                              ],
+                              "example": "TempTable",
+                              "type": "string"
+                            },
+                            "max_allowed_packet": {
+                              "default": 7108864,
+                              "description": "Size of the largest message in bytes that can be received by the server.",
+                              "example": 67108864,
+                              "maximum": 1073741824,
+                              "minimum": 102400,
+                              "type": "integer"
+                            },
+                            "max_heap_table_size": {
+                              "default": 16777216,
+                              "description": "Limits the size of internal in-memory tables. Also set `tmp_table_size`.",
+                              "example": 16777216,
+                              "maximum": 1073741824,
+                              "minimum": 1048576,
+                              "type": "integer"
+                            },
+                            "net_buffer_length": {
+                              "default": 16384,
+                              "description": "Start sizes of connection buffer and result buffer. Changing this parameter will lead to a restart of the MySQL service.",
+                              "example": 16384,
+                              "maximum": 1048576,
+                              "minimum": 1024,
+                              "type": "integer"
+                            },
+                            "net_read_timeout": {
+                              "description": "The number of seconds to wait for more data from a connection before aborting the read.",
+                              "example": 30,
+                              "maximum": 3600,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "net_write_timeout": {
+                              "description": "The number of seconds to wait for a block to be written to a connection before aborting the write.",
+                              "example": 30,
+                              "maximum": 3600,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "sql_mode": {
+                              "description": "Global SQL mode. Set to empty to use MySQL server defaults. When creating a new service and not setting this field, Akamai defaults to SQL mode which is strict, SQL standard compliant.",
+                              "example": "ANSI,TRADITIONAL",
+                              "maxLength": 1024,
+                              "pattern": "^[A-Z_]*(,[A-Z_]+)*$",
+                              "type": "string"
+                            },
+                            "sql_require_primary_key": {
+                              "description": "Require primary key to be defined for new tables or old tables modified with `ALTER TABLE` and fail if missing. You should always have primary keys because various functionality may break if any large table is missing them.",
+                              "example": true,
+                              "type": "boolean"
+                            },
+                            "tmp_table_size": {
+                              "default": 16777216,
+                              "description": "Limits the size of internal in-memory tables. This also requires a `max_heap_table_size`.",
+                              "example": 16777216,
+                              "maximum": 1073741824,
+                              "minimum": 1048576,
+                              "type": "integer"
+                            },
+                            "wait_timeout": {
+                              "description": "The number of seconds the server waits for activity on a non-interactive connection before closing it.",
+                              "example": 28800,
+                              "maximum": 2147483,
+                              "minimum": 1,
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "x-akamai": {
+                        "file-path": "schemas/database-mysql-engine-config.yaml"
+                      },
+                      "x-linode-cli-display": 9
+                    },
                     "fork": {
                       "additionalProperties": false,
-                      "description": "Details on the database that was the target of the fork. Only exists if the database was forked from another.",
+                      "description": "Details on the database that was the target of the fork. This only exists if the database was restored by creating a fork from another [MySQL](https://techdocs.akamai.com/linode-api/reference/post-databases-mysql-instances) or [PostgreSQL](https://techdocs.akamai.com/linode-api/reference/post-databases-postgre-sql-instances) database.",
                       "properties": {
                         "restore_time": {
                           "description": "The database timestamp from which it was restored. This is _not_ when the fork was created.",
@@ -24024,7 +25778,7 @@
                     },
                     "ssl_connection": {
                       "default": true,
-                      "description": "Currently required to be `true`. Whether to require SSL credentials to establish a connection to the Managed Database.\n\nRun the [Get managed MySQL database credentials](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-instance-credentials) operation for access information.",
+                      "description": "Currently required to be `true`. Whether to require SSL credentials to establish a connection to the Managed Database. Run the [Get managed MySQL database credentials](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-instance-credentials) operation for access information.",
                       "example": true,
                       "type": "boolean"
                     },
@@ -24128,7 +25882,7 @@
                             "properties": {
                               "deadline": {
                                 "description": "The time when a mandatory update needs to be applied.",
-                                "example": "2024-10-14 19:55:12",
+                                "example": "2024-10-14T19:55:12",
                                 "format": "date-time",
                                 "nullable": true,
                                 "type": "string"
@@ -24140,7 +25894,7 @@
                               },
                               "planned_for": {
                                 "description": "The date and time a maintenance update will be applied.",
-                                "example": "2024-10-14 19:55:12",
+                                "example": "2024-10-14T19:55:12",
                                 "format": "date-time",
                                 "nullable": true,
                                 "type": "string"
@@ -24177,9 +25931,6 @@
                   "x-akamai": {
                     "file-path": "schemas/database-mysql.yaml"
                   }
-                },
-                "x-example": {
-                  "x-ref": "../examples/post-databases-mysql-instances-200.json"
                 }
               }
             },
@@ -24239,7 +25990,7 @@
         "x-akamai": {
           "tabs": [
             {
-              "syntax": "linode-cli databases mysql-create \\\n  --label example-db1 \\\n  --region us-east \\\n  --type g6-dedicated-2 \\\n  --cluster_size 3 \\\n  --engine mysql/8.0.26 \\\n  --ssl_connection true \\\n  --allow_list 203.0.113.1 \\\n  --allow_list 192.0.1.0/24",
+              "syntax": "linode-cli databases mysql-create \\\n  --label example-db1 \\\n  --region us-east \\\n  --type g6-dedicated-2 \\\n  --cluster_size 3 \\\n  --engine mysql/8.0.26 \\\n  --engine_config.binlog_retention_period 60 \\\n  --engine_config.mysql.connect_timeout 10 \\\n  --engine_config.mysql.default_time_zone +03:00 \\\n  --ssl_connection true \\\n  --allow_list 203.0.113.1 \\\n  --allow_list 192.0.1.0/24",
               "title": "CLI for create operation",
               "url": "https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli"
             },
@@ -24309,6 +26060,38 @@
                       "created": "2022-01-01T00:01:01",
                       "encrypted": true,
                       "engine": "mysql",
+                      "engine_config": {
+                        "binlog_retention_period": 600,
+                        "mysql": {
+                          "connect_timeout": 10,
+                          "default_time_zone": "+03:00",
+                          "group_concat_max_len": 1024,
+                          "information_schema_stats_expiry": 86400,
+                          "innodb_change_buffer_max_size": 30,
+                          "innodb_flush_neighbors": 0,
+                          "innodb_ft_min_token_size": 3,
+                          "innodb_ft_server_stopword_table": "db_name/table_name",
+                          "innodb_lock_wait_timeout": 50,
+                          "innodb_log_buffer_size": 16777216,
+                          "innodb_online_alter_log_max_size": 134217728,
+                          "innodb_read_io_threads": 10,
+                          "innodb_rollback_on_timeout": true,
+                          "innodb_thread_concurrency": 10,
+                          "innodb_write_io_threads": 10,
+                          "interactive_timeout": 3600,
+                          "internal_tmp_mem_storage_engine": "TempTable",
+                          "max_allowed_packet": 67108864,
+                          "max_heap_table_size": 16777216,
+                          "net_buffer_length": 16384,
+                          "net_read_timeout": 30,
+                          "net_write_timeout": 30,
+                          "sort_buffer_size": 262144,
+                          "sql_mode": "ANSI,TRADITIONAL",
+                          "sql_require_primary_key": true,
+                          "tmp_table_size": 16777216,
+                          "wait_timeout": 28800
+                        }
+                      },
                       "fork": {
                         "restore_time": "2024-10-14T19:55:12",
                         "source": "176881"
@@ -24437,9 +26220,226 @@
                                 "x-linode-cli-display": 8,
                                 "x-linode-filterable": true
                               },
+                              "engine_config": {
+                                "additionalProperties": false,
+                                "description": "Advanced parameters you can apply to a MySQL Managed Database, via our partner [Aiven's specification](https://aiven.io/docs/products/mysql/reference/advanced-params). Only include the objects for parameters you want to set in your database. Omit objects for parameters you don't want to define or change.\n\n> \ud83d\udcd8\n>\n> Aiven may offer additional parameters in their specification. Currently, only those listed here are supported for use in a MySQL Managed Database. You can also run the [List MySQL Managed Database advanced parameters](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-config) operation to see an up-to-date list.",
+                                "properties": {
+                                  "binlog_retention_period": {
+                                    "description": "The minimum amount of time in seconds to keep `binlog` entries before deletion. This may be extended for services that require `binlog` entries for longer than the default, for example if using the MySQL Debezium Kafka connector.",
+                                    "example": 600,
+                                    "maximum": 86400,
+                                    "minimum": 600,
+                                    "type": "integer"
+                                  },
+                                  "mysql": {
+                                    "additionalProperties": false,
+                                    "description": "MySQL-specific advanced configuration parameters.",
+                                    "properties": {
+                                      "connect_timeout": {
+                                        "description": "The number of seconds that the `mysqld` server waits for a connect packet before responding with bad handshake.",
+                                        "example": 10,
+                                        "maximum": 3600,
+                                        "minimum": 2,
+                                        "type": "integer"
+                                      },
+                                      "default_time_zone": {
+                                        "description": "Default server time zone as an offset from UTC (from -12:00 to +12:00), a time zone name, or `SYSTEM` to use the MySQL server default.",
+                                        "example": "+03:00",
+                                        "maxLength": 100,
+                                        "minLength": 2,
+                                        "pattern": "^([-+][\\\\d:]*|[\\\\w/]*)$",
+                                        "type": "string"
+                                      },
+                                      "group_concat_max_len": {
+                                        "description": "The maximum permitted result length in bytes for the `GROUP_CONCAT()` function.",
+                                        "example": 1024,
+                                        "maximum": 18446744073709552000,
+                                        "minimum": 4,
+                                        "type": "integer"
+                                      },
+                                      "information_schema_stats_expiry": {
+                                        "description": "The time, in seconds, before cached statistics expire.",
+                                        "example": 86400,
+                                        "maximum": 31536000,
+                                        "minimum": 900,
+                                        "type": "integer"
+                                      },
+                                      "innodb_change_buffer_max_size": {
+                                        "default": 25,
+                                        "description": "Maximum size for the InnoDB change buffer, as a percentage of the total size of the buffer pool.",
+                                        "example": 30,
+                                        "maximum": 50,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "innodb_flush_neighbors": {
+                                        "default": 1,
+                                        "description": "Specifies whether flushing a page from the InnoDB buffer pool also flushes other dirty pages in the same extent: `0` - dirty pages in the same extent are not flushed, `1` - flush contiguous dirty pages in the same extent, `2` - flush dirty pages in the same extent.",
+                                        "example": 0,
+                                        "maximum": 2,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "innodb_ft_min_token_size": {
+                                        "description": "Minimum length of words that are stored in an InnoDB `-1FULLTEXT` index. Changing this parameter will lead to a restart of the MySQL service.",
+                                        "example": 3,
+                                        "maximum": 16,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "innodb_ft_server_stopword_table": {
+                                        "description": "This option is used to specify your own InnoDB `FULLTEXT` index `stopword` list for all InnoDB tables. Set to `null` for no value.",
+                                        "example": "db_name/table_name",
+                                        "maxLength": 1024,
+                                        "nullable": true,
+                                        "pattern": "^.+/.+$",
+                                        "type": "string"
+                                      },
+                                      "innodb_lock_wait_timeout": {
+                                        "default": 120,
+                                        "description": "The length of time in seconds an InnoDB transaction waits for a row lock before giving up.",
+                                        "example": 50,
+                                        "maximum": 3600,
+                                        "minimum": 1,
+                                        "type": "integer"
+                                      },
+                                      "innodb_log_buffer_size": {
+                                        "description": "The size in bytes of the buffer that InnoDB uses to write to the log files on disk.",
+                                        "example": 16777216,
+                                        "maximum": 4294967295,
+                                        "minimum": 1048576,
+                                        "type": "integer"
+                                      },
+                                      "innodb_online_alter_log_max_size": {
+                                        "description": "The upper limit in bytes on the size of the temporary log files used during online DDL operations for InnoDB tables.",
+                                        "example": 134217728,
+                                        "maximum": 1099511627776,
+                                        "minimum": 65536,
+                                        "type": "integer"
+                                      },
+                                      "innodb_read_io_threads": {
+                                        "default": 4,
+                                        "description": "The number of I/O threads for read operations in InnoDB. Changing this parameter will lead to a restart of the MySQL service.",
+                                        "example": 10,
+                                        "maximum": 64,
+                                        "minimum": 1,
+                                        "type": "integer"
+                                      },
+                                      "innodb_rollback_on_timeout": {
+                                        "description": "When enabled a transaction timeout causes InnoDB to abort and roll back the entire transaction. Changing this parameter will lead to a restart of the MySQL service.",
+                                        "example": true,
+                                        "type": "boolean"
+                                      },
+                                      "innodb_thread_concurrency": {
+                                        "default": 0,
+                                        "description": "Defines the maximum number of threads permitted inside of InnoDB. A value of `0` indicates infinite concurrency, or no limit.",
+                                        "example": 10,
+                                        "maximum": 1000,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "innodb_write_io_threads": {
+                                        "default": 4,
+                                        "description": "The number of I/O threads for write operations in InnoDB. Changing this parameter will lead to a restart of the MySQL service.",
+                                        "example": 10,
+                                        "maximum": 64,
+                                        "minimum": 1,
+                                        "type": "integer"
+                                      },
+                                      "interactive_timeout": {
+                                        "description": "The number of seconds the server waits for activity on an interactive connection before closing it.",
+                                        "example": 3600,
+                                        "maximum": 604800,
+                                        "minimum": 30,
+                                        "type": "integer"
+                                      },
+                                      "internal_tmp_mem_storage_engine": {
+                                        "description": "The storage engine for in-memory internal temporary tables.",
+                                        "enum": [
+                                          "TempTable",
+                                          "MEMORY"
+                                        ],
+                                        "example": "TempTable",
+                                        "type": "string"
+                                      },
+                                      "max_allowed_packet": {
+                                        "default": 7108864,
+                                        "description": "Size of the largest message in bytes that can be received by the server.",
+                                        "example": 67108864,
+                                        "maximum": 1073741824,
+                                        "minimum": 102400,
+                                        "type": "integer"
+                                      },
+                                      "max_heap_table_size": {
+                                        "default": 16777216,
+                                        "description": "Limits the size of internal in-memory tables. Also set `tmp_table_size`.",
+                                        "example": 16777216,
+                                        "maximum": 1073741824,
+                                        "minimum": 1048576,
+                                        "type": "integer"
+                                      },
+                                      "net_buffer_length": {
+                                        "default": 16384,
+                                        "description": "Start sizes of connection buffer and result buffer. Changing this parameter will lead to a restart of the MySQL service.",
+                                        "example": 16384,
+                                        "maximum": 1048576,
+                                        "minimum": 1024,
+                                        "type": "integer"
+                                      },
+                                      "net_read_timeout": {
+                                        "description": "The number of seconds to wait for more data from a connection before aborting the read.",
+                                        "example": 30,
+                                        "maximum": 3600,
+                                        "minimum": 1,
+                                        "type": "integer"
+                                      },
+                                      "net_write_timeout": {
+                                        "description": "The number of seconds to wait for a block to be written to a connection before aborting the write.",
+                                        "example": 30,
+                                        "maximum": 3600,
+                                        "minimum": 1,
+                                        "type": "integer"
+                                      },
+                                      "sql_mode": {
+                                        "description": "Global SQL mode. Set to empty to use MySQL server defaults. When creating a new service and not setting this field, Akamai defaults to SQL mode which is strict, SQL standard compliant.",
+                                        "example": "ANSI,TRADITIONAL",
+                                        "maxLength": 1024,
+                                        "pattern": "^[A-Z_]*(,[A-Z_]+)*$",
+                                        "type": "string"
+                                      },
+                                      "sql_require_primary_key": {
+                                        "description": "Require primary key to be defined for new tables or old tables modified with `ALTER TABLE` and fail if missing. You should always have primary keys because various functionality may break if any large table is missing them.",
+                                        "example": true,
+                                        "type": "boolean"
+                                      },
+                                      "tmp_table_size": {
+                                        "default": 16777216,
+                                        "description": "Limits the size of internal in-memory tables. This also requires a `max_heap_table_size`.",
+                                        "example": 16777216,
+                                        "maximum": 1073741824,
+                                        "minimum": 1048576,
+                                        "type": "integer"
+                                      },
+                                      "wait_timeout": {
+                                        "description": "The number of seconds the server waits for activity on a non-interactive connection before closing it.",
+                                        "example": 28800,
+                                        "maximum": 2147483,
+                                        "minimum": 1,
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-akamai": {
+                                  "file-path": "schemas/database-mysql-engine-config.yaml"
+                                },
+                                "x-linode-cli-display": 9
+                              },
                               "fork": {
                                 "additionalProperties": false,
-                                "description": "Details on the database that was the target of the fork. Only exists if the database was forked from another.",
+                                "description": "Details on the database that was the target of the fork. This only exists if the database was restored by creating a fork from another [MySQL](https://techdocs.akamai.com/linode-api/reference/post-databases-mysql-instances) or [PostgreSQL](https://techdocs.akamai.com/linode-api/reference/post-databases-postgre-sql-instances) database.",
                                 "properties": {
                                   "restore_time": {
                                     "description": "The database timestamp from which it was restored. This is _not_ when the fork was created.",
@@ -24549,7 +26549,7 @@
                               },
                               "ssl_connection": {
                                 "default": true,
-                                "description": "Currently required to be `true`. Whether to require SSL credentials to establish a connection to the Managed Database.\n\nRun the [Get managed MySQL database credentials](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-instance-credentials) operation for access information.",
+                                "description": "Currently required to be `true`. Whether to require SSL credentials to establish a connection to the Managed Database. Run the [Get managed MySQL database credentials](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-instance-credentials) operation for access information.",
                                 "example": true,
                                 "type": "boolean"
                               },
@@ -24653,7 +26653,7 @@
                                       "properties": {
                                         "deadline": {
                                           "description": "The time when a mandatory update needs to be applied.",
-                                          "example": "2024-10-14 19:55:12",
+                                          "example": "2024-10-14T19:55:12",
                                           "format": "date-time",
                                           "nullable": true,
                                           "type": "string"
@@ -24665,7 +26665,7 @@
                                         },
                                         "planned_for": {
                                           "description": "The date and time a maintenance update will be applied.",
-                                          "example": "2024-10-14 19:55:12",
+                                          "example": "2024-10-14T19:55:12",
                                           "format": "date-time",
                                           "nullable": true,
                                           "type": "string"
@@ -24822,6 +26822,80 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "allow_list": [
+                    "192.0.2.250/24",
+                    "192.0.2.131/24"
+                  ],
+                  "cluster_size": 3,
+                  "created": "2022-01-01T00:01:01",
+                  "encrypted": true,
+                  "engine": "mysql",
+                  "engine_config": {
+                    "binlog_retention_period": 600,
+                    "mysql": {
+                      "connect_timeout": 10,
+                      "default_time_zone": "+03:00",
+                      "group_concat_max_len": 1024,
+                      "information_schema_stats_expiry": 86400,
+                      "innodb_change_buffer_max_size": 30,
+                      "innodb_flush_neighbors": 0,
+                      "innodb_ft_min_token_size": 3,
+                      "innodb_ft_server_stopword_table": "db_name/table_name",
+                      "innodb_lock_wait_timeout": 50,
+                      "innodb_log_buffer_size": 16777216,
+                      "innodb_online_alter_log_max_size": 134217728,
+                      "innodb_read_io_threads": 10,
+                      "innodb_rollback_on_timeout": true,
+                      "innodb_thread_concurrency": 10,
+                      "innodb_write_io_threads": 10,
+                      "interactive_timeout": 3600,
+                      "internal_tmp_mem_storage_engine": "TempTable",
+                      "max_allowed_packet": 67108864,
+                      "max_heap_table_size": 16777216,
+                      "net_buffer_length": 16384,
+                      "net_read_timeout": 30,
+                      "net_write_timeout": 30,
+                      "sort_buffer_size": 262144,
+                      "sql_mode": "ANSI,TRADITIONAL",
+                      "sql_require_primary_key": true,
+                      "tmp_table_size": 16777216,
+                      "wait_timeout": 28800
+                    }
+                  },
+                  "fork": {
+                    "restore_time": "2024-10-14T19:55:12",
+                    "source": 176881
+                  },
+                  "hosts": {
+                    "primary": "lin-123-456-mysql-mysql-primary.servers.linodedb.net",
+                    "secondary": "lin-123-456-mysql-primary-private.servers.linodedb.net"
+                  },
+                  "id": 123,
+                  "label": "example-db",
+                  "members": {
+                    "45.56.110.70": "primary",
+                    "45.79.159.239": "failover"
+                  },
+                  "oldest_restore_time": "2024-10-03T20:48:05",
+                  "platform": "rdbms-default",
+                  "port": 3306,
+                  "region": "us-east",
+                  "ssl_connection": true,
+                  "status": "active",
+                  "total_disk_size_gb": 15,
+                  "type": "g6-dedicated-2",
+                  "updated": "2022-01-01T00:01:01",
+                  "updates": {
+                    "day_of_week": 1,
+                    "duration": 3,
+                    "frequency": "weekly",
+                    "hour_of_day": 0,
+                    "pending": []
+                  },
+                  "used_disk_size_gb": 2,
+                  "version": "8.0.26"
+                },
                 "schema": {
                   "additionalProperties": false,
                   "description": "Managed MySQL Databases object.",
@@ -24878,9 +26952,226 @@
                       "x-linode-cli-display": 8,
                       "x-linode-filterable": true
                     },
+                    "engine_config": {
+                      "additionalProperties": false,
+                      "description": "Advanced parameters you can apply to a MySQL Managed Database, via our partner [Aiven's specification](https://aiven.io/docs/products/mysql/reference/advanced-params). Only include the objects for parameters you want to set in your database. Omit objects for parameters you don't want to define or change.\n\n> \ud83d\udcd8\n>\n> Aiven may offer additional parameters in their specification. Currently, only those listed here are supported for use in a MySQL Managed Database. You can also run the [List MySQL Managed Database advanced parameters](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-config) operation to see an up-to-date list.",
+                      "properties": {
+                        "binlog_retention_period": {
+                          "description": "The minimum amount of time in seconds to keep `binlog` entries before deletion. This may be extended for services that require `binlog` entries for longer than the default, for example if using the MySQL Debezium Kafka connector.",
+                          "example": 600,
+                          "maximum": 86400,
+                          "minimum": 600,
+                          "type": "integer"
+                        },
+                        "mysql": {
+                          "additionalProperties": false,
+                          "description": "MySQL-specific advanced configuration parameters.",
+                          "properties": {
+                            "connect_timeout": {
+                              "description": "The number of seconds that the `mysqld` server waits for a connect packet before responding with bad handshake.",
+                              "example": 10,
+                              "maximum": 3600,
+                              "minimum": 2,
+                              "type": "integer"
+                            },
+                            "default_time_zone": {
+                              "description": "Default server time zone as an offset from UTC (from -12:00 to +12:00), a time zone name, or `SYSTEM` to use the MySQL server default.",
+                              "example": "+03:00",
+                              "maxLength": 100,
+                              "minLength": 2,
+                              "pattern": "^([-+][\\\\d:]*|[\\\\w/]*)$",
+                              "type": "string"
+                            },
+                            "group_concat_max_len": {
+                              "description": "The maximum permitted result length in bytes for the `GROUP_CONCAT()` function.",
+                              "example": 1024,
+                              "maximum": 18446744073709552000,
+                              "minimum": 4,
+                              "type": "integer"
+                            },
+                            "information_schema_stats_expiry": {
+                              "description": "The time, in seconds, before cached statistics expire.",
+                              "example": 86400,
+                              "maximum": 31536000,
+                              "minimum": 900,
+                              "type": "integer"
+                            },
+                            "innodb_change_buffer_max_size": {
+                              "default": 25,
+                              "description": "Maximum size for the InnoDB change buffer, as a percentage of the total size of the buffer pool.",
+                              "example": 30,
+                              "maximum": 50,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "innodb_flush_neighbors": {
+                              "default": 1,
+                              "description": "Specifies whether flushing a page from the InnoDB buffer pool also flushes other dirty pages in the same extent: `0` - dirty pages in the same extent are not flushed, `1` - flush contiguous dirty pages in the same extent, `2` - flush dirty pages in the same extent.",
+                              "example": 0,
+                              "maximum": 2,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "innodb_ft_min_token_size": {
+                              "description": "Minimum length of words that are stored in an InnoDB `-1FULLTEXT` index. Changing this parameter will lead to a restart of the MySQL service.",
+                              "example": 3,
+                              "maximum": 16,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "innodb_ft_server_stopword_table": {
+                              "description": "This option is used to specify your own InnoDB `FULLTEXT` index `stopword` list for all InnoDB tables. Set to `null` for no value.",
+                              "example": "db_name/table_name",
+                              "maxLength": 1024,
+                              "nullable": true,
+                              "pattern": "^.+/.+$",
+                              "type": "string"
+                            },
+                            "innodb_lock_wait_timeout": {
+                              "default": 120,
+                              "description": "The length of time in seconds an InnoDB transaction waits for a row lock before giving up.",
+                              "example": 50,
+                              "maximum": 3600,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "innodb_log_buffer_size": {
+                              "description": "The size in bytes of the buffer that InnoDB uses to write to the log files on disk.",
+                              "example": 16777216,
+                              "maximum": 4294967295,
+                              "minimum": 1048576,
+                              "type": "integer"
+                            },
+                            "innodb_online_alter_log_max_size": {
+                              "description": "The upper limit in bytes on the size of the temporary log files used during online DDL operations for InnoDB tables.",
+                              "example": 134217728,
+                              "maximum": 1099511627776,
+                              "minimum": 65536,
+                              "type": "integer"
+                            },
+                            "innodb_read_io_threads": {
+                              "default": 4,
+                              "description": "The number of I/O threads for read operations in InnoDB. Changing this parameter will lead to a restart of the MySQL service.",
+                              "example": 10,
+                              "maximum": 64,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "innodb_rollback_on_timeout": {
+                              "description": "When enabled a transaction timeout causes InnoDB to abort and roll back the entire transaction. Changing this parameter will lead to a restart of the MySQL service.",
+                              "example": true,
+                              "type": "boolean"
+                            },
+                            "innodb_thread_concurrency": {
+                              "default": 0,
+                              "description": "Defines the maximum number of threads permitted inside of InnoDB. A value of `0` indicates infinite concurrency, or no limit.",
+                              "example": 10,
+                              "maximum": 1000,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "innodb_write_io_threads": {
+                              "default": 4,
+                              "description": "The number of I/O threads for write operations in InnoDB. Changing this parameter will lead to a restart of the MySQL service.",
+                              "example": 10,
+                              "maximum": 64,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "interactive_timeout": {
+                              "description": "The number of seconds the server waits for activity on an interactive connection before closing it.",
+                              "example": 3600,
+                              "maximum": 604800,
+                              "minimum": 30,
+                              "type": "integer"
+                            },
+                            "internal_tmp_mem_storage_engine": {
+                              "description": "The storage engine for in-memory internal temporary tables.",
+                              "enum": [
+                                "TempTable",
+                                "MEMORY"
+                              ],
+                              "example": "TempTable",
+                              "type": "string"
+                            },
+                            "max_allowed_packet": {
+                              "default": 7108864,
+                              "description": "Size of the largest message in bytes that can be received by the server.",
+                              "example": 67108864,
+                              "maximum": 1073741824,
+                              "minimum": 102400,
+                              "type": "integer"
+                            },
+                            "max_heap_table_size": {
+                              "default": 16777216,
+                              "description": "Limits the size of internal in-memory tables. Also set `tmp_table_size`.",
+                              "example": 16777216,
+                              "maximum": 1073741824,
+                              "minimum": 1048576,
+                              "type": "integer"
+                            },
+                            "net_buffer_length": {
+                              "default": 16384,
+                              "description": "Start sizes of connection buffer and result buffer. Changing this parameter will lead to a restart of the MySQL service.",
+                              "example": 16384,
+                              "maximum": 1048576,
+                              "minimum": 1024,
+                              "type": "integer"
+                            },
+                            "net_read_timeout": {
+                              "description": "The number of seconds to wait for more data from a connection before aborting the read.",
+                              "example": 30,
+                              "maximum": 3600,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "net_write_timeout": {
+                              "description": "The number of seconds to wait for a block to be written to a connection before aborting the write.",
+                              "example": 30,
+                              "maximum": 3600,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "sql_mode": {
+                              "description": "Global SQL mode. Set to empty to use MySQL server defaults. When creating a new service and not setting this field, Akamai defaults to SQL mode which is strict, SQL standard compliant.",
+                              "example": "ANSI,TRADITIONAL",
+                              "maxLength": 1024,
+                              "pattern": "^[A-Z_]*(,[A-Z_]+)*$",
+                              "type": "string"
+                            },
+                            "sql_require_primary_key": {
+                              "description": "Require primary key to be defined for new tables or old tables modified with `ALTER TABLE` and fail if missing. You should always have primary keys because various functionality may break if any large table is missing them.",
+                              "example": true,
+                              "type": "boolean"
+                            },
+                            "tmp_table_size": {
+                              "default": 16777216,
+                              "description": "Limits the size of internal in-memory tables. This also requires a `max_heap_table_size`.",
+                              "example": 16777216,
+                              "maximum": 1073741824,
+                              "minimum": 1048576,
+                              "type": "integer"
+                            },
+                            "wait_timeout": {
+                              "description": "The number of seconds the server waits for activity on a non-interactive connection before closing it.",
+                              "example": 28800,
+                              "maximum": 2147483,
+                              "minimum": 1,
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "x-akamai": {
+                        "file-path": "schemas/database-mysql-engine-config.yaml"
+                      },
+                      "x-linode-cli-display": 9
+                    },
                     "fork": {
                       "additionalProperties": false,
-                      "description": "Details on the database that was the target of the fork. Only exists if the database was forked from another.",
+                      "description": "Details on the database that was the target of the fork. This only exists if the database was restored by creating a fork from another [MySQL](https://techdocs.akamai.com/linode-api/reference/post-databases-mysql-instances) or [PostgreSQL](https://techdocs.akamai.com/linode-api/reference/post-databases-postgre-sql-instances) database.",
                       "properties": {
                         "restore_time": {
                           "description": "The database timestamp from which it was restored. This is _not_ when the fork was created.",
@@ -24990,7 +27281,7 @@
                     },
                     "ssl_connection": {
                       "default": true,
-                      "description": "Currently required to be `true`. Whether to require SSL credentials to establish a connection to the Managed Database.\n\nRun the [Get managed MySQL database credentials](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-instance-credentials) operation for access information.",
+                      "description": "Currently required to be `true`. Whether to require SSL credentials to establish a connection to the Managed Database. Run the [Get managed MySQL database credentials](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-instance-credentials) operation for access information.",
                       "example": true,
                       "type": "boolean"
                     },
@@ -25094,7 +27385,7 @@
                             "properties": {
                               "deadline": {
                                 "description": "The time when a mandatory update needs to be applied.",
-                                "example": "2024-10-14 19:55:12",
+                                "example": "2024-10-14T19:55:12",
                                 "format": "date-time",
                                 "nullable": true,
                                 "type": "string"
@@ -25106,7 +27397,7 @@
                               },
                               "planned_for": {
                                 "description": "The date and time a maintenance update will be applied.",
-                                "example": "2024-10-14 19:55:12",
+                                "example": "2024-10-14T19:55:12",
                                 "format": "date-time",
                                 "nullable": true,
                                 "type": "string"
@@ -25143,9 +27434,6 @@
                   "x-akamai": {
                     "file-path": "schemas/database-mysql.yaml"
                   }
-                },
-                "x-example": {
-                  "x-ref": "../examples/get-databases-mysql-instance-200.json"
                 }
               }
             },
@@ -25220,7 +27508,7 @@
         "x-linode-grant": "read_only"
       },
       "put": {
-        "description": "Make changes to an existing MySQL Managed Database.\n\n- The user needs `read_write` [user grant](https://techdocs.akamai.com/linode-api/reference/get-user-grants) access to the database.\n\n- The database's status needs to be `active`.\n\n- New values set in the `allow_list` overwrite existing values. To keep existing values, run the [List MySQL Managed Databases](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-instances) operation, store the `allow_list` addresses from the response, and include them with any new addresses in this operation.\n\n- Updates to your `allow_list` may take a short time to complete, making this operation inappropriate for rapid successive updates.\n\n- Also allows resizing the database cluster to a larger one. Clusters can't be resized to smaller plans.\n\n- All Managed Databases include automatic updates, which apply security patches to the underlying operating system of the Managed MySQL Database. Use the `updates` object in this operation to modify the maintenance window for these updates.\n\n- If your database cluster is configured with a single node, downtime occurs during maintenance updates. Use the `updates` object to adjust the window to match a time that's the least disruptive to your application and users. Also consider upgrading to a [high availability](https://techdocs.akamai.com/cloud-computing/docs/managed-databases#high-availability) plan to avoid any maintenance downtime.\n\n- Major upgrades are optional until the service reaches end of service, and can be done in place.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli databases mysql-update 123 \\\n  --label example-db \\\n  --allow_list 203.0.113.1 \\\n  --allow_list 192.0.1.0/24 \\\n  --type g6-standard-1 \\\n  --updates.frequency weekly \\\n  --updates.duration 3 \\\n  --updates.hour_of_day 12 \\\n  --updates.day_of_week 4 \\\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    databases:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Make changes to an existing MySQL Managed Database.\n\n- The user needs `read_write` [user grant](https://techdocs.akamai.com/linode-api/reference/get-user-grants) access to the database.\n\n- The database's status needs to be `active`.\n\n- New values set in the `allow_list` overwrite existing values. To keep existing values, run the [List MySQL Managed Databases](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-instances) operation, store the `allow_list` addresses from the response, and include them with any new addresses in this operation.\n\n- Updates to your `allow_list` may take a short time to complete, making this operation inappropriate for rapid successive updates.\n\n- Also allows resizing the database cluster to a larger one. Clusters can't be resized to smaller plans.\n\n- All Managed Databases include automatic updates, which apply security patches to the underlying operating system of the Managed MySQL Database. Use the `updates` object in this operation to modify the maintenance window for these updates.\n\n- If your database cluster is configured with a single node, downtime occurs during maintenance updates. Use the `updates` object to adjust the window to match a time that's the least disruptive to your application and users. Also consider upgrading to a [high availability](https://techdocs.akamai.com/cloud-computing/docs/managed-databases#high-availability) plan to avoid any maintenance downtime.\n\n- Major upgrades are optional until the service reaches end of service, and can be done in place.\n\n- You can't update `engine_config` advanced parameter settings for a suspended database. You'll need to [resume](https://techdocs.akamai.com/linode-api/reference/resume-databases-mysql-instance) it first.\n\n- A successful request triggers a `database_update` [event](https://techdocs.akamai.com/linode-api/reference/get-events).\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli databases mysql-update 123 \\\n  --label example-db \\\n  --allow_list 203.0.113.1 \\\n  --allow_list 192.0.1.0/24 \\\n  --type g6-standard-1 \\\n  --engine_config.binlog_retention_period 60 \\\n  --engine_config.mysql.connect_timeout 10 \\\n  --engine_config.mysql.default_time_zone +03:00 \\\n  --updates.frequency weekly \\\n  --updates.duration 3 \\\n  --updates.hour_of_day 12 \\\n  --updates.day_of_week 4 \\\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    databases:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/put-databases-mysql-instance"
@@ -25229,6 +27517,53 @@
         "requestBody": {
           "content": {
             "application/json": {
+              "example": {
+                "allow_list": [
+                  "192.0.2.138/24",
+                  "192.0.2.228/24"
+                ],
+                "engine_config": {
+                  "binlog_retention_period": 600,
+                  "mysql": {
+                    "connect_timeout": 10,
+                    "default_time_zone": "+03:00",
+                    "group_concat_max_len": 1024,
+                    "information_schema_stats_expiry": 86400,
+                    "innodb_change_buffer_max_size": 30,
+                    "innodb_flush_neighbors": 0,
+                    "innodb_ft_min_token_size": 3,
+                    "innodb_ft_server_stopword_table": "db_name/table_name",
+                    "innodb_lock_wait_timeout": 50,
+                    "innodb_log_buffer_size": 16777216,
+                    "innodb_online_alter_log_max_size": 134217728,
+                    "innodb_read_io_threads": 10,
+                    "innodb_rollback_on_timeout": true,
+                    "innodb_thread_concurrency": 10,
+                    "innodb_write_io_threads": 10,
+                    "interactive_timeout": 3600,
+                    "internal_tmp_mem_storage_engine": "TempTable",
+                    "max_allowed_packet": 67108864,
+                    "max_heap_table_size": 16777216,
+                    "net_buffer_length": 16384,
+                    "net_read_timeout": 30,
+                    "net_write_timeout": 30,
+                    "sort_buffer_size": 262144,
+                    "sql_mode": "ANSI,TRADITIONAL",
+                    "sql_require_primary_key": true,
+                    "tmp_table_size": 16777216,
+                    "wait_timeout": 28800
+                  }
+                },
+                "label": "example-db",
+                "type": "g6-standard-1",
+                "updates": {
+                  "day_of_week": 1,
+                  "duration": 3,
+                  "frequency": "weekly",
+                  "hour_of_day": 0
+                },
+                "version": "8.0.26"
+              },
               "schema": {
                 "additionalProperties": false,
                 "description": "Updated information for the Managed MySQL Database.",
@@ -25245,6 +27580,222 @@
                       "type": "string"
                     },
                     "type": "array"
+                  },
+                  "engine_config": {
+                    "additionalProperties": false,
+                    "description": "Advanced parameters you can apply to a MySQL Managed Database, via our partner [Aiven's specification](https://aiven.io/docs/products/mysql/reference/advanced-params). Only include the objects for parameters you want to set in your database. Omit objects for parameters you don't want to define or change.\n\n> \ud83d\udcd8\n>\n> Aiven may offer additional parameters in their specification. Currently, only those listed here are supported for use in a MySQL Managed Database. You can also run the [List MySQL Managed Database advanced parameters](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-config) operation to see an up-to-date list.",
+                    "properties": {
+                      "binlog_retention_period": {
+                        "description": "The minimum amount of time in seconds to keep `binlog` entries before deletion. This may be extended for services that require `binlog` entries for longer than the default, for example if using the MySQL Debezium Kafka connector.",
+                        "example": 600,
+                        "maximum": 86400,
+                        "minimum": 600,
+                        "type": "integer"
+                      },
+                      "mysql": {
+                        "additionalProperties": false,
+                        "description": "MySQL-specific advanced configuration parameters.",
+                        "properties": {
+                          "connect_timeout": {
+                            "description": "The number of seconds that the `mysqld` server waits for a connect packet before responding with bad handshake.",
+                            "example": 10,
+                            "maximum": 3600,
+                            "minimum": 2,
+                            "type": "integer"
+                          },
+                          "default_time_zone": {
+                            "description": "Default server time zone as an offset from UTC (from -12:00 to +12:00), a time zone name, or `SYSTEM` to use the MySQL server default.",
+                            "example": "+03:00",
+                            "maxLength": 100,
+                            "minLength": 2,
+                            "pattern": "^([-+][\\\\d:]*|[\\\\w/]*)$",
+                            "type": "string"
+                          },
+                          "group_concat_max_len": {
+                            "description": "The maximum permitted result length in bytes for the `GROUP_CONCAT()` function.",
+                            "example": 1024,
+                            "maximum": 18446744073709552000,
+                            "minimum": 4,
+                            "type": "integer"
+                          },
+                          "information_schema_stats_expiry": {
+                            "description": "The time, in seconds, before cached statistics expire.",
+                            "example": 86400,
+                            "maximum": 31536000,
+                            "minimum": 900,
+                            "type": "integer"
+                          },
+                          "innodb_change_buffer_max_size": {
+                            "default": 25,
+                            "description": "Maximum size for the InnoDB change buffer, as a percentage of the total size of the buffer pool.",
+                            "example": 30,
+                            "maximum": 50,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "innodb_flush_neighbors": {
+                            "default": 1,
+                            "description": "Specifies whether flushing a page from the InnoDB buffer pool also flushes other dirty pages in the same extent: `0` - dirty pages in the same extent are not flushed, `1` - flush contiguous dirty pages in the same extent, `2` - flush dirty pages in the same extent.",
+                            "example": 0,
+                            "maximum": 2,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "innodb_ft_min_token_size": {
+                            "description": "Minimum length of words that are stored in an InnoDB `-1FULLTEXT` index. Changing this parameter will lead to a restart of the MySQL service.",
+                            "example": 3,
+                            "maximum": 16,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "innodb_ft_server_stopword_table": {
+                            "description": "This option is used to specify your own InnoDB `FULLTEXT` index `stopword` list for all InnoDB tables. Set to `null` for no value.",
+                            "example": "db_name/table_name",
+                            "maxLength": 1024,
+                            "nullable": true,
+                            "pattern": "^.+/.+$",
+                            "type": "string"
+                          },
+                          "innodb_lock_wait_timeout": {
+                            "default": 120,
+                            "description": "The length of time in seconds an InnoDB transaction waits for a row lock before giving up.",
+                            "example": 50,
+                            "maximum": 3600,
+                            "minimum": 1,
+                            "type": "integer"
+                          },
+                          "innodb_log_buffer_size": {
+                            "description": "The size in bytes of the buffer that InnoDB uses to write to the log files on disk.",
+                            "example": 16777216,
+                            "maximum": 4294967295,
+                            "minimum": 1048576,
+                            "type": "integer"
+                          },
+                          "innodb_online_alter_log_max_size": {
+                            "description": "The upper limit in bytes on the size of the temporary log files used during online DDL operations for InnoDB tables.",
+                            "example": 134217728,
+                            "maximum": 1099511627776,
+                            "minimum": 65536,
+                            "type": "integer"
+                          },
+                          "innodb_read_io_threads": {
+                            "default": 4,
+                            "description": "The number of I/O threads for read operations in InnoDB. Changing this parameter will lead to a restart of the MySQL service.",
+                            "example": 10,
+                            "maximum": 64,
+                            "minimum": 1,
+                            "type": "integer"
+                          },
+                          "innodb_rollback_on_timeout": {
+                            "description": "When enabled a transaction timeout causes InnoDB to abort and roll back the entire transaction. Changing this parameter will lead to a restart of the MySQL service.",
+                            "example": true,
+                            "type": "boolean"
+                          },
+                          "innodb_thread_concurrency": {
+                            "default": 0,
+                            "description": "Defines the maximum number of threads permitted inside of InnoDB. A value of `0` indicates infinite concurrency, or no limit.",
+                            "example": 10,
+                            "maximum": 1000,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "innodb_write_io_threads": {
+                            "default": 4,
+                            "description": "The number of I/O threads for write operations in InnoDB. Changing this parameter will lead to a restart of the MySQL service.",
+                            "example": 10,
+                            "maximum": 64,
+                            "minimum": 1,
+                            "type": "integer"
+                          },
+                          "interactive_timeout": {
+                            "description": "The number of seconds the server waits for activity on an interactive connection before closing it.",
+                            "example": 3600,
+                            "maximum": 604800,
+                            "minimum": 30,
+                            "type": "integer"
+                          },
+                          "internal_tmp_mem_storage_engine": {
+                            "description": "The storage engine for in-memory internal temporary tables.",
+                            "enum": [
+                              "TempTable",
+                              "MEMORY"
+                            ],
+                            "example": "TempTable",
+                            "type": "string"
+                          },
+                          "max_allowed_packet": {
+                            "default": 7108864,
+                            "description": "Size of the largest message in bytes that can be received by the server.",
+                            "example": 67108864,
+                            "maximum": 1073741824,
+                            "minimum": 102400,
+                            "type": "integer"
+                          },
+                          "max_heap_table_size": {
+                            "default": 16777216,
+                            "description": "Limits the size of internal in-memory tables. Also set `tmp_table_size`.",
+                            "example": 16777216,
+                            "maximum": 1073741824,
+                            "minimum": 1048576,
+                            "type": "integer"
+                          },
+                          "net_buffer_length": {
+                            "default": 16384,
+                            "description": "Start sizes of connection buffer and result buffer. Changing this parameter will lead to a restart of the MySQL service.",
+                            "example": 16384,
+                            "maximum": 1048576,
+                            "minimum": 1024,
+                            "type": "integer"
+                          },
+                          "net_read_timeout": {
+                            "description": "The number of seconds to wait for more data from a connection before aborting the read.",
+                            "example": 30,
+                            "maximum": 3600,
+                            "minimum": 1,
+                            "type": "integer"
+                          },
+                          "net_write_timeout": {
+                            "description": "The number of seconds to wait for a block to be written to a connection before aborting the write.",
+                            "example": 30,
+                            "maximum": 3600,
+                            "minimum": 1,
+                            "type": "integer"
+                          },
+                          "sql_mode": {
+                            "description": "Global SQL mode. Set to empty to use MySQL server defaults. When creating a new service and not setting this field, Akamai defaults to SQL mode which is strict, SQL standard compliant.",
+                            "example": "ANSI,TRADITIONAL",
+                            "maxLength": 1024,
+                            "pattern": "^[A-Z_]*(,[A-Z_]+)*$",
+                            "type": "string"
+                          },
+                          "sql_require_primary_key": {
+                            "description": "Require primary key to be defined for new tables or old tables modified with `ALTER TABLE` and fail if missing. You should always have primary keys because various functionality may break if any large table is missing them.",
+                            "example": true,
+                            "type": "boolean"
+                          },
+                          "tmp_table_size": {
+                            "default": 16777216,
+                            "description": "Limits the size of internal in-memory tables. This also requires a `max_heap_table_size`.",
+                            "example": 16777216,
+                            "maximum": 1073741824,
+                            "minimum": 1048576,
+                            "type": "integer"
+                          },
+                          "wait_timeout": {
+                            "description": "The number of seconds the server waits for activity on a non-interactive connection before closing it.",
+                            "example": 28800,
+                            "maximum": 2147483,
+                            "minimum": 1,
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "x-akamai": {
+                      "file-path": "schemas/database-mysql-engine-config.yaml"
+                    }
                   },
                   "label": {
                     "description": "__Filterable__ A unique, user-defined string referring to the Managed Database. This string needs to be unique per Managed Database engine type.",
@@ -25307,7 +27858,7 @@
                           "properties": {
                             "deadline": {
                               "description": "The time when a mandatory update needs to be applied.",
-                              "example": "2024-10-14 19:55:12",
+                              "example": "2024-10-14T19:55:12",
                               "format": "date-time",
                               "nullable": true,
                               "type": "string"
@@ -25319,7 +27870,7 @@
                             },
                             "planned_for": {
                               "description": "The date and time a maintenance update will be applied.",
-                              "example": "2024-10-14 19:55:12",
+                              "example": "2024-10-14T19:55:12",
                               "format": "date-time",
                               "nullable": true,
                               "type": "string"
@@ -25350,9 +27901,6 @@
                 "x-akamai": {
                   "file-path": "schemas/added-put-databases-mysql-instance.yaml"
                 }
-              },
-              "x-example": {
-                "x-ref": "../examples/put-databases-mysql-instance.json"
               }
             }
           },
@@ -25362,6 +27910,80 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "allow_list": [
+                    "192.0.2.250/24",
+                    "192.0.2.131/24"
+                  ],
+                  "cluster_size": 3,
+                  "created": "2022-01-01T00:01:01",
+                  "encrypted": true,
+                  "engine": "mysql",
+                  "engine_config": {
+                    "binlog_retention_period": 600,
+                    "mysql": {
+                      "connect_timeout": 10,
+                      "default_time_zone": "+03:00",
+                      "group_concat_max_len": 1024,
+                      "information_schema_stats_expiry": 86400,
+                      "innodb_change_buffer_max_size": 30,
+                      "innodb_flush_neighbors": 0,
+                      "innodb_ft_min_token_size": 3,
+                      "innodb_ft_server_stopword_table": "db_name/table_name",
+                      "innodb_lock_wait_timeout": 50,
+                      "innodb_log_buffer_size": 16777216,
+                      "innodb_online_alter_log_max_size": 134217728,
+                      "innodb_read_io_threads": 10,
+                      "innodb_rollback_on_timeout": true,
+                      "innodb_thread_concurrency": 10,
+                      "innodb_write_io_threads": 10,
+                      "interactive_timeout": 3600,
+                      "internal_tmp_mem_storage_engine": "TempTable",
+                      "max_allowed_packet": 67108864,
+                      "max_heap_table_size": 16777216,
+                      "net_buffer_length": 16384,
+                      "net_read_timeout": 30,
+                      "net_write_timeout": 30,
+                      "sort_buffer_size": 262144,
+                      "sql_mode": "ANSI,TRADITIONAL",
+                      "sql_require_primary_key": true,
+                      "tmp_table_size": 16777216,
+                      "wait_timeout": 28800
+                    }
+                  },
+                  "fork": {
+                    "restore_time": "2024-10-14T19:55:12",
+                    "source": 176881
+                  },
+                  "hosts": {
+                    "primary": "lin-123-456-mysql-mysql-primary.servers.linodedb.net",
+                    "secondary": "lin-123-456-mysql-primary-private.servers.linodedb.net"
+                  },
+                  "id": 123,
+                  "label": "example-db",
+                  "members": {
+                    "45.56.110.70": "primary",
+                    "45.79.159.239": "failover"
+                  },
+                  "oldest_restore_time": "2024-10-03T20:48:05",
+                  "platform": "rdbms-default",
+                  "port": 3306,
+                  "region": "us-east",
+                  "ssl_connection": true,
+                  "status": "active",
+                  "total_disk_size_gb": 15,
+                  "type": "g6-dedicated-2",
+                  "updated": "2022-01-01T00:01:01",
+                  "updates": {
+                    "day_of_week": 1,
+                    "duration": 3,
+                    "frequency": "weekly",
+                    "hour_of_day": 0,
+                    "pending": []
+                  },
+                  "used_disk_size_gb": 2,
+                  "version": "8.0.26"
+                },
                 "schema": {
                   "additionalProperties": false,
                   "description": "Managed MySQL Databases object.",
@@ -25418,9 +28040,226 @@
                       "x-linode-cli-display": 8,
                       "x-linode-filterable": true
                     },
+                    "engine_config": {
+                      "additionalProperties": false,
+                      "description": "Advanced parameters you can apply to a MySQL Managed Database, via our partner [Aiven's specification](https://aiven.io/docs/products/mysql/reference/advanced-params). Only include the objects for parameters you want to set in your database. Omit objects for parameters you don't want to define or change.\n\n> \ud83d\udcd8\n>\n> Aiven may offer additional parameters in their specification. Currently, only those listed here are supported for use in a MySQL Managed Database. You can also run the [List MySQL Managed Database advanced parameters](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-config) operation to see an up-to-date list.",
+                      "properties": {
+                        "binlog_retention_period": {
+                          "description": "The minimum amount of time in seconds to keep `binlog` entries before deletion. This may be extended for services that require `binlog` entries for longer than the default, for example if using the MySQL Debezium Kafka connector.",
+                          "example": 600,
+                          "maximum": 86400,
+                          "minimum": 600,
+                          "type": "integer"
+                        },
+                        "mysql": {
+                          "additionalProperties": false,
+                          "description": "MySQL-specific advanced configuration parameters.",
+                          "properties": {
+                            "connect_timeout": {
+                              "description": "The number of seconds that the `mysqld` server waits for a connect packet before responding with bad handshake.",
+                              "example": 10,
+                              "maximum": 3600,
+                              "minimum": 2,
+                              "type": "integer"
+                            },
+                            "default_time_zone": {
+                              "description": "Default server time zone as an offset from UTC (from -12:00 to +12:00), a time zone name, or `SYSTEM` to use the MySQL server default.",
+                              "example": "+03:00",
+                              "maxLength": 100,
+                              "minLength": 2,
+                              "pattern": "^([-+][\\\\d:]*|[\\\\w/]*)$",
+                              "type": "string"
+                            },
+                            "group_concat_max_len": {
+                              "description": "The maximum permitted result length in bytes for the `GROUP_CONCAT()` function.",
+                              "example": 1024,
+                              "maximum": 18446744073709552000,
+                              "minimum": 4,
+                              "type": "integer"
+                            },
+                            "information_schema_stats_expiry": {
+                              "description": "The time, in seconds, before cached statistics expire.",
+                              "example": 86400,
+                              "maximum": 31536000,
+                              "minimum": 900,
+                              "type": "integer"
+                            },
+                            "innodb_change_buffer_max_size": {
+                              "default": 25,
+                              "description": "Maximum size for the InnoDB change buffer, as a percentage of the total size of the buffer pool.",
+                              "example": 30,
+                              "maximum": 50,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "innodb_flush_neighbors": {
+                              "default": 1,
+                              "description": "Specifies whether flushing a page from the InnoDB buffer pool also flushes other dirty pages in the same extent: `0` - dirty pages in the same extent are not flushed, `1` - flush contiguous dirty pages in the same extent, `2` - flush dirty pages in the same extent.",
+                              "example": 0,
+                              "maximum": 2,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "innodb_ft_min_token_size": {
+                              "description": "Minimum length of words that are stored in an InnoDB `-1FULLTEXT` index. Changing this parameter will lead to a restart of the MySQL service.",
+                              "example": 3,
+                              "maximum": 16,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "innodb_ft_server_stopword_table": {
+                              "description": "This option is used to specify your own InnoDB `FULLTEXT` index `stopword` list for all InnoDB tables. Set to `null` for no value.",
+                              "example": "db_name/table_name",
+                              "maxLength": 1024,
+                              "nullable": true,
+                              "pattern": "^.+/.+$",
+                              "type": "string"
+                            },
+                            "innodb_lock_wait_timeout": {
+                              "default": 120,
+                              "description": "The length of time in seconds an InnoDB transaction waits for a row lock before giving up.",
+                              "example": 50,
+                              "maximum": 3600,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "innodb_log_buffer_size": {
+                              "description": "The size in bytes of the buffer that InnoDB uses to write to the log files on disk.",
+                              "example": 16777216,
+                              "maximum": 4294967295,
+                              "minimum": 1048576,
+                              "type": "integer"
+                            },
+                            "innodb_online_alter_log_max_size": {
+                              "description": "The upper limit in bytes on the size of the temporary log files used during online DDL operations for InnoDB tables.",
+                              "example": 134217728,
+                              "maximum": 1099511627776,
+                              "minimum": 65536,
+                              "type": "integer"
+                            },
+                            "innodb_read_io_threads": {
+                              "default": 4,
+                              "description": "The number of I/O threads for read operations in InnoDB. Changing this parameter will lead to a restart of the MySQL service.",
+                              "example": 10,
+                              "maximum": 64,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "innodb_rollback_on_timeout": {
+                              "description": "When enabled a transaction timeout causes InnoDB to abort and roll back the entire transaction. Changing this parameter will lead to a restart of the MySQL service.",
+                              "example": true,
+                              "type": "boolean"
+                            },
+                            "innodb_thread_concurrency": {
+                              "default": 0,
+                              "description": "Defines the maximum number of threads permitted inside of InnoDB. A value of `0` indicates infinite concurrency, or no limit.",
+                              "example": 10,
+                              "maximum": 1000,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "innodb_write_io_threads": {
+                              "default": 4,
+                              "description": "The number of I/O threads for write operations in InnoDB. Changing this parameter will lead to a restart of the MySQL service.",
+                              "example": 10,
+                              "maximum": 64,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "interactive_timeout": {
+                              "description": "The number of seconds the server waits for activity on an interactive connection before closing it.",
+                              "example": 3600,
+                              "maximum": 604800,
+                              "minimum": 30,
+                              "type": "integer"
+                            },
+                            "internal_tmp_mem_storage_engine": {
+                              "description": "The storage engine for in-memory internal temporary tables.",
+                              "enum": [
+                                "TempTable",
+                                "MEMORY"
+                              ],
+                              "example": "TempTable",
+                              "type": "string"
+                            },
+                            "max_allowed_packet": {
+                              "default": 7108864,
+                              "description": "Size of the largest message in bytes that can be received by the server.",
+                              "example": 67108864,
+                              "maximum": 1073741824,
+                              "minimum": 102400,
+                              "type": "integer"
+                            },
+                            "max_heap_table_size": {
+                              "default": 16777216,
+                              "description": "Limits the size of internal in-memory tables. Also set `tmp_table_size`.",
+                              "example": 16777216,
+                              "maximum": 1073741824,
+                              "minimum": 1048576,
+                              "type": "integer"
+                            },
+                            "net_buffer_length": {
+                              "default": 16384,
+                              "description": "Start sizes of connection buffer and result buffer. Changing this parameter will lead to a restart of the MySQL service.",
+                              "example": 16384,
+                              "maximum": 1048576,
+                              "minimum": 1024,
+                              "type": "integer"
+                            },
+                            "net_read_timeout": {
+                              "description": "The number of seconds to wait for more data from a connection before aborting the read.",
+                              "example": 30,
+                              "maximum": 3600,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "net_write_timeout": {
+                              "description": "The number of seconds to wait for a block to be written to a connection before aborting the write.",
+                              "example": 30,
+                              "maximum": 3600,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "sql_mode": {
+                              "description": "Global SQL mode. Set to empty to use MySQL server defaults. When creating a new service and not setting this field, Akamai defaults to SQL mode which is strict, SQL standard compliant.",
+                              "example": "ANSI,TRADITIONAL",
+                              "maxLength": 1024,
+                              "pattern": "^[A-Z_]*(,[A-Z_]+)*$",
+                              "type": "string"
+                            },
+                            "sql_require_primary_key": {
+                              "description": "Require primary key to be defined for new tables or old tables modified with `ALTER TABLE` and fail if missing. You should always have primary keys because various functionality may break if any large table is missing them.",
+                              "example": true,
+                              "type": "boolean"
+                            },
+                            "tmp_table_size": {
+                              "default": 16777216,
+                              "description": "Limits the size of internal in-memory tables. This also requires a `max_heap_table_size`.",
+                              "example": 16777216,
+                              "maximum": 1073741824,
+                              "minimum": 1048576,
+                              "type": "integer"
+                            },
+                            "wait_timeout": {
+                              "description": "The number of seconds the server waits for activity on a non-interactive connection before closing it.",
+                              "example": 28800,
+                              "maximum": 2147483,
+                              "minimum": 1,
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "x-akamai": {
+                        "file-path": "schemas/database-mysql-engine-config.yaml"
+                      },
+                      "x-linode-cli-display": 9
+                    },
                     "fork": {
                       "additionalProperties": false,
-                      "description": "Details on the database that was the target of the fork. Only exists if the database was forked from another.",
+                      "description": "Details on the database that was the target of the fork. This only exists if the database was restored by creating a fork from another [MySQL](https://techdocs.akamai.com/linode-api/reference/post-databases-mysql-instances) or [PostgreSQL](https://techdocs.akamai.com/linode-api/reference/post-databases-postgre-sql-instances) database.",
                       "properties": {
                         "restore_time": {
                           "description": "The database timestamp from which it was restored. This is _not_ when the fork was created.",
@@ -25530,7 +28369,7 @@
                     },
                     "ssl_connection": {
                       "default": true,
-                      "description": "Currently required to be `true`. Whether to require SSL credentials to establish a connection to the Managed Database.\n\nRun the [Get managed MySQL database credentials](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-instance-credentials) operation for access information.",
+                      "description": "Currently required to be `true`. Whether to require SSL credentials to establish a connection to the Managed Database. Run the [Get managed MySQL database credentials](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-instance-credentials) operation for access information.",
                       "example": true,
                       "type": "boolean"
                     },
@@ -25634,7 +28473,7 @@
                             "properties": {
                               "deadline": {
                                 "description": "The time when a mandatory update needs to be applied.",
-                                "example": "2024-10-14 19:55:12",
+                                "example": "2024-10-14T19:55:12",
                                 "format": "date-time",
                                 "nullable": true,
                                 "type": "string"
@@ -25646,7 +28485,7 @@
                               },
                               "planned_for": {
                                 "description": "The date and time a maintenance update will be applied.",
-                                "example": "2024-10-14 19:55:12",
+                                "example": "2024-10-14T19:55:12",
                                 "format": "date-time",
                                 "nullable": true,
                                 "type": "string"
@@ -25683,9 +28522,6 @@
                   "x-akamai": {
                     "file-path": "schemas/database-mysql.yaml"
                   }
-                },
-                "x-example": {
-                  "x-ref": "../examples/get-databases-mysql-instance-200.json"
                 }
               }
             },
@@ -25745,7 +28581,7 @@
         "x-akamai": {
           "tabs": [
             {
-              "syntax": "linode-cli databases mysql-update 123 \\\n  --label example-db \\\n  --allow_list 203.0.113.1 \\\n  --allow_list 192.0.1.0/24 \\\n  --type g6-standard-1 \\\n  --updates.frequency weekly \\\n  --updates.duration 3 \\\n  --updates.hour_of_day 12 \\\n  --updates.day_of_week 4 \\",
+              "syntax": "linode-cli databases mysql-update 123 \\\n  --label example-db \\\n  --allow_list 203.0.113.1 \\\n  --allow_list 192.0.1.0/24 \\\n  --type g6-standard-1 \\\n  --engine_config.binlog_retention_period 60 \\\n  --engine_config.mysql.connect_timeout 10 \\\n  --engine_config.mysql.default_time_zone +03:00 \\\n  --updates.frequency weekly \\\n  --updates.duration 3 \\\n  --updates.hour_of_day 12 \\\n  --updates.day_of_week 4 \\",
               "title": "CLI",
               "url": "https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli"
             },
@@ -26178,7 +29014,7 @@
     },
     "/{apiVersion}/databases/mysql/instances/{instanceId}/patch": {
       "post": {
-        "description": "Apply security patches and updates to the underlying operating system of the MySQL Managed Database. This function runs during regular maintenance windows, which you can configure with the [Update a managed MySQL database](https://techdocs.akamai.com/linode-api/reference/put-databases-mysql-instance) operation.\n\n- The user needs `read_write` [user grant](https://techdocs.akamai.com/linode-api/reference/get-user-grants) access to the database.\n\n- The database's status meeds to be `active`.\n\n- If your database cluster is configured with a single node, downtime occurs during maintenance updates. Consider upgrading to a [high availability](https://techdocs.akamai.com/cloud-computing/docs/managed-databases#high-availability) plan to avoid any maintenance downtime.\n\n- Major upgrades are optional until the service reaches end of service, and can be done in place.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli databases mysql-patch 123\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    databases:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Apply security patches and updates to the underlying operating system of the MySQL Managed Database. This function runs during regular maintenance windows, which you can configure with the [Update a managed MySQL database](https://techdocs.akamai.com/linode-api/reference/put-databases-mysql-instance) operation.\n\n- The user needs `read_write` [user grant](https://techdocs.akamai.com/linode-api/reference/get-user-grants) access to the database.\n\n- The database's status meeds to be `active`.\n\n- If your database cluster is configured with a single node, downtime occurs during maintenance updates. Consider upgrading to a [high availability](https://techdocs.akamai.com/cloud-computing/docs/managed-databases#high-availability) plan to avoid any maintenance downtime.\n\n- Major upgrades are optional until the service reaches end of service, and can be done in place.\n\n- A successful request triggers a `database_upgrade` [event](https://techdocs.akamai.com/linode-api/reference/get-events).\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli databases mysql-patch 123\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    databases:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/post-databases-mysql-instance-patch"
@@ -26312,7 +29148,7 @@
     },
     "/{apiVersion}/databases/mysql/instances/{instanceId}/resume": {
       "post": {
-        "description": "Resume a suspended MySQL Managed Database from your account. This resumes billing for the cluster.\n\n- The user needs `read_write` [user grant](https://techdocs.akamai.com/linode-api/reference/get-user-grants) access to the database.\n\n- The database's status needs to be `suspended`.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    databases:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Resume a suspended MySQL Managed Database from your account. This resumes billing for the cluster.\n\n- The user needs `read_write` [user grant](https://techdocs.akamai.com/linode-api/reference/get-user-grants) access to the database.\n\n- The database's status needs to be `suspended`.\n\n- A successful request triggers a `database_resume` [event](https://techdocs.akamai.com/linode-api/reference/get-events).\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    databases:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/resume-databases-mysql-instance"
@@ -26583,7 +29419,7 @@
     },
     "/{apiVersion}/databases/mysql/instances/{instanceId}/suspend": {
       "post": {
-        "description": "Suspend a MySQL Managed Database from your account, releasing idle resources and keeping only necessary data. All service data is lost if there are no backups available. This halts billing for the cluster.\n\n- The user needs `read_write` [user grant](https://techdocs.akamai.com/linode-api/reference/get-user-grants) access to the database.\n\n- The database's status needs to be `active`.\n\n- Akamai deletes suspended clusters after 180 days.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    databases:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Suspend a MySQL Managed Database from your account, releasing idle resources and keeping only necessary data. All service data is lost if there are no backups available. This halts billing for the cluster.\n\n- The user needs `read_write` [user grant](https://techdocs.akamai.com/linode-api/reference/get-user-grants) access to the database.\n\n- The database's status needs to be `active`.\n\n- Akamai deletes suspended clusters after 180 days.\n\n- A successful request triggers a `database_update` [event](https://techdocs.akamai.com/linode-api/reference/get-events).\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    databases:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/suspend-databases-mysql-instance"
@@ -26709,9 +29545,1908 @@
       },
       "x-linode-cli-command": "databases"
     },
+    "/{apiVersion}/databases/postgresql/config": {
+      "get": {
+        "description": "All advanced parameters you can apply to a PostgreSQL Managed Database, via our partner [Aiven](https://aiven.io/docs/products/postgresql/reference/advanced-params).\n\n> \ud83d\udcd8\n>\n> Aiven may offer other parameters, but Akamai Managed Databases only supports the ones listed in this operation.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli databases postgres-config\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    databases:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "externalDocs": {
+          "description": "See documentation for this operation in Akamai's Linode API",
+          "url": "https://techdocs.akamai.com/linode-api/reference/get-databases-postgresql-config"
+        },
+        "operationId": "get-databases-postgresql-config",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "pg": {
+                    "autovacuum_analyze_scale_factor": {
+                      "description": "Specifies a fraction of the table size to add to autovacuum_analyze_threshold when deciding whether to trigger an ANALYZE. The default is 0.2 (20% of table size)",
+                      "maximum": 1,
+                      "minimum": 0,
+                      "requires_restart": false,
+                      "type": "number"
+                    },
+                    "autovacuum_analyze_threshold": {
+                      "description": "Specifies the minimum number of inserted, updated or deleted tuples needed to trigger an ANALYZE in any one table. The default is 50 tuples.",
+                      "maximum": 2147483647,
+                      "minimum": 0,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "autovacuum_max_workers": {
+                      "description": "Specifies the maximum number of autovacuum processes (other than the autovacuum launcher) that may be running at any one time. The default is three. This parameter can only be set at server start.",
+                      "maximum": 20,
+                      "minimum": 1,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "autovacuum_naptime": {
+                      "description": "Specifies the minimum delay between autovacuum runs on any given database. The delay is measured in seconds, and the default is one minute",
+                      "maximum": 86400,
+                      "minimum": 1,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "autovacuum_vacuum_cost_delay": {
+                      "description": "Specifies the cost delay value that will be used in automatic VACUUM operations. If -1 is specified, the regular vacuum_cost_delay value will be used. The default value is 20 milliseconds",
+                      "maximum": 100,
+                      "minimum": -1,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "autovacuum_vacuum_cost_limit": {
+                      "description": "Specifies the cost limit value that will be used in automatic VACUUM operations. If -1 is specified (which is the default), the regular vacuum_cost_limit value will be used.",
+                      "maximum": 10000,
+                      "minimum": -1,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "autovacuum_vacuum_scale_factor": {
+                      "description": "Specifies a fraction of the table size to add to autovacuum_vacuum_threshold when deciding whether to trigger a VACUUM. The default is 0.2 (20% of table size)",
+                      "maximum": 1,
+                      "minimum": 0,
+                      "requires_restart": false,
+                      "type": "number"
+                    },
+                    "autovacuum_vacuum_threshold": {
+                      "description": "Specifies the minimum number of updated or deleted tuples needed to trigger a VACUUM in any one table. The default is 50 tuples",
+                      "maximum": 2147483647,
+                      "minimum": 0,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "bgwriter_delay": {
+                      "description": "Specifies the delay between activity rounds for the background writer in milliseconds. Default is 200.",
+                      "example": 200,
+                      "maximum": 10000,
+                      "minimum": 10,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "bgwriter_flush_after": {
+                      "description": "Whenever more than bgwriter_flush_after bytes have been written by the background writer, attempt to force the OS to issue these writes to the underlying storage. Specified in kilobytes, default is 512. Setting of 0 disables forced writeback.",
+                      "example": 512,
+                      "maximum": 2048,
+                      "minimum": 0,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "bgwriter_lru_maxpages": {
+                      "description": "In each round, no more than this many buffers will be written by the background writer. Setting this to zero disables background writing. Default is 100.",
+                      "example": 100,
+                      "maximum": 1073741823,
+                      "minimum": 0,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "bgwriter_lru_multiplier": {
+                      "description": "The average recent need for new buffers is multiplied by bgwriter_lru_multiplier to arrive at an estimate of the number that will be needed during the next round, (up to bgwriter_lru_maxpages). 1.0 represents a \u201cjust in time\u201d policy of writing exactly the number of buffers predicted to be needed. Larger values provide some cushion against spikes in demand, while smaller values intentionally leave writes to be done by server processes. The default is 2.0.",
+                      "example": 2,
+                      "maximum": 10,
+                      "minimum": 0,
+                      "requires_restart": false,
+                      "type": "number"
+                    },
+                    "deadlock_timeout": {
+                      "description": "This is the amount of time, in milliseconds, to wait on a lock before checking to see if there is a deadlock condition.",
+                      "example": 1000,
+                      "maximum": 1800000,
+                      "minimum": 500,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "default_toast_compression": {
+                      "description": "Specifies the default TOAST compression method for values of compressible columns (the default is lz4).",
+                      "enum": [
+                        "lz4",
+                        "pglz"
+                      ],
+                      "example": "lz4",
+                      "requires_restart": false,
+                      "type": "string"
+                    },
+                    "idle_in_transaction_session_timeout": {
+                      "description": "Time out sessions with open transactions after this number of milliseconds",
+                      "maximum": 604800000,
+                      "minimum": 0,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "jit": {
+                      "description": "Controls system-wide use of Just-in-Time Compilation (JIT).",
+                      "example": true,
+                      "requires_restart": false,
+                      "type": "boolean"
+                    },
+                    "max_files_per_process": {
+                      "description": "PostgreSQL maximum number of files that can be open per process",
+                      "maximum": 4096,
+                      "minimum": 1000,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "max_locks_per_transaction": {
+                      "description": "PostgreSQL maximum locks per transaction",
+                      "maximum": 6400,
+                      "minimum": 64,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "max_logical_replication_workers": {
+                      "description": "PostgreSQL maximum logical replication workers (taken from the pool of max_parallel_workers)",
+                      "maximum": 64,
+                      "minimum": 4,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "max_parallel_workers": {
+                      "description": "Sets the maximum number of workers that the system can support for parallel queries",
+                      "maximum": 96,
+                      "minimum": 0,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "max_parallel_workers_per_gather": {
+                      "description": "Sets the maximum number of workers that can be started by a single Gather or Gather Merge node",
+                      "maximum": 96,
+                      "minimum": 0,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "max_pred_locks_per_transaction": {
+                      "description": "PostgreSQL maximum predicate locks per transaction",
+                      "maximum": 5120,
+                      "minimum": 64,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "max_replication_slots": {
+                      "description": "PostgreSQL maximum replication slots",
+                      "maximum": 64,
+                      "minimum": 8,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "max_slot_wal_keep_size": {
+                      "description": "PostgreSQL maximum WAL size (MB) reserved for replication slots. Default is -1 (unlimited). wal_keep_size minimum WAL size setting takes precedence over this.",
+                      "maximum": 2147483647,
+                      "minimum": -1,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "max_stack_depth": {
+                      "description": "Maximum depth of the stack in bytes",
+                      "maximum": 6291456,
+                      "minimum": 2097152,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "max_standby_archive_delay": {
+                      "description": "Max standby archive delay in milliseconds",
+                      "maximum": 43200000,
+                      "minimum": 1,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "max_standby_streaming_delay": {
+                      "description": "Max standby streaming delay in milliseconds",
+                      "maximum": 43200000,
+                      "minimum": 1,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "max_wal_senders": {
+                      "description": "PostgreSQL maximum WAL senders",
+                      "maximum": 64,
+                      "minimum": 20,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "max_worker_processes": {
+                      "description": "Sets the maximum number of background processes that the system can support",
+                      "maximum": 96,
+                      "minimum": 8,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "password_encryption": {
+                      "description": "Chooses the algorithm for encrypting passwords.",
+                      "enum": [
+                        "md5",
+                        "scram-sha-256"
+                      ],
+                      "example": "scram-sha-256",
+                      "requires_restart": false,
+                      "type": "string"
+                    },
+                    "pg_partman_bgw.interval": {
+                      "description": "Sets the time interval to run pg_partman's scheduled tasks",
+                      "example": 3600,
+                      "maximum": 604800,
+                      "minimum": 3600,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "pg_partman_bgw.role": {
+                      "description": "Controls which role to use for pg_partman's scheduled background tasks.",
+                      "example": "myrolename",
+                      "maxLength": 64,
+                      "pattern": "^[_A-Za-z0-9][-._A-Za-z0-9]{0,63}$",
+                      "requires_restart": false,
+                      "type": "string"
+                    },
+                    "pg_stat_monitor.pgsm_enable_query_plan": {
+                      "description": "Enables or disables query plan monitoring",
+                      "example": false,
+                      "requires_restart": false,
+                      "type": "boolean"
+                    },
+                    "pg_stat_monitor.pgsm_max_buckets": {
+                      "description": "Sets the maximum number of buckets ",
+                      "example": 10,
+                      "maximum": 10,
+                      "minimum": 1,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "pg_stat_statements.track": {
+                      "description": "Controls which statements are counted. Specify top to track top-level statements (those issued directly by clients), all to also track nested statements (such as statements invoked within functions), or none to disable statement statistics collection. The default value is top.",
+                      "enum": [
+                        "all",
+                        "top",
+                        "none"
+                      ],
+                      "requires_restart": false,
+                      "type": "string"
+                    },
+                    "temp_file_limit": {
+                      "description": "PostgreSQL temporary file limit in KiB, -1 for unlimited",
+                      "example": 5000000,
+                      "maximum": 2147483647,
+                      "minimum": -1,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "timezone": {
+                      "description": "PostgreSQL service timezone",
+                      "example": "Europe/Helsinki",
+                      "maxLength": 64,
+                      "pattern": "^[\\w/]*$",
+                      "requires_restart": false,
+                      "type": "string"
+                    },
+                    "track_activity_query_size": {
+                      "description": "Specifies the number of bytes reserved to track the currently executing command for each active session.",
+                      "example": 1024,
+                      "maximum": 10240,
+                      "minimum": 1024,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "track_commit_timestamp": {
+                      "description": "Record commit time of transactions.",
+                      "enum": [
+                        "off",
+                        "on"
+                      ],
+                      "example": "off",
+                      "requires_restart": false,
+                      "type": "string"
+                    },
+                    "track_functions": {
+                      "description": "Enables tracking of function call counts and time used.",
+                      "enum": [
+                        "all",
+                        "pl",
+                        "none"
+                      ],
+                      "requires_restart": false,
+                      "type": "string"
+                    },
+                    "track_io_timing": {
+                      "description": "Enables timing of database I/O calls. This parameter is off by default, because it will repeatedly query the operating system for the current time, which may cause significant overhead on some platforms.",
+                      "enum": [
+                        "off",
+                        "on"
+                      ],
+                      "example": "off",
+                      "requires_restart": false,
+                      "type": "string"
+                    },
+                    "wal_sender_timeout": {
+                      "description": "Terminate replication connections that are inactive for longer than this amount of time, in milliseconds. Setting this value to zero disables the timeout.",
+                      "example": 60000,
+                      "requires_restart": false,
+                      "type": "integer"
+                    },
+                    "wal_writer_delay": {
+                      "description": "WAL flush interval in milliseconds. Note that setting this value to lower than the default 200ms may negatively impact performance",
+                      "example": 50,
+                      "maximum": 200,
+                      "minimum": 10,
+                      "requires_restart": false,
+                      "type": "integer"
+                    }
+                  },
+                  "pg_stat_monitor_enable": {
+                    "description": "Enable the pg_stat_monitor extension. Enabling this extension will cause the cluster to be restarted.When this extension is enabled, pg_stat_statements results for utility commands are unreliable",
+                    "requires_restart": true,
+                    "type": "boolean"
+                  },
+                  "pglookout": {
+                    "max_failover_replication_time_lag": {
+                      "description": "Number of seconds of master unavailability before triggering database failover to standby",
+                      "maximum": 999999,
+                      "minimum": 10,
+                      "requires_restart": false,
+                      "type": "integer"
+                    }
+                  },
+                  "shared_buffers_percentage": {
+                    "description": "Percentage of total RAM that the database server uses for shared memory buffers. Valid range is 20-60 (float), which corresponds to 20% - 60%. This setting adjusts the shared_buffers configuration value.",
+                    "example": 41.5,
+                    "maximum": 60,
+                    "minimum": 20,
+                    "requires_restart": false,
+                    "type": "number"
+                  },
+                  "work_mem": {
+                    "description": "Sets the maximum amount of memory to be used by a query operation (such as a sort or hash table) before writing to temporary disk files, in MB. Default is 1MB + 0.075% of total RAM (up to 32MB).",
+                    "example": 4,
+                    "maximum": 1024,
+                    "minimum": 1,
+                    "requires_restart": false,
+                    "type": "integer"
+                  }
+                },
+                "schema": {
+                  "additionalProperties": false,
+                  "description": "Available [advanced parameters](https://aiven.io/docs/products/postgresql/reference/advanced-params) for a PostgreSQL Managed Database.",
+                  "properties": {
+                    "pg": {
+                      "additionalProperties": false,
+                      "description": "Configuration values available for a postgresql.conf.",
+                      "properties": {
+                        "autovacuum_analyze_scale_factor": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `autovacuum_analyze_scale_factor`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "autovacuum_analyze_threshold": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `autovacuum_analyze_threshold`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "autovacuum_max_workers": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `autovacuum_max_workers`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "autovacuum_naptime": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `autovacuum_naptime`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "autovacuum_vacuum_cost_delay": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `autovacuum_vacuum_cost_delay`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "autovacuum_vacuum_cost_limit": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `autovacuum_vacuum_cost_limit`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "autovacuum_vacuum_scale_factor": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `autovacuum_vacuum_scale_factor`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "autovacuum_vacuum_threshold": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `autovacuum_vacuum_threshold`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "bgwriter_delay": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `bgwriter_delay`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "bgwriter_flush_after": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `bgwriter_flush_after`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "bgwriter_lru_maxpages": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure `bgwriter_lru_maxpages`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "bgwriter_lru_multiplier": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `bgwriter_lru_multiplier`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "deadlock_timeout": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `deadlock_timeout`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "default_toast_compression": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `default_toast_compression`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "enum": {
+                              "description": "Specific values available for use as this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "One of the `enum` values available for use.",
+                              "type": "string"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "idle_in_transaction_session_timeout": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `idle_in_transaction_session_timeout`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "jit": {
+                          "additionalProperties": false,
+                          "description": "Parameter used to enable the Just-In-Time (`jit`) compilation, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example boolean value for this parameter.",
+                              "type": "string"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "max_files_per_process": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `max_files_per_process`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "max_locks_per_transaction": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `max_locks_per_transaction`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "max_logical_replication_workers": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `max_logical_replication_workers`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "max_parallel_workers": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `max_parallel_workers`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "max_parallel_workers_per_gather": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `max_parallel_workers_per_gather`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "max_pred_locks_per_transaction": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `max_pred_locks_per_transaction`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "max_replication_slots": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `max_replication_slots`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "max_slot_wal_keep_size": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `max_slot_wal_keep_size`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "max_stack_depth": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `max_stack_depth`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "max_standby_archive_delay": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `max_standby_archive_delay`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "max_standby_streaming_delay": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `max_standby_streaming_delay`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "max_wal_senders": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `max_wal_senders`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "max_worker_processes": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `max_worker_processes`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "password_encryption": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure `password_encryption`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "enum": {
+                              "description": "Specific values available for use as this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "One of the `enum` values available for use.",
+                              "type": "string"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "pg_partman_bgw.interval": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `pg_partman_bgw.interval`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "pg_partman_bgw.role": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `pg_partman_bgw.role`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter, using the required `pattern`.",
+                              "type": "string"
+                            },
+                            "maxLength": {
+                              "description": "The maximum character length for this parameter.",
+                              "type": "integer"
+                            },
+                            "pattern": {
+                              "description": "The pattern to follow when defining this parameter.",
+                              "type": "string"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "pg_stat_monitor.pgsm_enable_query_plan": {
+                          "additionalProperties": false,
+                          "description": "Parameter used to enable query plan monitoring, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example boolean value for this parameter.",
+                              "type": "string"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "pg_stat_monitor.pgsm_max_buckets": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure `pg_stat_monitor.pgsm_max_buckets`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "pg_stat_statements.track": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure `password_encryption`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "enum": {
+                              "description": "Specific values available for use as this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "One of the `enum` values available for use.",
+                              "type": "string"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "items": {
+                                "type": "integer"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "temp_file_limit": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `temp_file_limit`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "timezone": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the PostgreSQL service time zone, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter, using the required `pattern`.",
+                              "type": "string"
+                            },
+                            "maxLength": {
+                              "description": "The maximum character length for this parameter.",
+                              "type": "integer"
+                            },
+                            "pattern": {
+                              "description": "The pattern to follow when defining this parameter.",
+                              "type": "string"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "track_activity_query_size": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `track_activity_query_size`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "track_commit_timestamp": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `track_commit_timestamp`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "enum": {
+                              "description": "Specific values available for use as this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "One of the `enum` values available for use.",
+                              "type": "string"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "track_functions": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure `track_functions`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "enum": {
+                              "description": "Specific values available for use as this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "One of the `enum` values available for use.",
+                              "type": "string"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "track_io_timing": {
+                          "additionalProperties": false,
+                          "description": "Settings available to enable `track_io_timing`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "enum": {
+                              "description": "Specific values available for use as this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "One of the `enum` values available for use.",
+                              "type": "string"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "wal_sender_timeout": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `wal_sender_timeout`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "wal_writer_delay": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `wal_writer_delay`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "pg_stat_monitor_enable": {
+                      "additionalProperties": false,
+                      "description": "Parameter used to enable the `pg_stat_monitor` extension for a PostgreSQL cluster, per Aiven's specifications.",
+                      "properties": {
+                        "description": {
+                          "description": "The description for this parameter.",
+                          "example": {
+                            "description": "An example boolean value for this parameter.",
+                            "type": "string"
+                          },
+                          "type": "string"
+                        },
+                        "requires_restart": {
+                          "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "description": "The format of this object.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "pglookout": {
+                      "additionalProperties": false,
+                      "description": "Parameter used to apply PGLookout settings, per Aiven's specifications.",
+                      "properties": {
+                        "max_failover_replication_time_lag": {
+                          "additionalProperties": false,
+                          "description": "Settings available to configure the `max_failover_replication_time_lag`, per Aiven's specifications.",
+                          "properties": {
+                            "description": {
+                              "description": "The description for this parameter.",
+                              "type": "string"
+                            },
+                            "example": {
+                              "description": "An example value for this parameter.",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "The maximum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "The minimum value allowed for this parameter.",
+                              "type": "integer"
+                            },
+                            "requires_restart": {
+                              "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "description": "The format of this object.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "shared_buffers_percentage": {
+                      "additionalProperties": false,
+                      "description": "Parameters used to set up the `shared_buffers_percentage`, per Aiven's specifications.",
+                      "properties": {
+                        "description": {
+                          "description": "The description for this parameter.",
+                          "type": "string"
+                        },
+                        "example": {
+                          "description": "An example value for this parameter.",
+                          "type": "integer"
+                        },
+                        "maximum": {
+                          "description": "The maximum value allowed for this parameter.",
+                          "type": "integer"
+                        },
+                        "minimum": {
+                          "description": "The minimum value allowed for this parameter.",
+                          "type": "integer"
+                        },
+                        "requires_restart": {
+                          "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "description": "The format of this object.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "work_mem": {
+                      "additionalProperties": false,
+                      "description": "Parameters used to set up `work_mem`, per Aiven's specifications.",
+                      "properties": {
+                        "description": {
+                          "description": "The description for this parameter.",
+                          "type": "string"
+                        },
+                        "example": {
+                          "description": "An example value for this parameter.",
+                          "type": "integer"
+                        },
+                        "maximum": {
+                          "description": "The maximum value allowed for this parameter.",
+                          "type": "integer"
+                        },
+                        "minimum": {
+                          "description": "The minimum value allowed for this parameter.",
+                          "type": "integer"
+                        },
+                        "requires_restart": {
+                          "description": "Whether a change to this parameter requires a restart of the PostgreSQL database.",
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "description": "The format of this object.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "x-akamai": {
+                    "file-path": "schemas/database-postgresql-config-200.yaml"
+                  }
+                }
+              }
+            },
+            "description": "PostgreSQL Managed Database advanced parameters."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "errors": {
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "An object for describing a single error that occurred during the processing of a request.",
+                        "properties": {
+                          "field": {
+                            "description": "The field in the request that caused this error. This may be a path, separated by periods in the case of nested fields. In some cases this may come back as `null` if the error is not specific to any single element of the request.",
+                            "example": "fieldname",
+                            "type": "string"
+                          },
+                          "reason": {
+                            "description": "What happened to cause this error. In most cases, this can be fixed immediately by changing the data you sent in the request, but in some cases you will be instructed to [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) or perform some other action before you can complete the request successfully.",
+                            "example": "fieldname must be a valid value",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-akamai": {
+                          "file-path": "schemas/error-object.yaml"
+                        }
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "See [Errors](https://techdocs.akamai.com/linode-api/reference/errors) for the range of possible error response codes."
+          }
+        },
+        "security": [
+          {
+            "personalAccessToken": []
+          },
+          {
+            "oauth": [
+              "databases:read_only"
+            ]
+          }
+        ],
+        "summary": "List PostgreSQL Managed Database advanced parameters",
+        "tags": [
+          "Advanced parameters"
+        ],
+        "x-akamai": {
+          "tabs": [
+            {
+              "syntax": "linode-cli databases postgres-config",
+              "title": "CLI",
+              "url": "https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli"
+            },
+            {
+              "syntax": "databases:read_only",
+              "title": "OAuth scopes",
+              "url": "https://techdocs.akamai.com/linode-api/reference/get-started#oauth"
+            }
+          ]
+        },
+        "x-linode-cli-action": "postgres-config-view",
+        "x-linode-grant": "read_only"
+      },
+      "parameters": [
+        {
+          "description": "__Enum__ Call either the `v4` URL, or `v4beta` for operations still in Beta.",
+          "example": "{{apiVersion}}",
+          "in": "path",
+          "name": "apiVersion",
+          "required": true,
+          "schema": {
+            "enum": [
+              "v4",
+              "v4beta"
+            ],
+            "type": "string"
+          },
+          "x-akamai": {
+            "file-path": "parameters/api-version-path.yaml"
+          }
+        }
+      ],
+      "x-akamai": {
+        "file-path": "paths/postgresql-config.yaml",
+        "path-info": "/{apiVersion}/databases/postgresql/config"
+      },
+      "x-linode-cli-command": "databases"
+    },
     "/{apiVersion}/databases/postgresql/instances": {
       "post": {
-        "description": "**Provision a PostgreSQL Managed Database**\n\nUse this operation to create a new PostgreSQL Managed Database.\n\n- Restricted users need the `add_databases` [user grant](https://techdocs.akamai.com/linode-api/reference/get-user-grants).\n\n- New instances can take 10 to 15 minutes to deploy.\n\n- All Managed Databases include automatic, daily backups. Up to seven backups are automatically stored for each Managed Database, providing restore points for each day of the past week.\n\n- All Managed Databases include automatic updates, which apply security patches to the underlying operating system of the PostgreSQL Managed Database. Configure the maintenance window for these updates with the [Update a managed PostgreSQL database](https://techdocs.akamai.com/linode-api/reference/put-databases-postgre-sql-instance) operation.\n\n- If your database cluster is configured with a single node, downtime occurs during maintenance updates. Adjust the window to match a time that's the least disruptive to your application and users. Also consider upgrading to a [high availability](https://techdocs.akamai.com/cloud-computing/docs/managed-databases#high-availability) plan to avoid any maintenance downtime.\n\n- Major upgrades are optional until the service reaches end of service, and can be done in place.\n\n**Restore a PostgreSQL Managed Database**\n\nDo this by creating a `fork` from a backup. A user needs `read_write` access to the database, and its status can be `active`, `degraded`, or `failed`.\n\n> \ud83d\udcd8\n>\n> Restoring from a backup creates a second running cluster, which incurs billing. Delete the first cluster after the restore is complete, to avoid this billing.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli databases postgresql-create \\\n  --label example-db \\\n  --region us-east \\\n  --type g6-dedicated-2 \\\n  --cluster_size 3 \\\n  --engine postgresql/13.2 \\\n  --ssl_connection true \\\n  --allow_list 203.0.113.1 \\\n  --allow_list 192.0.1.0/24\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    databases:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "**Provision a PostgreSQL Managed Database**\n\nUse this operation to create a new PostgreSQL Managed Database.\n\n- Restricted users need the `add_databases` [user grant](https://techdocs.akamai.com/linode-api/reference/get-user-grants).\n\n- New instances can take 10 to 15 minutes to deploy.\n\n- When you create a new PostgreSQL Managed Database, our partner [Aiven](https://aiven.io/docs/platform/concepts/cloud-security#data-encryption) automatically enables disk encryption on each cluster.\n\n- All Managed Databases include automatic, daily backups. Up to seven backups are automatically stored for each Managed Database, providing restore points for each day of the past week.\n\n- All Managed Databases include automatic updates, which apply security patches to the underlying operating system of the PostgreSQL Managed Database. Configure the maintenance window for these updates with the [Update a managed PostgreSQL database](https://techdocs.akamai.com/linode-api/reference/put-databases-postgre-sql-instance) operation.\n\n- If your database cluster is configured with a single node, downtime occurs during maintenance updates. Adjust the window to match a time that's the least disruptive to your application and users. Also consider upgrading to a [high availability](https://techdocs.akamai.com/cloud-computing/docs/managed-databases#high-availability) plan to avoid any maintenance downtime.\n\n- Major upgrades are optional until the service reaches end of service, and can be done in place.\n\n- A successful request triggers a `database_create` [event](https://techdocs.akamai.com/linode-api/reference/get-events).\n\n**Restore a PostgreSQL Managed Database**\n\nInclude the `fork` object in the request to target a backed-up database. Your user needs `read_write` access to the target database and its status can be `active`, `degraded`, or `failed`.\n\n> \ud83d\udcd8\n>\n> Restoring from a backup creates a second running cluster, which incurs billing. Delete the first cluster after the restore is complete, to avoid this billing.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli databases postgresql-create \\\n  --label example-db \\\n  --region us-east \\\n  --type g6-dedicated-2 \\\n  --cluster_size 3 \\\n  --engine postgresql/13.2 \\\n  --engine_config.shared_buffers_percentage 41.5 \\\n  --engine_config.pg.autovacuum_analyze_scale_factor 0.0 \\\n  --engine_config.pg.autovacuum_vacuum_cost_delay 60 \\\n  --engine_config.pg.pg_partman_bgw.interval 3600 \\\n  --engine_config.pg.pg_partman_bgw.role myrolename \\\n  --engine_config.pglookout.max_failover_replication_time_lag 60 \\\n  --ssl_connection true \\\n  --allow_list 203.0.113.1 \\\n  --allow_list 192.0.1.0/24\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    databases:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/post-databases-postgre-sql-instances"
@@ -26720,6 +31455,75 @@
         "requestBody": {
           "content": {
             "application/json": {
+              "example": {
+                "allow_list": [
+                  "192.0.2.61/24",
+                  "192.0.2.124/24"
+                ],
+                "cluster_size": 3,
+                "engine": "postgresql/13.2",
+                "engine_config": {
+                  "pg": {
+                    "autovacuum_analyze_scale_factor": 1,
+                    "autovacuum_analyze_threshold": 2147483647,
+                    "autovacuum_max_workers": 20,
+                    "autovacuum_naptime": 86400,
+                    "autovacuum_vacuum_cost_delay": 100,
+                    "autovacuum_vacuum_cost_limit": 10000,
+                    "autovacuum_vacuum_scale_factor": 1,
+                    "autovacuum_vacuum_threshold": 2147483647,
+                    "bgwriter_delay": 200,
+                    "bgwriter_flush_after": 512,
+                    "bgwriter_lru_maxpages": 100,
+                    "bgwriter_lru_multiplier": 2.5,
+                    "deadlock_timeout": 1000,
+                    "default_toast_compression": "lz4",
+                    "idle_in_transaction_session_timeout": 604800000,
+                    "jit": true,
+                    "max_files_per_process": 1024,
+                    "max_locks_per_transaction": 1024,
+                    "max_logical_replication_workers": 64,
+                    "max_parallel_workers": 96,
+                    "max_parallel_workers_per_gather": 96,
+                    "max_pred_locks_per_transaction": 5120,
+                    "max_replication_slots": 64,
+                    "max_slot_wal_keep_size": 1000000,
+                    "max_stack_depth": 2097152,
+                    "max_standby_archive_delay": 1,
+                    "max_standby_streaming_delay": 10,
+                    "max_wal_senders": 20,
+                    "max_worker_processes": 96,
+                    "password_encryption": "scram-sha-256",
+                    "pg_partman_bgw.interval": 3600,
+                    "pg_partman_bgw.role": "myrolename",
+                    "pg_stat_monitor.pgsm_enable_query_plan": true,
+                    "pg_stat_monitor.pgsm_max_buckets": 10,
+                    "pg_stat_statements.track": "all",
+                    "temp_file_limit": 5000000,
+                    "timezone": "Europe/Helsinki",
+                    "track_activity_query_size": 1024,
+                    "track_commit_timestamp": true,
+                    "track_functions": "off",
+                    "track_io_timing": "off",
+                    "wal_sender_timeout": 60000,
+                    "wal_writer_delay": 200
+                  },
+                  "pg_stat_monitor_enable": false,
+                  "pglookout": {
+                    "max_failover_replication_time_lag": 10
+                  },
+                  "shared_buffers_percentage": 41.5,
+                  "work_mem": 4
+                },
+                "fork": {
+                  "restore_time": "2024-10-14 19:55:12",
+                  "source": 176881
+                },
+                "label": "example-db",
+                "region": "us-east",
+                "ssl_connection": true,
+                "type": "g6-dedicated-2"
+              },
               "schema": {
                 "additionalProperties": false,
                 "description": "Managed PostgreSQL Database request object.",
@@ -26754,34 +31558,403 @@
                     "example": "{{engine}}",
                     "type": "string"
                   },
-                  "fork": {
-                    "allOf": [
-                      {
+                  "engine_config": {
+                    "additionalProperties": false,
+                    "description": "Advanced parameters you can apply to a PostgreSQL Managed Database, via our partner [Aiven's specification](https://aiven.io/docs/products/postgresql/reference/advanced-params). Only include the objects for parameters you want to set in your database. Omit objects for parameters you don't want to define or change.\n\n> \ud83d\udcd8\n>\n> Aiven may offer additional parameters in their specification. Currently, only those listed here are supported for use in a PostgreSQL Managed Database. You can also run the [List PostgreSQL Managed Database advanced parameters](https://techdocs.akamai.com/linode-api/reference/get-databases-postgresql-config) operation to see an up-to-date list.",
+                    "properties": {
+                      "pg": {
                         "additionalProperties": false,
-                        "description": "Details on the database that was the target of the fork. Only exists if the database was forked from another.",
+                        "description": "PostgreSQL-specific advanced configuration parameters.",
                         "properties": {
-                          "restore_time": {
-                            "description": "The database timestamp from which it was restored. This is _not_ when the fork was created.",
-                            "example": "2024-10-14 19:55:12",
-                            "format": "date-time",
+                          "autovacuum_analyze_scale_factor": {
+                            "default": 0.2,
+                            "description": "Specifies a fraction of the table size to add to `autovacuum_analyze_threshold` when deciding whether to trigger an `ANALYZE`.",
+                            "example": 1,
+                            "maximum": 1,
+                            "minimum": 0,
+                            "type": "number"
+                          },
+                          "autovacuum_analyze_threshold": {
+                            "default": 50,
+                            "description": "Specifies the minimum number of inserted, updated, or deleted tuples needed to trigger an `ANALYZE` in any one table. The default is 50 tuples.",
+                            "example": 2147483647,
+                            "maximum": 2147483647,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "autovacuum_max_workers": {
+                            "default": 3,
+                            "description": "Specifies the maximum number of `autovacuum` processes, other than the `autovacuum` launcher, that may be running at any one time. This parameter can only be set at server start.",
+                            "example": 20,
+                            "maximum": 20,
+                            "minimum": 1,
+                            "type": "integer"
+                          },
+                          "autovacuum_naptime": {
+                            "default": 60,
+                            "description": "Specifies the minimum delay between `autovacuum` runs on any given database. The delay is measured in seconds, and the default is one minute.",
+                            "example": 86400,
+                            "maximum": 86400,
+                            "minimum": 1,
+                            "type": "integer"
+                          },
+                          "autovacuum_vacuum_cost_delay": {
+                            "default": 20,
+                            "description": "Specifies the cost delay value that will be used in automatic `VACUUM` operations. If `-1` is specified, the regular `vacuum_cost_delay` value will be used.",
+                            "example": 100,
+                            "maximum": 100,
+                            "minimum": -1,
+                            "type": "integer"
+                          },
+                          "autovacuum_vacuum_cost_limit": {
+                            "default": -1,
+                            "description": "Specifies the cost limit value that will be used in automatic `VACUUM` operations. If `-1` is specified, the regular `vacuum_cost_limit` value will be used.",
+                            "example": 10000,
+                            "maximum": 10000,
+                            "minimum": -1,
+                            "type": "integer"
+                          },
+                          "autovacuum_vacuum_scale_factor": {
+                            "default": 0.2,
+                            "description": "Specifies a fraction of the table size to add to `autovacuum_vacuum_threshold` when deciding whether to trigger a `VACUUM`.",
+                            "example": 1,
+                            "maximum": 1,
+                            "minimum": 0,
+                            "type": "number"
+                          },
+                          "autovacuum_vacuum_threshold": {
+                            "default": 50,
+                            "description": "Specifies the minimum number of updated or deleted tuples needed to trigger a `VACUUM` in any one table.",
+                            "example": 2147483647,
+                            "maximum": 2147483647,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "bgwriter_delay": {
+                            "default": 200,
+                            "description": "Specifies the delay between activity rounds for the background writer in milliseconds.",
+                            "example": 200,
+                            "maximum": 10000,
+                            "minimum": 20,
+                            "type": "integer"
+                          },
+                          "bgwriter_flush_after": {
+                            "default": 512,
+                            "description": "Whenever more than `bgwriter_flush_after` bytes have been written by the background writer, attempt to force the OS to issue these writes to the underlying storage. Specified in kilobytes. Setting of `0` disables forced writeback.",
+                            "example": 512,
+                            "maximum": 2048,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "bgwriter_lru_maxpages": {
+                            "default": 100,
+                            "description": "In each round, no more than this many buffers will be written by the background writer. Setting this to zero disables background writing.",
+                            "example": 100,
+                            "maximum": 1073741823,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "bgwriter_lru_multiplier": {
+                            "default": 2.5,
+                            "description": "The average recent need for new buffers is multiplied by bgwriter_lru_multiplier to arrive at an estimate of the number that will be needed during the next round, (up to `bgwriter_lru_maxpages`). `1.0` represents a `\\u201cjust` in `time\\u201d` policy of writing exactly the number of buffers predicted to be needed. Larger values provide some cushion against spikes in demand, while smaller values intentionally leave writes to be done by server processes.",
+                            "example": 2.5,
+                            "maximum": 10,
+                            "minimum": 0,
+                            "type": "number"
+                          },
+                          "deadlock_timeout": {
+                            "description": "This is the amount of time, in milliseconds, to wait on a lock before checking to see if there is a deadlock condition.",
+                            "example": 1000,
+                            "maximum": 1800000,
+                            "minimum": 500,
+                            "type": "integer"
+                          },
+                          "default_toast_compression": {
+                            "default": "lz4",
+                            "description": "Specifies the default TOAST compression method for values of compressible columns.",
+                            "enum": [
+                              "lz4",
+                              "pglz"
+                            ],
+                            "example": "lz4",
                             "type": "string"
                           },
-                          "source": {
-                            "description": "The instance id of the database that was forked from.",
-                            "example": 176881,
+                          "idle_in_transaction_session_timeout": {
+                            "description": "Time out sessions with open transactions after this number of milliseconds.",
+                            "example": 604800000,
+                            "maximum": 604800000,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "jit": {
+                            "description": "Controls system-wide use of Just-in-Time Compilation (JIT).",
+                            "example": true,
+                            "type": "boolean"
+                          },
+                          "max_files_per_process": {
+                            "description": "PostgreSQL maximum number of files that can be open per process.",
+                            "example": 1024,
+                            "maximum": 4096,
+                            "minimum": 1000,
+                            "type": "integer"
+                          },
+                          "max_locks_per_transaction": {
+                            "description": "PostgreSQL maximum locks per transaction.",
+                            "example": 1024,
+                            "maximum": 6400,
+                            "minimum": 64,
+                            "type": "integer"
+                          },
+                          "max_logical_replication_workers": {
+                            "description": "PostgreSQL maximum logical replication workers, taken from the pool of `max_parallel_workers`.",
+                            "example": 64,
+                            "maximum": 64,
+                            "minimum": 4,
+                            "type": "integer"
+                          },
+                          "max_parallel_workers": {
+                            "description": "Sets the maximum number of workers that the system can support for parallel queries.",
+                            "example": 96,
+                            "maximum": 96,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "max_parallel_workers_per_gather": {
+                            "description": "Sets the maximum number of workers that can be started by a single Gather or Gather Merge node.",
+                            "example": 96,
+                            "maximum": 96,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "max_pred_locks_per_transaction": {
+                            "description": "PostgreSQL maximum predicate locks per transaction.",
+                            "example": 5120,
+                            "maximum": 5120,
+                            "minimum": 64,
+                            "type": "integer"
+                          },
+                          "max_replication_slots": {
+                            "description": "PostgreSQL maximum replication slots.",
+                            "example": 64,
+                            "maximum": 64,
+                            "minimum": 8,
+                            "type": "integer"
+                          },
+                          "max_slot_wal_keep_size": {
+                            "default": -1,
+                            "description": "PostgreSQL maximum write ahead log (WAL) size in MB, reserved for replication slots. A value of `-1` indicates unlimited. The `wal_keep_size` minimum write ahead log (WAL) size setting takes precedence over this.",
+                            "example": 1000000,
+                            "maximum": 2147483647,
+                            "minimum": -1,
+                            "type": "integer"
+                          },
+                          "max_stack_depth": {
+                            "description": "Maximum depth of the stack in bytes.",
+                            "example": 2097152,
+                            "maximum": 6291456,
+                            "minimum": 2097152,
+                            "type": "integer"
+                          },
+                          "max_standby_archive_delay": {
+                            "description": "Maximum standby archive delay in milliseconds.",
+                            "example": 1,
+                            "maximum": 43200000,
+                            "minimum": 1,
+                            "type": "integer"
+                          },
+                          "max_standby_streaming_delay": {
+                            "description": "Maximum standby streaming delay in milliseconds.",
+                            "example": 10,
+                            "maximum": 43200000,
+                            "minimum": 1,
+                            "type": "integer"
+                          },
+                          "max_wal_senders": {
+                            "description": "PostgreSQL maximum write ahead log (WAL) senders.",
+                            "example": 20,
+                            "maximum": 64,
+                            "minimum": 20,
+                            "type": "integer"
+                          },
+                          "max_worker_processes": {
+                            "description": "Maximum number of background processes that the system can support.",
+                            "example": 96,
+                            "maximum": 96,
+                            "minimum": 8,
+                            "type": "integer"
+                          },
+                          "password_encryption": {
+                            "default": "md5",
+                            "description": "Chooses the algorithm for encrypting passwords.",
+                            "enum": [
+                              "scram-sh-256",
+                              "md5"
+                            ],
+                            "example": "scram-sha-256",
+                            "type": "string"
+                          },
+                          "pg_partman_bgw.interval": {
+                            "description": "Sets the time interval to run `pg_partman` scheduled tasks.",
+                            "example": 3600,
+                            "maximum": 604800,
+                            "minimum": 3600,
+                            "type": "integer"
+                          },
+                          "pg_partman_bgw.role": {
+                            "description": "Controls which role to use for `pg_partman`` scheduled background tasks.",
+                            "example": "myrolename",
+                            "type": "string"
+                          },
+                          "pg_stat_monitor.pgsm_enable_query_plan": {
+                            "description": "Enables query plan monitoring.",
+                            "example": true,
+                            "type": "boolean"
+                          },
+                          "pg_stat_monitor.pgsm_max_buckets": {
+                            "description": "Sets the maximum number of buckets.",
+                            "example": 10,
+                            "maximum": 10,
+                            "minimum": 1,
+                            "type": "integer"
+                          },
+                          "pg_stat_statements.track": {
+                            "default": "top",
+                            "description": "Controls which statements are counted. Specify `top` to track top-level statements that are issued directly by clients, `all` to also track nested statements, such as those invoked within functions, or `none` to disable statement statistics collection.",
+                            "enum": [
+                              "all",
+                              "top",
+                              "none"
+                            ],
+                            "example": "all",
+                            "type": "string"
+                          },
+                          "temp_file_limit": {
+                            "description": "PostgreSQL temporary file limit in KB. Set to `-1` for unlimited.",
+                            "example": 5000000,
+                            "maximum": 2147483647,
+                            "minimum": -1,
+                            "type": "integer"
+                          },
+                          "timezone": {
+                            "description": "PostgreSQL service time zone.",
+                            "example": "Europe/Helsinki",
+                            "maxLength": 64,
+                            "pattern": "^[\\\\w/]*$",
+                            "type": "string"
+                          },
+                          "track_activity_query_size": {
+                            "description": "Specifies the number of bytes reserved to track the currently executing command for each active session.",
+                            "example": 1024,
+                            "maximum": 10240,
+                            "minimum": 1024,
+                            "type": "integer"
+                          },
+                          "track_commit_timestamp": {
+                            "description": "Record the commit time of transactions.",
+                            "enum": [
+                              "on",
+                              "off"
+                            ],
+                            "example": "on",
+                            "type": "string"
+                          },
+                          "track_functions": {
+                            "default": "none",
+                            "description": "Enables tracking of function call counts and time used. Specify `pl` to track only procedural-language functions, `all` to also track SQL and C language functions, or `none` to disable function statistics tracking.",
+                            "enum": [
+                              "all",
+                              "pl",
+                              "none"
+                            ],
+                            "example": "all",
+                            "type": "string"
+                          },
+                          "track_io_timing": {
+                            "default": "off",
+                            "description": "Enables timing of database I/O calls. This parameter is `off` by default, because it will repeatedly query the operating system for the current time, which may cause significant overhead on some platforms.",
+                            "enum": [
+                              "on",
+                              "off"
+                            ],
+                            "example": "off",
+                            "type": "string"
+                          },
+                          "wal_sender_timeout": {
+                            "description": "Terminate replication connections that are inactive for longer than this amount of time, in milliseconds. Setting this value to `0` disables the timeout.",
+                            "example": 60000,
+                            "maximum": 60000,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "wal_writer_delay": {
+                            "default": 200,
+                            "description": "Write ahead log (WAL) flush interval in milliseconds. A value lower than 200 milliseconds may negatively impact performance.",
+                            "example": 200,
+                            "maximum": 200,
+                            "minimum": 10,
                             "type": "integer"
                           }
                         },
                         "type": "object"
                       },
-                      {
-                        "description": "Information about a database to fork from. If specified, all other fields will become optional.",
-                        "required": [
-                          "source"
-                        ]
+                      "pg_stat_monitor_enable": {
+                        "description": "Enable the `pg_stat_monitor` extension. When this extension is enabled, PostgreSQL restarts the cluster it's in. Additionally, `pg_stat_statements` results for utility commands are unreliable.",
+                        "example": false,
+                        "type": "boolean"
+                      },
+                      "pglookout": {
+                        "description": "Parameter used to apply PGLookout settings.",
+                        "properties": {
+                          "max_failover_replication_time_lag": {
+                            "description": "Number of seconds of master unavailability before triggering database failover to standby.",
+                            "example": 10,
+                            "maximum": 999999,
+                            "minimum": 10,
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "shared_buffers_percentage": {
+                        "description": "Percentage of total RAM that the database server uses for shared memory buffers. Valid range is 20-60 (float), which corresponds to 20% - 60%. This setting adjusts the `shared_buffers` configuration value.",
+                        "example": 41.5,
+                        "maximum": 60,
+                        "minimum": 20,
+                        "type": "number"
+                      },
+                      "work_mem": {
+                        "description": "Sets the maximum amount of memory in MB to be used by a query operation, such as a sort or hash table, before writing to temporary disk files. Default is 1MB + 0.075% of total RAM, up to 32 MB.",
+                        "example": 4,
+                        "maximum": 4,
+                        "minimum": 1,
+                        "type": "integer"
                       }
+                    },
+                    "type": "object",
+                    "x-akamai": {
+                      "file-path": "schemas/database-postgresql-engine-config.yaml"
+                    }
+                  },
+                  "fork": {
+                    "additionalProperties": false,
+                    "description": "Include this object to restore a Managed Database by forking from a backup.\n\n- If you include this object, all other fields are optional.\n\n- Don't include this object if you're creating a new Managed Database.",
+                    "properties": {
+                      "restore_time": {
+                        "description": "A specific database timestamp to restore from.",
+                        "example": "2024-10-14T19:55:12",
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "source": {
+                        "description": "The unique instance id for the database to fork from. Run the [List Managed Databases](https://techdocs.akamai.com/linode-api/reference/get-databases-instances) operation and store the unique `id` for the target Managed Database.",
+                        "example": 176881,
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "source"
                     ],
-                    "example": "{{fork}}",
+                    "type": "object",
                     "x-akamai": {
                       "file-path": "schemas/database-restore-fork.yaml"
                     }
@@ -26814,7 +31987,7 @@
                   },
                   "ssl_connection": {
                     "default": true,
-                    "description": "Currently required to be `true`. Whether to require SSL credentials to establish a connection to the Managed Database.\n\nRun the [Get managed PostgreSQL database credentials](https://techdocs.akamai.com/linode-api/reference/get-databases-postgre-sql-instance-credentials) operation for access information.",
+                    "description": "Currently required to be `true`. Whether to require SSL credentials to establish a connection to the Managed Database. Run the [Get managed PostgreSQL database credentials](https://techdocs.akamai.com/linode-api/reference/get-databases-postgre-sql-instance-credentials) operation for access information.",
                     "example": "{{ssl_connection}}",
                     "type": "boolean"
                   },
@@ -26841,9 +32014,6 @@
                 "x-akamai": {
                   "file-path": "schemas/database-postgresql-request.yaml"
                 }
-              },
-              "x-example": {
-                "x-ref": "../examples/post-databases-postgre-sql-instances.json"
               }
             }
           },
@@ -26858,6 +32028,100 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "allow_list": [
+                    "192.0.2.219/24",
+                    "192.0.2.5/24"
+                  ],
+                  "cluster_size": 3,
+                  "created": "2022-01-01T00:01:01",
+                  "encrypted": true,
+                  "engine": "postgresql",
+                  "engine_config": {
+                    "pg": {
+                      "autovacuum_analyze_scale_factor": 1,
+                      "autovacuum_analyze_threshold": 2147483647,
+                      "autovacuum_max_workers": 20,
+                      "autovacuum_naptime": 86400,
+                      "autovacuum_vacuum_cost_delay": 100,
+                      "autovacuum_vacuum_cost_limit": 10000,
+                      "autovacuum_vacuum_scale_factor": 1,
+                      "autovacuum_vacuum_threshold": 2147483647,
+                      "bgwriter_delay": 200,
+                      "bgwriter_flush_after": 512,
+                      "bgwriter_lru_maxpages": 100,
+                      "bgwriter_lru_multiplier": 2.5,
+                      "deadlock_timeout": 1000,
+                      "default_toast_compression": "lz4",
+                      "idle_in_transaction_session_timeout": 604800000,
+                      "jit": true,
+                      "max_files_per_process": 1024,
+                      "max_locks_per_transaction": 1024,
+                      "max_logical_replication_workers": 64,
+                      "max_parallel_workers": 96,
+                      "max_parallel_workers_per_gather": 96,
+                      "max_pred_locks_per_transaction": 5120,
+                      "max_replication_slots": 64,
+                      "max_slot_wal_keep_size": 1000000,
+                      "max_stack_depth": 2097152,
+                      "max_standby_archive_delay": 1,
+                      "max_standby_streaming_delay": 10,
+                      "max_wal_senders": 20,
+                      "max_worker_processes": 96,
+                      "password_encryption": "scram-sha-256",
+                      "pg_partman_bgw.interval": 3600,
+                      "pg_partman_bgw.role": "myrolename",
+                      "pg_stat_monitor.pgsm_enable_query_plan": true,
+                      "pg_stat_monitor.pgsm_max_buckets": 10,
+                      "pg_stat_statements.track": "all",
+                      "temp_file_limit": 5000000,
+                      "timezone": "Europe/Helsinki",
+                      "track_activity_query_size": 1024,
+                      "track_commit_timestamp": true,
+                      "track_functions": "off",
+                      "track_io_timing": "off",
+                      "wal_sender_timeout": 60000,
+                      "wal_writer_delay": 200
+                    },
+                    "pg_stat_monitor_enable": false,
+                    "pglookout": {
+                      "max_failover_replication_time_lag": 10
+                    },
+                    "shared_buffers_percentage": 41.5,
+                    "work_mem": 4
+                  },
+                  "fork": {
+                    "restore_time": "2024-10-14 19:55:12",
+                    "source": 176881
+                  },
+                  "hosts": {
+                    "primary": "lin-0000-000-pgsql-primary.servers.linodedb.net",
+                    "secondary": "lin-0000-000-pgsql-primary-private.servers.linodedb.net"
+                  },
+                  "id": 123,
+                  "label": "example-db",
+                  "members": {
+                    "45.56.110.70": "primary",
+                    "45.79.159.239": "failover"
+                  },
+                  "platform": "rdbms-default",
+                  "port": 3306,
+                  "region": "us-east",
+                  "ssl_connection": true,
+                  "status": "active",
+                  "total_disk_size_gb": 15,
+                  "type": "g6-dedicated-2",
+                  "updated": "2022-01-01T00:01:01",
+                  "updates": {
+                    "day_of_week": 1,
+                    "duration": 3,
+                    "frequency": "weekly",
+                    "hour_of_day": 0,
+                    "pending": []
+                  },
+                  "used_disk_size_gb": 2,
+                  "version": "13.2"
+                },
                 "schema": {
                   "additionalProperties": false,
                   "description": "Managed PostgreSQL Databases object.",
@@ -26914,9 +32178,387 @@
                       "x-linode-cli-display": 6,
                       "x-linode-filterable": true
                     },
+                    "engine_config": {
+                      "additionalProperties": false,
+                      "description": "Advanced parameters you can apply to a PostgreSQL Managed Database, via our partner [Aiven's specification](https://aiven.io/docs/products/postgresql/reference/advanced-params). Only include the objects for parameters you want to set in your database. Omit objects for parameters you don't want to define or change.\n\n> \ud83d\udcd8\n>\n> Aiven may offer additional parameters in their specification. Currently, only those listed here are supported for use in a PostgreSQL Managed Database. You can also run the [List PostgreSQL Managed Database advanced parameters](https://techdocs.akamai.com/linode-api/reference/get-databases-postgresql-config) operation to see an up-to-date list.",
+                      "properties": {
+                        "pg": {
+                          "additionalProperties": false,
+                          "description": "PostgreSQL-specific advanced configuration parameters.",
+                          "properties": {
+                            "autovacuum_analyze_scale_factor": {
+                              "default": 0.2,
+                              "description": "Specifies a fraction of the table size to add to `autovacuum_analyze_threshold` when deciding whether to trigger an `ANALYZE`.",
+                              "example": 1,
+                              "maximum": 1,
+                              "minimum": 0,
+                              "type": "number"
+                            },
+                            "autovacuum_analyze_threshold": {
+                              "default": 50,
+                              "description": "Specifies the minimum number of inserted, updated, or deleted tuples needed to trigger an `ANALYZE` in any one table. The default is 50 tuples.",
+                              "example": 2147483647,
+                              "maximum": 2147483647,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "autovacuum_max_workers": {
+                              "default": 3,
+                              "description": "Specifies the maximum number of `autovacuum` processes, other than the `autovacuum` launcher, that may be running at any one time. This parameter can only be set at server start.",
+                              "example": 20,
+                              "maximum": 20,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "autovacuum_naptime": {
+                              "default": 60,
+                              "description": "Specifies the minimum delay between `autovacuum` runs on any given database. The delay is measured in seconds, and the default is one minute.",
+                              "example": 86400,
+                              "maximum": 86400,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "autovacuum_vacuum_cost_delay": {
+                              "default": 20,
+                              "description": "Specifies the cost delay value that will be used in automatic `VACUUM` operations. If `-1` is specified, the regular `vacuum_cost_delay` value will be used.",
+                              "example": 100,
+                              "maximum": 100,
+                              "minimum": -1,
+                              "type": "integer"
+                            },
+                            "autovacuum_vacuum_cost_limit": {
+                              "default": -1,
+                              "description": "Specifies the cost limit value that will be used in automatic `VACUUM` operations. If `-1` is specified, the regular `vacuum_cost_limit` value will be used.",
+                              "example": 10000,
+                              "maximum": 10000,
+                              "minimum": -1,
+                              "type": "integer"
+                            },
+                            "autovacuum_vacuum_scale_factor": {
+                              "default": 0.2,
+                              "description": "Specifies a fraction of the table size to add to `autovacuum_vacuum_threshold` when deciding whether to trigger a `VACUUM`.",
+                              "example": 1,
+                              "maximum": 1,
+                              "minimum": 0,
+                              "type": "number"
+                            },
+                            "autovacuum_vacuum_threshold": {
+                              "default": 50,
+                              "description": "Specifies the minimum number of updated or deleted tuples needed to trigger a `VACUUM` in any one table.",
+                              "example": 2147483647,
+                              "maximum": 2147483647,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "bgwriter_delay": {
+                              "default": 200,
+                              "description": "Specifies the delay between activity rounds for the background writer in milliseconds.",
+                              "example": 200,
+                              "maximum": 10000,
+                              "minimum": 20,
+                              "type": "integer"
+                            },
+                            "bgwriter_flush_after": {
+                              "default": 512,
+                              "description": "Whenever more than `bgwriter_flush_after` bytes have been written by the background writer, attempt to force the OS to issue these writes to the underlying storage. Specified in kilobytes. Setting of `0` disables forced writeback.",
+                              "example": 512,
+                              "maximum": 2048,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "bgwriter_lru_maxpages": {
+                              "default": 100,
+                              "description": "In each round, no more than this many buffers will be written by the background writer. Setting this to zero disables background writing.",
+                              "example": 100,
+                              "maximum": 1073741823,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "bgwriter_lru_multiplier": {
+                              "default": 2.5,
+                              "description": "The average recent need for new buffers is multiplied by bgwriter_lru_multiplier to arrive at an estimate of the number that will be needed during the next round, (up to `bgwriter_lru_maxpages`). `1.0` represents a `\\u201cjust` in `time\\u201d` policy of writing exactly the number of buffers predicted to be needed. Larger values provide some cushion against spikes in demand, while smaller values intentionally leave writes to be done by server processes.",
+                              "example": 2.5,
+                              "maximum": 10,
+                              "minimum": 0,
+                              "type": "number"
+                            },
+                            "deadlock_timeout": {
+                              "description": "This is the amount of time, in milliseconds, to wait on a lock before checking to see if there is a deadlock condition.",
+                              "example": 1000,
+                              "maximum": 1800000,
+                              "minimum": 500,
+                              "type": "integer"
+                            },
+                            "default_toast_compression": {
+                              "default": "lz4",
+                              "description": "Specifies the default TOAST compression method for values of compressible columns.",
+                              "enum": [
+                                "lz4",
+                                "pglz"
+                              ],
+                              "example": "lz4",
+                              "type": "string"
+                            },
+                            "idle_in_transaction_session_timeout": {
+                              "description": "Time out sessions with open transactions after this number of milliseconds.",
+                              "example": 604800000,
+                              "maximum": 604800000,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "jit": {
+                              "description": "Controls system-wide use of Just-in-Time Compilation (JIT).",
+                              "example": true,
+                              "type": "boolean"
+                            },
+                            "max_files_per_process": {
+                              "description": "PostgreSQL maximum number of files that can be open per process.",
+                              "example": 1024,
+                              "maximum": 4096,
+                              "minimum": 1000,
+                              "type": "integer"
+                            },
+                            "max_locks_per_transaction": {
+                              "description": "PostgreSQL maximum locks per transaction.",
+                              "example": 1024,
+                              "maximum": 6400,
+                              "minimum": 64,
+                              "type": "integer"
+                            },
+                            "max_logical_replication_workers": {
+                              "description": "PostgreSQL maximum logical replication workers, taken from the pool of `max_parallel_workers`.",
+                              "example": 64,
+                              "maximum": 64,
+                              "minimum": 4,
+                              "type": "integer"
+                            },
+                            "max_parallel_workers": {
+                              "description": "Sets the maximum number of workers that the system can support for parallel queries.",
+                              "example": 96,
+                              "maximum": 96,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "max_parallel_workers_per_gather": {
+                              "description": "Sets the maximum number of workers that can be started by a single Gather or Gather Merge node.",
+                              "example": 96,
+                              "maximum": 96,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "max_pred_locks_per_transaction": {
+                              "description": "PostgreSQL maximum predicate locks per transaction.",
+                              "example": 5120,
+                              "maximum": 5120,
+                              "minimum": 64,
+                              "type": "integer"
+                            },
+                            "max_replication_slots": {
+                              "description": "PostgreSQL maximum replication slots.",
+                              "example": 64,
+                              "maximum": 64,
+                              "minimum": 8,
+                              "type": "integer"
+                            },
+                            "max_slot_wal_keep_size": {
+                              "default": -1,
+                              "description": "PostgreSQL maximum write ahead log (WAL) size in MB, reserved for replication slots. A value of `-1` indicates unlimited. The `wal_keep_size` minimum write ahead log (WAL) size setting takes precedence over this.",
+                              "example": 1000000,
+                              "maximum": 2147483647,
+                              "minimum": -1,
+                              "type": "integer"
+                            },
+                            "max_stack_depth": {
+                              "description": "Maximum depth of the stack in bytes.",
+                              "example": 2097152,
+                              "maximum": 6291456,
+                              "minimum": 2097152,
+                              "type": "integer"
+                            },
+                            "max_standby_archive_delay": {
+                              "description": "Maximum standby archive delay in milliseconds.",
+                              "example": 1,
+                              "maximum": 43200000,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "max_standby_streaming_delay": {
+                              "description": "Maximum standby streaming delay in milliseconds.",
+                              "example": 10,
+                              "maximum": 43200000,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "max_wal_senders": {
+                              "description": "PostgreSQL maximum write ahead log (WAL) senders.",
+                              "example": 20,
+                              "maximum": 64,
+                              "minimum": 20,
+                              "type": "integer"
+                            },
+                            "max_worker_processes": {
+                              "description": "Maximum number of background processes that the system can support.",
+                              "example": 96,
+                              "maximum": 96,
+                              "minimum": 8,
+                              "type": "integer"
+                            },
+                            "password_encryption": {
+                              "default": "md5",
+                              "description": "Chooses the algorithm for encrypting passwords.",
+                              "enum": [
+                                "scram-sh-256",
+                                "md5"
+                              ],
+                              "example": "scram-sha-256",
+                              "type": "string"
+                            },
+                            "pg_partman_bgw.interval": {
+                              "description": "Sets the time interval to run `pg_partman` scheduled tasks.",
+                              "example": 3600,
+                              "maximum": 604800,
+                              "minimum": 3600,
+                              "type": "integer"
+                            },
+                            "pg_partman_bgw.role": {
+                              "description": "Controls which role to use for `pg_partman`` scheduled background tasks.",
+                              "example": "myrolename",
+                              "type": "string"
+                            },
+                            "pg_stat_monitor.pgsm_enable_query_plan": {
+                              "description": "Enables query plan monitoring.",
+                              "example": true,
+                              "type": "boolean"
+                            },
+                            "pg_stat_monitor.pgsm_max_buckets": {
+                              "description": "Sets the maximum number of buckets.",
+                              "example": 10,
+                              "maximum": 10,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "pg_stat_statements.track": {
+                              "default": "top",
+                              "description": "Controls which statements are counted. Specify `top` to track top-level statements that are issued directly by clients, `all` to also track nested statements, such as those invoked within functions, or `none` to disable statement statistics collection.",
+                              "enum": [
+                                "all",
+                                "top",
+                                "none"
+                              ],
+                              "example": "all",
+                              "type": "string"
+                            },
+                            "temp_file_limit": {
+                              "description": "PostgreSQL temporary file limit in KB. Set to `-1` for unlimited.",
+                              "example": 5000000,
+                              "maximum": 2147483647,
+                              "minimum": -1,
+                              "type": "integer"
+                            },
+                            "timezone": {
+                              "description": "PostgreSQL service time zone.",
+                              "example": "Europe/Helsinki",
+                              "maxLength": 64,
+                              "pattern": "^[\\\\w/]*$",
+                              "type": "string"
+                            },
+                            "track_activity_query_size": {
+                              "description": "Specifies the number of bytes reserved to track the currently executing command for each active session.",
+                              "example": 1024,
+                              "maximum": 10240,
+                              "minimum": 1024,
+                              "type": "integer"
+                            },
+                            "track_commit_timestamp": {
+                              "description": "Record the commit time of transactions.",
+                              "enum": [
+                                "on",
+                                "off"
+                              ],
+                              "example": "on",
+                              "type": "string"
+                            },
+                            "track_functions": {
+                              "default": "none",
+                              "description": "Enables tracking of function call counts and time used. Specify `pl` to track only procedural-language functions, `all` to also track SQL and C language functions, or `none` to disable function statistics tracking.",
+                              "enum": [
+                                "all",
+                                "pl",
+                                "none"
+                              ],
+                              "example": "all",
+                              "type": "string"
+                            },
+                            "track_io_timing": {
+                              "default": "off",
+                              "description": "Enables timing of database I/O calls. This parameter is `off` by default, because it will repeatedly query the operating system for the current time, which may cause significant overhead on some platforms.",
+                              "enum": [
+                                "on",
+                                "off"
+                              ],
+                              "example": "off",
+                              "type": "string"
+                            },
+                            "wal_sender_timeout": {
+                              "description": "Terminate replication connections that are inactive for longer than this amount of time, in milliseconds. Setting this value to `0` disables the timeout.",
+                              "example": 60000,
+                              "maximum": 60000,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "wal_writer_delay": {
+                              "default": 200,
+                              "description": "Write ahead log (WAL) flush interval in milliseconds. A value lower than 200 milliseconds may negatively impact performance.",
+                              "example": 200,
+                              "maximum": 200,
+                              "minimum": 10,
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "pg_stat_monitor_enable": {
+                          "description": "Enable the `pg_stat_monitor` extension. When this extension is enabled, PostgreSQL restarts the cluster it's in. Additionally, `pg_stat_statements` results for utility commands are unreliable.",
+                          "example": false,
+                          "type": "boolean"
+                        },
+                        "pglookout": {
+                          "description": "Parameter used to apply PGLookout settings.",
+                          "properties": {
+                            "max_failover_replication_time_lag": {
+                              "description": "Number of seconds of master unavailability before triggering database failover to standby.",
+                              "example": 10,
+                              "maximum": 999999,
+                              "minimum": 10,
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "shared_buffers_percentage": {
+                          "description": "Percentage of total RAM that the database server uses for shared memory buffers. Valid range is 20-60 (float), which corresponds to 20% - 60%. This setting adjusts the `shared_buffers` configuration value.",
+                          "example": 41.5,
+                          "maximum": 60,
+                          "minimum": 20,
+                          "type": "number"
+                        },
+                        "work_mem": {
+                          "description": "Sets the maximum amount of memory in MB to be used by a query operation, such as a sort or hash table, before writing to temporary disk files. Default is 1MB + 0.075% of total RAM, up to 32 MB.",
+                          "example": 4,
+                          "maximum": 4,
+                          "minimum": 1,
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "x-akamai": {
+                        "file-path": "schemas/database-postgresql-engine-config.yaml"
+                      },
+                      "x-linode-cli-display": 7
+                    },
                     "fork": {
                       "additionalProperties": false,
-                      "description": "Details on the database that was the target of the fork. Only exists if the database was forked from another.",
+                      "description": "Details on the database that was the target of the fork. This only exists if the database was restored by creating a fork from another [MySQL](https://techdocs.akamai.com/linode-api/reference/post-databases-mysql-instances) or [PostgreSQL](https://techdocs.akamai.com/linode-api/reference/post-databases-postgre-sql-instances) database.",
                       "properties": {
                         "restore_time": {
                           "description": "The database timestamp from which it was restored. This is _not_ when the fork was created.",
@@ -27123,7 +32765,7 @@
                             "properties": {
                               "deadline": {
                                 "description": "The time when a mandatory update needs to be applied.",
-                                "example": "2024-10-14 19:55:12",
+                                "example": "2024-10-14T19:55:12",
                                 "format": "date-time",
                                 "nullable": true,
                                 "type": "string"
@@ -27135,7 +32777,7 @@
                               },
                               "planned_for": {
                                 "description": "The date and time a maintenance update will be applied.",
-                                "example": "2024-10-14 19:55:12",
+                                "example": "2024-10-14T19:55:12",
                                 "format": "date-time",
                                 "nullable": true,
                                 "type": "string"
@@ -27164,7 +32806,7 @@
                           "Filterable"
                         ]
                       },
-                      "x-linode-cli-display": 7,
+                      "x-linode-cli-display": 8,
                       "x-linode-filterable": true
                     }
                   },
@@ -27172,9 +32814,6 @@
                   "x-akamai": {
                     "file-path": "schemas/database-postgresql-response.yaml"
                   }
-                },
-                "x-example": {
-                  "x-ref": "../examples/post-databases-postgre-sql-instances-200.json"
                 }
               }
             },
@@ -27234,7 +32873,7 @@
         "x-akamai": {
           "tabs": [
             {
-              "syntax": "linode-cli databases postgresql-create \\\n  --label example-db \\\n  --region us-east \\\n  --type g6-dedicated-2 \\\n  --cluster_size 3 \\\n  --engine postgresql/13.2 \\\n  --ssl_connection true \\\n  --allow_list 203.0.113.1 \\\n  --allow_list 192.0.1.0/24",
+              "syntax": "linode-cli databases postgresql-create \\\n  --label example-db \\\n  --region us-east \\\n  --type g6-dedicated-2 \\\n  --cluster_size 3 \\\n  --engine postgresql/13.2 \\\n  --engine_config.shared_buffers_percentage 41.5 \\\n  --engine_config.pg.autovacuum_analyze_scale_factor 0.0 \\\n  --engine_config.pg.autovacuum_vacuum_cost_delay 60 \\\n  --engine_config.pg.pg_partman_bgw.interval 3600 \\\n  --engine_config.pg.pg_partman_bgw.role myrolename \\\n  --engine_config.pglookout.max_failover_replication_time_lag 60 \\\n  --ssl_connection true \\\n  --allow_list 203.0.113.1 \\\n  --allow_list 192.0.1.0/24",
               "title": "CLI",
               "url": "https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli"
             },
@@ -27304,6 +32943,59 @@
                       "created": "2022-01-01T00:01:01",
                       "encrypted": true,
                       "engine": "postgresql",
+                      "engine_config": {
+                        "pg": {
+                          "autovacuum_analyze_scale_factor": 1,
+                          "autovacuum_analyze_threshold": 2147483647,
+                          "autovacuum_max_workers": 20,
+                          "autovacuum_naptime": 86400,
+                          "autovacuum_vacuum_cost_delay": 100,
+                          "autovacuum_vacuum_cost_limit": 10000,
+                          "autovacuum_vacuum_scale_factor": 1,
+                          "autovacuum_vacuum_threshold": 2147483647,
+                          "bgwriter_delay": 200,
+                          "bgwriter_flush_after": 512,
+                          "bgwriter_lru_maxpages": 100,
+                          "bgwriter_lru_multiplier": 2.5,
+                          "deadlock_timeout": 1000,
+                          "default_toast_compression": "lz4",
+                          "idle_in_transaction_session_timeout": 604800000,
+                          "jit": true,
+                          "max_files_per_process": 1024,
+                          "max_locks_per_transaction": 1024,
+                          "max_logical_replication_workers": 64,
+                          "max_parallel_workers": 96,
+                          "max_parallel_workers_per_gather": 96,
+                          "max_pred_locks_per_transaction": 5120,
+                          "max_replication_slots": 64,
+                          "max_slot_wal_keep_size": 1000000,
+                          "max_stack_depth": 2097152,
+                          "max_standby_archive_delay": 1,
+                          "max_standby_streaming_delay": 10,
+                          "max_wal_senders": 20,
+                          "max_worker_processes": 96,
+                          "password_encryption": "scram-sha-256",
+                          "pg_partman_bgw.interval": 3600,
+                          "pg_partman_bgw.role": "myrolename",
+                          "pg_stat_monitor.pgsm_enable_query_plan": true,
+                          "pg_stat_monitor.pgsm_max_buckets": 10,
+                          "pg_stat_statements.track": "all",
+                          "temp_file_limit": 5000000,
+                          "timezone": "Europe/Helsinki",
+                          "track_activity_query_size": 1024,
+                          "track_commit_timestamp": true,
+                          "track_functions": "off",
+                          "track_io_timing": "off",
+                          "wal_sender_timeout": 60000,
+                          "wal_writer_delay": 200
+                        },
+                        "pg_stat_monitor_enable": false,
+                        "pglookout": {
+                          "max_failover_replication_time_lag": 10
+                        },
+                        "shared_buffers_percentage": 41.5,
+                        "work_mem": 4
+                      },
                       "fork": {
                         "restore_time": "2024-10-14T19:55:12",
                         "source": "176881"
@@ -27432,9 +33124,387 @@
                                 "x-linode-cli-display": 6,
                                 "x-linode-filterable": true
                               },
+                              "engine_config": {
+                                "additionalProperties": false,
+                                "description": "Advanced parameters you can apply to a PostgreSQL Managed Database, via our partner [Aiven's specification](https://aiven.io/docs/products/postgresql/reference/advanced-params). Only include the objects for parameters you want to set in your database. Omit objects for parameters you don't want to define or change.\n\n> \ud83d\udcd8\n>\n> Aiven may offer additional parameters in their specification. Currently, only those listed here are supported for use in a PostgreSQL Managed Database. You can also run the [List PostgreSQL Managed Database advanced parameters](https://techdocs.akamai.com/linode-api/reference/get-databases-postgresql-config) operation to see an up-to-date list.",
+                                "properties": {
+                                  "pg": {
+                                    "additionalProperties": false,
+                                    "description": "PostgreSQL-specific advanced configuration parameters.",
+                                    "properties": {
+                                      "autovacuum_analyze_scale_factor": {
+                                        "default": 0.2,
+                                        "description": "Specifies a fraction of the table size to add to `autovacuum_analyze_threshold` when deciding whether to trigger an `ANALYZE`.",
+                                        "example": 1,
+                                        "maximum": 1,
+                                        "minimum": 0,
+                                        "type": "number"
+                                      },
+                                      "autovacuum_analyze_threshold": {
+                                        "default": 50,
+                                        "description": "Specifies the minimum number of inserted, updated, or deleted tuples needed to trigger an `ANALYZE` in any one table. The default is 50 tuples.",
+                                        "example": 2147483647,
+                                        "maximum": 2147483647,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "autovacuum_max_workers": {
+                                        "default": 3,
+                                        "description": "Specifies the maximum number of `autovacuum` processes, other than the `autovacuum` launcher, that may be running at any one time. This parameter can only be set at server start.",
+                                        "example": 20,
+                                        "maximum": 20,
+                                        "minimum": 1,
+                                        "type": "integer"
+                                      },
+                                      "autovacuum_naptime": {
+                                        "default": 60,
+                                        "description": "Specifies the minimum delay between `autovacuum` runs on any given database. The delay is measured in seconds, and the default is one minute.",
+                                        "example": 86400,
+                                        "maximum": 86400,
+                                        "minimum": 1,
+                                        "type": "integer"
+                                      },
+                                      "autovacuum_vacuum_cost_delay": {
+                                        "default": 20,
+                                        "description": "Specifies the cost delay value that will be used in automatic `VACUUM` operations. If `-1` is specified, the regular `vacuum_cost_delay` value will be used.",
+                                        "example": 100,
+                                        "maximum": 100,
+                                        "minimum": -1,
+                                        "type": "integer"
+                                      },
+                                      "autovacuum_vacuum_cost_limit": {
+                                        "default": -1,
+                                        "description": "Specifies the cost limit value that will be used in automatic `VACUUM` operations. If `-1` is specified, the regular `vacuum_cost_limit` value will be used.",
+                                        "example": 10000,
+                                        "maximum": 10000,
+                                        "minimum": -1,
+                                        "type": "integer"
+                                      },
+                                      "autovacuum_vacuum_scale_factor": {
+                                        "default": 0.2,
+                                        "description": "Specifies a fraction of the table size to add to `autovacuum_vacuum_threshold` when deciding whether to trigger a `VACUUM`.",
+                                        "example": 1,
+                                        "maximum": 1,
+                                        "minimum": 0,
+                                        "type": "number"
+                                      },
+                                      "autovacuum_vacuum_threshold": {
+                                        "default": 50,
+                                        "description": "Specifies the minimum number of updated or deleted tuples needed to trigger a `VACUUM` in any one table.",
+                                        "example": 2147483647,
+                                        "maximum": 2147483647,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "bgwriter_delay": {
+                                        "default": 200,
+                                        "description": "Specifies the delay between activity rounds for the background writer in milliseconds.",
+                                        "example": 200,
+                                        "maximum": 10000,
+                                        "minimum": 20,
+                                        "type": "integer"
+                                      },
+                                      "bgwriter_flush_after": {
+                                        "default": 512,
+                                        "description": "Whenever more than `bgwriter_flush_after` bytes have been written by the background writer, attempt to force the OS to issue these writes to the underlying storage. Specified in kilobytes. Setting of `0` disables forced writeback.",
+                                        "example": 512,
+                                        "maximum": 2048,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "bgwriter_lru_maxpages": {
+                                        "default": 100,
+                                        "description": "In each round, no more than this many buffers will be written by the background writer. Setting this to zero disables background writing.",
+                                        "example": 100,
+                                        "maximum": 1073741823,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "bgwriter_lru_multiplier": {
+                                        "default": 2.5,
+                                        "description": "The average recent need for new buffers is multiplied by bgwriter_lru_multiplier to arrive at an estimate of the number that will be needed during the next round, (up to `bgwriter_lru_maxpages`). `1.0` represents a `\\u201cjust` in `time\\u201d` policy of writing exactly the number of buffers predicted to be needed. Larger values provide some cushion against spikes in demand, while smaller values intentionally leave writes to be done by server processes.",
+                                        "example": 2.5,
+                                        "maximum": 10,
+                                        "minimum": 0,
+                                        "type": "number"
+                                      },
+                                      "deadlock_timeout": {
+                                        "description": "This is the amount of time, in milliseconds, to wait on a lock before checking to see if there is a deadlock condition.",
+                                        "example": 1000,
+                                        "maximum": 1800000,
+                                        "minimum": 500,
+                                        "type": "integer"
+                                      },
+                                      "default_toast_compression": {
+                                        "default": "lz4",
+                                        "description": "Specifies the default TOAST compression method for values of compressible columns.",
+                                        "enum": [
+                                          "lz4",
+                                          "pglz"
+                                        ],
+                                        "example": "lz4",
+                                        "type": "string"
+                                      },
+                                      "idle_in_transaction_session_timeout": {
+                                        "description": "Time out sessions with open transactions after this number of milliseconds.",
+                                        "example": 604800000,
+                                        "maximum": 604800000,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "jit": {
+                                        "description": "Controls system-wide use of Just-in-Time Compilation (JIT).",
+                                        "example": true,
+                                        "type": "boolean"
+                                      },
+                                      "max_files_per_process": {
+                                        "description": "PostgreSQL maximum number of files that can be open per process.",
+                                        "example": 1024,
+                                        "maximum": 4096,
+                                        "minimum": 1000,
+                                        "type": "integer"
+                                      },
+                                      "max_locks_per_transaction": {
+                                        "description": "PostgreSQL maximum locks per transaction.",
+                                        "example": 1024,
+                                        "maximum": 6400,
+                                        "minimum": 64,
+                                        "type": "integer"
+                                      },
+                                      "max_logical_replication_workers": {
+                                        "description": "PostgreSQL maximum logical replication workers, taken from the pool of `max_parallel_workers`.",
+                                        "example": 64,
+                                        "maximum": 64,
+                                        "minimum": 4,
+                                        "type": "integer"
+                                      },
+                                      "max_parallel_workers": {
+                                        "description": "Sets the maximum number of workers that the system can support for parallel queries.",
+                                        "example": 96,
+                                        "maximum": 96,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "max_parallel_workers_per_gather": {
+                                        "description": "Sets the maximum number of workers that can be started by a single Gather or Gather Merge node.",
+                                        "example": 96,
+                                        "maximum": 96,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "max_pred_locks_per_transaction": {
+                                        "description": "PostgreSQL maximum predicate locks per transaction.",
+                                        "example": 5120,
+                                        "maximum": 5120,
+                                        "minimum": 64,
+                                        "type": "integer"
+                                      },
+                                      "max_replication_slots": {
+                                        "description": "PostgreSQL maximum replication slots.",
+                                        "example": 64,
+                                        "maximum": 64,
+                                        "minimum": 8,
+                                        "type": "integer"
+                                      },
+                                      "max_slot_wal_keep_size": {
+                                        "default": -1,
+                                        "description": "PostgreSQL maximum write ahead log (WAL) size in MB, reserved for replication slots. A value of `-1` indicates unlimited. The `wal_keep_size` minimum write ahead log (WAL) size setting takes precedence over this.",
+                                        "example": 1000000,
+                                        "maximum": 2147483647,
+                                        "minimum": -1,
+                                        "type": "integer"
+                                      },
+                                      "max_stack_depth": {
+                                        "description": "Maximum depth of the stack in bytes.",
+                                        "example": 2097152,
+                                        "maximum": 6291456,
+                                        "minimum": 2097152,
+                                        "type": "integer"
+                                      },
+                                      "max_standby_archive_delay": {
+                                        "description": "Maximum standby archive delay in milliseconds.",
+                                        "example": 1,
+                                        "maximum": 43200000,
+                                        "minimum": 1,
+                                        "type": "integer"
+                                      },
+                                      "max_standby_streaming_delay": {
+                                        "description": "Maximum standby streaming delay in milliseconds.",
+                                        "example": 10,
+                                        "maximum": 43200000,
+                                        "minimum": 1,
+                                        "type": "integer"
+                                      },
+                                      "max_wal_senders": {
+                                        "description": "PostgreSQL maximum write ahead log (WAL) senders.",
+                                        "example": 20,
+                                        "maximum": 64,
+                                        "minimum": 20,
+                                        "type": "integer"
+                                      },
+                                      "max_worker_processes": {
+                                        "description": "Maximum number of background processes that the system can support.",
+                                        "example": 96,
+                                        "maximum": 96,
+                                        "minimum": 8,
+                                        "type": "integer"
+                                      },
+                                      "password_encryption": {
+                                        "default": "md5",
+                                        "description": "Chooses the algorithm for encrypting passwords.",
+                                        "enum": [
+                                          "scram-sh-256",
+                                          "md5"
+                                        ],
+                                        "example": "scram-sha-256",
+                                        "type": "string"
+                                      },
+                                      "pg_partman_bgw.interval": {
+                                        "description": "Sets the time interval to run `pg_partman` scheduled tasks.",
+                                        "example": 3600,
+                                        "maximum": 604800,
+                                        "minimum": 3600,
+                                        "type": "integer"
+                                      },
+                                      "pg_partman_bgw.role": {
+                                        "description": "Controls which role to use for `pg_partman`` scheduled background tasks.",
+                                        "example": "myrolename",
+                                        "type": "string"
+                                      },
+                                      "pg_stat_monitor.pgsm_enable_query_plan": {
+                                        "description": "Enables query plan monitoring.",
+                                        "example": true,
+                                        "type": "boolean"
+                                      },
+                                      "pg_stat_monitor.pgsm_max_buckets": {
+                                        "description": "Sets the maximum number of buckets.",
+                                        "example": 10,
+                                        "maximum": 10,
+                                        "minimum": 1,
+                                        "type": "integer"
+                                      },
+                                      "pg_stat_statements.track": {
+                                        "default": "top",
+                                        "description": "Controls which statements are counted. Specify `top` to track top-level statements that are issued directly by clients, `all` to also track nested statements, such as those invoked within functions, or `none` to disable statement statistics collection.",
+                                        "enum": [
+                                          "all",
+                                          "top",
+                                          "none"
+                                        ],
+                                        "example": "all",
+                                        "type": "string"
+                                      },
+                                      "temp_file_limit": {
+                                        "description": "PostgreSQL temporary file limit in KB. Set to `-1` for unlimited.",
+                                        "example": 5000000,
+                                        "maximum": 2147483647,
+                                        "minimum": -1,
+                                        "type": "integer"
+                                      },
+                                      "timezone": {
+                                        "description": "PostgreSQL service time zone.",
+                                        "example": "Europe/Helsinki",
+                                        "maxLength": 64,
+                                        "pattern": "^[\\\\w/]*$",
+                                        "type": "string"
+                                      },
+                                      "track_activity_query_size": {
+                                        "description": "Specifies the number of bytes reserved to track the currently executing command for each active session.",
+                                        "example": 1024,
+                                        "maximum": 10240,
+                                        "minimum": 1024,
+                                        "type": "integer"
+                                      },
+                                      "track_commit_timestamp": {
+                                        "description": "Record the commit time of transactions.",
+                                        "enum": [
+                                          "on",
+                                          "off"
+                                        ],
+                                        "example": "on",
+                                        "type": "string"
+                                      },
+                                      "track_functions": {
+                                        "default": "none",
+                                        "description": "Enables tracking of function call counts and time used. Specify `pl` to track only procedural-language functions, `all` to also track SQL and C language functions, or `none` to disable function statistics tracking.",
+                                        "enum": [
+                                          "all",
+                                          "pl",
+                                          "none"
+                                        ],
+                                        "example": "all",
+                                        "type": "string"
+                                      },
+                                      "track_io_timing": {
+                                        "default": "off",
+                                        "description": "Enables timing of database I/O calls. This parameter is `off` by default, because it will repeatedly query the operating system for the current time, which may cause significant overhead on some platforms.",
+                                        "enum": [
+                                          "on",
+                                          "off"
+                                        ],
+                                        "example": "off",
+                                        "type": "string"
+                                      },
+                                      "wal_sender_timeout": {
+                                        "description": "Terminate replication connections that are inactive for longer than this amount of time, in milliseconds. Setting this value to `0` disables the timeout.",
+                                        "example": 60000,
+                                        "maximum": 60000,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "wal_writer_delay": {
+                                        "default": 200,
+                                        "description": "Write ahead log (WAL) flush interval in milliseconds. A value lower than 200 milliseconds may negatively impact performance.",
+                                        "example": 200,
+                                        "maximum": 200,
+                                        "minimum": 10,
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "pg_stat_monitor_enable": {
+                                    "description": "Enable the `pg_stat_monitor` extension. When this extension is enabled, PostgreSQL restarts the cluster it's in. Additionally, `pg_stat_statements` results for utility commands are unreliable.",
+                                    "example": false,
+                                    "type": "boolean"
+                                  },
+                                  "pglookout": {
+                                    "description": "Parameter used to apply PGLookout settings.",
+                                    "properties": {
+                                      "max_failover_replication_time_lag": {
+                                        "description": "Number of seconds of master unavailability before triggering database failover to standby.",
+                                        "example": 10,
+                                        "maximum": 999999,
+                                        "minimum": 10,
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "shared_buffers_percentage": {
+                                    "description": "Percentage of total RAM that the database server uses for shared memory buffers. Valid range is 20-60 (float), which corresponds to 20% - 60%. This setting adjusts the `shared_buffers` configuration value.",
+                                    "example": 41.5,
+                                    "maximum": 60,
+                                    "minimum": 20,
+                                    "type": "number"
+                                  },
+                                  "work_mem": {
+                                    "description": "Sets the maximum amount of memory in MB to be used by a query operation, such as a sort or hash table, before writing to temporary disk files. Default is 1MB + 0.075% of total RAM, up to 32 MB.",
+                                    "example": 4,
+                                    "maximum": 4,
+                                    "minimum": 1,
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "x-akamai": {
+                                  "file-path": "schemas/database-postgresql-engine-config.yaml"
+                                },
+                                "x-linode-cli-display": 7
+                              },
                               "fork": {
                                 "additionalProperties": false,
-                                "description": "Details on the database that was the target of the fork. Only exists if the database was forked from another.",
+                                "description": "Details on the database that was the target of the fork. This only exists if the database was restored by creating a fork from another [MySQL](https://techdocs.akamai.com/linode-api/reference/post-databases-mysql-instances) or [PostgreSQL](https://techdocs.akamai.com/linode-api/reference/post-databases-postgre-sql-instances) database.",
                                 "properties": {
                                   "restore_time": {
                                     "description": "The database timestamp from which it was restored. This is _not_ when the fork was created.",
@@ -27544,7 +33614,7 @@
                               },
                               "ssl_connection": {
                                 "default": true,
-                                "description": "Currently required to be `true`. Whether to require SSL credentials to establish a connection to the Managed Database.\n\nRun the [Get managed PostgreSQL database credentials](https://techdocs.akamai.com/linode-api/reference/get-databases-postgre-sql-instance-credentials) operation for access information.",
+                                "description": "Currently required to be `true`. Whether to require SSL credentials to establish a connection to the Managed Database. Run the [Get managed PostgreSQL database credentials](https://techdocs.akamai.com/linode-api/reference/get-databases-postgre-sql-instance-credentials) operation for access information.",
                                 "example": true,
                                 "type": "boolean"
                               },
@@ -27648,7 +33718,7 @@
                                       "properties": {
                                         "deadline": {
                                           "description": "The time when a mandatory update needs to be applied.",
-                                          "example": "2024-10-14 19:55:12",
+                                          "example": "2024-10-14T19:55:12",
                                           "format": "date-time",
                                           "nullable": true,
                                           "type": "string"
@@ -27660,7 +33730,7 @@
                                         },
                                         "planned_for": {
                                           "description": "The date and time a maintenance update will be applied.",
-                                          "example": "2024-10-14 19:55:12",
+                                          "example": "2024-10-14T19:55:12",
                                           "format": "date-time",
                                           "nullable": true,
                                           "type": "string"
@@ -27817,6 +33887,100 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "allow_list": [
+                    "192.0.2.133/24",
+                    "192.0.2.92/24"
+                  ],
+                  "cluster_size": 3,
+                  "created": "2022-01-01T00:01:01",
+                  "encrypted": true,
+                  "engine": "postgresql",
+                  "engine_config": {
+                    "pg": {
+                      "autovacuum_analyze_scale_factor": 1,
+                      "autovacuum_analyze_threshold": 2147483647,
+                      "autovacuum_max_workers": 20,
+                      "autovacuum_naptime": 86400,
+                      "autovacuum_vacuum_cost_delay": 100,
+                      "autovacuum_vacuum_cost_limit": 10000,
+                      "autovacuum_vacuum_scale_factor": 1,
+                      "autovacuum_vacuum_threshold": 2147483647,
+                      "bgwriter_delay": 200,
+                      "bgwriter_flush_after": 512,
+                      "bgwriter_lru_maxpages": 100,
+                      "bgwriter_lru_multiplier": 2.5,
+                      "deadlock_timeout": 1000,
+                      "default_toast_compression": "lz4",
+                      "idle_in_transaction_session_timeout": 604800000,
+                      "max_files_per_process": 1024,
+                      "max_locks_per_transaction": 1024,
+                      "max_logical_replication_workers": 64,
+                      "max_parallel_workers": 96,
+                      "max_parallel_workers_per_gather": 96,
+                      "max_pred_locks_per_transaction": 5120,
+                      "max_replication_slots": 64,
+                      "max_slot_wal_keep_size": 1000000,
+                      "max_stack_depth": 2097152,
+                      "max_standby_archive_delay": 1,
+                      "max_standby_streaming_delay": 10,
+                      "max_wal_senders": 20,
+                      "max_worker_processes": 96,
+                      "password_encryption": "scram-sha-256",
+                      "pg_partman_bgw.interval": 3600,
+                      "pg_partman_bgw.role": "myrolename",
+                      "pg_stat_monitor.pgsm_enable_query_plan": true,
+                      "pg_stat_monitor.pgsm_max_buckets": 10,
+                      "pg_stat_statements.track": "all",
+                      "temp_file_limit": 5000000,
+                      "timezone": "Europe/Helsinki",
+                      "track_activity_query_size": 1024,
+                      "track_commit_timestamp": "on",
+                      "track_functions": "on",
+                      "track_io_timing": "off",
+                      "wal_sender_timeout": 60000,
+                      "wal_writer_delay": 200
+                    },
+                    "pg_stat_monitor_enable": false,
+                    "pglookout": {
+                      "max_failover_replication_time_lag": 10
+                    },
+                    "shared_buffers_percentage": 41.5,
+                    "work_mem": 4
+                  },
+                  "fork": {
+                    "restore_time": "2024-10-14T19:55:12",
+                    "source": 176881
+                  },
+                  "hosts": {
+                    "primary": "lin-0000-000-pgsql-primary.servers.linodedb.net",
+                    "secondary": "lin-0000-000-pgsql-primary-private.servers.linodedb.net"
+                  },
+                  "id": 123,
+                  "label": "example-db",
+                  "members": {
+                    "45.56.110.70": "primary",
+                    "45.79.159.239": "failover"
+                  },
+                  "oldest_restore_time": "2024-10-03T20:48:05",
+                  "platform": "rdbms-default",
+                  "port": 3306,
+                  "region": "us-east",
+                  "ssl_connection": true,
+                  "status": "active",
+                  "total_disk_size_gb": 15,
+                  "type": "g6-dedicated-2",
+                  "updated": "2022-01-01T00:01:01",
+                  "updates": {
+                    "day_of_week": 1,
+                    "duration": 3,
+                    "frequency": "weekly",
+                    "hour_of_day": 0,
+                    "pending": []
+                  },
+                  "used_disk_size_gb": 2,
+                  "version": "13.2"
+                },
                 "schema": {
                   "additionalProperties": false,
                   "description": "Managed PostgreSQL Databases object.",
@@ -27873,9 +34037,387 @@
                       "x-linode-cli-display": 6,
                       "x-linode-filterable": true
                     },
+                    "engine_config": {
+                      "additionalProperties": false,
+                      "description": "Advanced parameters you can apply to a PostgreSQL Managed Database, via our partner [Aiven's specification](https://aiven.io/docs/products/postgresql/reference/advanced-params). Only include the objects for parameters you want to set in your database. Omit objects for parameters you don't want to define or change.\n\n> \ud83d\udcd8\n>\n> Aiven may offer additional parameters in their specification. Currently, only those listed here are supported for use in a PostgreSQL Managed Database. You can also run the [List PostgreSQL Managed Database advanced parameters](https://techdocs.akamai.com/linode-api/reference/get-databases-postgresql-config) operation to see an up-to-date list.",
+                      "properties": {
+                        "pg": {
+                          "additionalProperties": false,
+                          "description": "PostgreSQL-specific advanced configuration parameters.",
+                          "properties": {
+                            "autovacuum_analyze_scale_factor": {
+                              "default": 0.2,
+                              "description": "Specifies a fraction of the table size to add to `autovacuum_analyze_threshold` when deciding whether to trigger an `ANALYZE`.",
+                              "example": 1,
+                              "maximum": 1,
+                              "minimum": 0,
+                              "type": "number"
+                            },
+                            "autovacuum_analyze_threshold": {
+                              "default": 50,
+                              "description": "Specifies the minimum number of inserted, updated, or deleted tuples needed to trigger an `ANALYZE` in any one table. The default is 50 tuples.",
+                              "example": 2147483647,
+                              "maximum": 2147483647,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "autovacuum_max_workers": {
+                              "default": 3,
+                              "description": "Specifies the maximum number of `autovacuum` processes, other than the `autovacuum` launcher, that may be running at any one time. This parameter can only be set at server start.",
+                              "example": 20,
+                              "maximum": 20,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "autovacuum_naptime": {
+                              "default": 60,
+                              "description": "Specifies the minimum delay between `autovacuum` runs on any given database. The delay is measured in seconds, and the default is one minute.",
+                              "example": 86400,
+                              "maximum": 86400,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "autovacuum_vacuum_cost_delay": {
+                              "default": 20,
+                              "description": "Specifies the cost delay value that will be used in automatic `VACUUM` operations. If `-1` is specified, the regular `vacuum_cost_delay` value will be used.",
+                              "example": 100,
+                              "maximum": 100,
+                              "minimum": -1,
+                              "type": "integer"
+                            },
+                            "autovacuum_vacuum_cost_limit": {
+                              "default": -1,
+                              "description": "Specifies the cost limit value that will be used in automatic `VACUUM` operations. If `-1` is specified, the regular `vacuum_cost_limit` value will be used.",
+                              "example": 10000,
+                              "maximum": 10000,
+                              "minimum": -1,
+                              "type": "integer"
+                            },
+                            "autovacuum_vacuum_scale_factor": {
+                              "default": 0.2,
+                              "description": "Specifies a fraction of the table size to add to `autovacuum_vacuum_threshold` when deciding whether to trigger a `VACUUM`.",
+                              "example": 1,
+                              "maximum": 1,
+                              "minimum": 0,
+                              "type": "number"
+                            },
+                            "autovacuum_vacuum_threshold": {
+                              "default": 50,
+                              "description": "Specifies the minimum number of updated or deleted tuples needed to trigger a `VACUUM` in any one table.",
+                              "example": 2147483647,
+                              "maximum": 2147483647,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "bgwriter_delay": {
+                              "default": 200,
+                              "description": "Specifies the delay between activity rounds for the background writer in milliseconds.",
+                              "example": 200,
+                              "maximum": 10000,
+                              "minimum": 20,
+                              "type": "integer"
+                            },
+                            "bgwriter_flush_after": {
+                              "default": 512,
+                              "description": "Whenever more than `bgwriter_flush_after` bytes have been written by the background writer, attempt to force the OS to issue these writes to the underlying storage. Specified in kilobytes. Setting of `0` disables forced writeback.",
+                              "example": 512,
+                              "maximum": 2048,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "bgwriter_lru_maxpages": {
+                              "default": 100,
+                              "description": "In each round, no more than this many buffers will be written by the background writer. Setting this to zero disables background writing.",
+                              "example": 100,
+                              "maximum": 1073741823,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "bgwriter_lru_multiplier": {
+                              "default": 2.5,
+                              "description": "The average recent need for new buffers is multiplied by bgwriter_lru_multiplier to arrive at an estimate of the number that will be needed during the next round, (up to `bgwriter_lru_maxpages`). `1.0` represents a `\\u201cjust` in `time\\u201d` policy of writing exactly the number of buffers predicted to be needed. Larger values provide some cushion against spikes in demand, while smaller values intentionally leave writes to be done by server processes.",
+                              "example": 2.5,
+                              "maximum": 10,
+                              "minimum": 0,
+                              "type": "number"
+                            },
+                            "deadlock_timeout": {
+                              "description": "This is the amount of time, in milliseconds, to wait on a lock before checking to see if there is a deadlock condition.",
+                              "example": 1000,
+                              "maximum": 1800000,
+                              "minimum": 500,
+                              "type": "integer"
+                            },
+                            "default_toast_compression": {
+                              "default": "lz4",
+                              "description": "Specifies the default TOAST compression method for values of compressible columns.",
+                              "enum": [
+                                "lz4",
+                                "pglz"
+                              ],
+                              "example": "lz4",
+                              "type": "string"
+                            },
+                            "idle_in_transaction_session_timeout": {
+                              "description": "Time out sessions with open transactions after this number of milliseconds.",
+                              "example": 604800000,
+                              "maximum": 604800000,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "jit": {
+                              "description": "Controls system-wide use of Just-in-Time Compilation (JIT).",
+                              "example": true,
+                              "type": "boolean"
+                            },
+                            "max_files_per_process": {
+                              "description": "PostgreSQL maximum number of files that can be open per process.",
+                              "example": 1024,
+                              "maximum": 4096,
+                              "minimum": 1000,
+                              "type": "integer"
+                            },
+                            "max_locks_per_transaction": {
+                              "description": "PostgreSQL maximum locks per transaction.",
+                              "example": 1024,
+                              "maximum": 6400,
+                              "minimum": 64,
+                              "type": "integer"
+                            },
+                            "max_logical_replication_workers": {
+                              "description": "PostgreSQL maximum logical replication workers, taken from the pool of `max_parallel_workers`.",
+                              "example": 64,
+                              "maximum": 64,
+                              "minimum": 4,
+                              "type": "integer"
+                            },
+                            "max_parallel_workers": {
+                              "description": "Sets the maximum number of workers that the system can support for parallel queries.",
+                              "example": 96,
+                              "maximum": 96,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "max_parallel_workers_per_gather": {
+                              "description": "Sets the maximum number of workers that can be started by a single Gather or Gather Merge node.",
+                              "example": 96,
+                              "maximum": 96,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "max_pred_locks_per_transaction": {
+                              "description": "PostgreSQL maximum predicate locks per transaction.",
+                              "example": 5120,
+                              "maximum": 5120,
+                              "minimum": 64,
+                              "type": "integer"
+                            },
+                            "max_replication_slots": {
+                              "description": "PostgreSQL maximum replication slots.",
+                              "example": 64,
+                              "maximum": 64,
+                              "minimum": 8,
+                              "type": "integer"
+                            },
+                            "max_slot_wal_keep_size": {
+                              "default": -1,
+                              "description": "PostgreSQL maximum write ahead log (WAL) size in MB, reserved for replication slots. A value of `-1` indicates unlimited. The `wal_keep_size` minimum write ahead log (WAL) size setting takes precedence over this.",
+                              "example": 1000000,
+                              "maximum": 2147483647,
+                              "minimum": -1,
+                              "type": "integer"
+                            },
+                            "max_stack_depth": {
+                              "description": "Maximum depth of the stack in bytes.",
+                              "example": 2097152,
+                              "maximum": 6291456,
+                              "minimum": 2097152,
+                              "type": "integer"
+                            },
+                            "max_standby_archive_delay": {
+                              "description": "Maximum standby archive delay in milliseconds.",
+                              "example": 1,
+                              "maximum": 43200000,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "max_standby_streaming_delay": {
+                              "description": "Maximum standby streaming delay in milliseconds.",
+                              "example": 10,
+                              "maximum": 43200000,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "max_wal_senders": {
+                              "description": "PostgreSQL maximum write ahead log (WAL) senders.",
+                              "example": 20,
+                              "maximum": 64,
+                              "minimum": 20,
+                              "type": "integer"
+                            },
+                            "max_worker_processes": {
+                              "description": "Maximum number of background processes that the system can support.",
+                              "example": 96,
+                              "maximum": 96,
+                              "minimum": 8,
+                              "type": "integer"
+                            },
+                            "password_encryption": {
+                              "default": "md5",
+                              "description": "Chooses the algorithm for encrypting passwords.",
+                              "enum": [
+                                "scram-sh-256",
+                                "md5"
+                              ],
+                              "example": "scram-sha-256",
+                              "type": "string"
+                            },
+                            "pg_partman_bgw.interval": {
+                              "description": "Sets the time interval to run `pg_partman` scheduled tasks.",
+                              "example": 3600,
+                              "maximum": 604800,
+                              "minimum": 3600,
+                              "type": "integer"
+                            },
+                            "pg_partman_bgw.role": {
+                              "description": "Controls which role to use for `pg_partman`` scheduled background tasks.",
+                              "example": "myrolename",
+                              "type": "string"
+                            },
+                            "pg_stat_monitor.pgsm_enable_query_plan": {
+                              "description": "Enables query plan monitoring.",
+                              "example": true,
+                              "type": "boolean"
+                            },
+                            "pg_stat_monitor.pgsm_max_buckets": {
+                              "description": "Sets the maximum number of buckets.",
+                              "example": 10,
+                              "maximum": 10,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "pg_stat_statements.track": {
+                              "default": "top",
+                              "description": "Controls which statements are counted. Specify `top` to track top-level statements that are issued directly by clients, `all` to also track nested statements, such as those invoked within functions, or `none` to disable statement statistics collection.",
+                              "enum": [
+                                "all",
+                                "top",
+                                "none"
+                              ],
+                              "example": "all",
+                              "type": "string"
+                            },
+                            "temp_file_limit": {
+                              "description": "PostgreSQL temporary file limit in KB. Set to `-1` for unlimited.",
+                              "example": 5000000,
+                              "maximum": 2147483647,
+                              "minimum": -1,
+                              "type": "integer"
+                            },
+                            "timezone": {
+                              "description": "PostgreSQL service time zone.",
+                              "example": "Europe/Helsinki",
+                              "maxLength": 64,
+                              "pattern": "^[\\\\w/]*$",
+                              "type": "string"
+                            },
+                            "track_activity_query_size": {
+                              "description": "Specifies the number of bytes reserved to track the currently executing command for each active session.",
+                              "example": 1024,
+                              "maximum": 10240,
+                              "minimum": 1024,
+                              "type": "integer"
+                            },
+                            "track_commit_timestamp": {
+                              "description": "Record the commit time of transactions.",
+                              "enum": [
+                                "on",
+                                "off"
+                              ],
+                              "example": "on",
+                              "type": "string"
+                            },
+                            "track_functions": {
+                              "default": "none",
+                              "description": "Enables tracking of function call counts and time used. Specify `pl` to track only procedural-language functions, `all` to also track SQL and C language functions, or `none` to disable function statistics tracking.",
+                              "enum": [
+                                "all",
+                                "pl",
+                                "none"
+                              ],
+                              "example": "all",
+                              "type": "string"
+                            },
+                            "track_io_timing": {
+                              "default": "off",
+                              "description": "Enables timing of database I/O calls. This parameter is `off` by default, because it will repeatedly query the operating system for the current time, which may cause significant overhead on some platforms.",
+                              "enum": [
+                                "on",
+                                "off"
+                              ],
+                              "example": "off",
+                              "type": "string"
+                            },
+                            "wal_sender_timeout": {
+                              "description": "Terminate replication connections that are inactive for longer than this amount of time, in milliseconds. Setting this value to `0` disables the timeout.",
+                              "example": 60000,
+                              "maximum": 60000,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "wal_writer_delay": {
+                              "default": 200,
+                              "description": "Write ahead log (WAL) flush interval in milliseconds. A value lower than 200 milliseconds may negatively impact performance.",
+                              "example": 200,
+                              "maximum": 200,
+                              "minimum": 10,
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "pg_stat_monitor_enable": {
+                          "description": "Enable the `pg_stat_monitor` extension. When this extension is enabled, PostgreSQL restarts the cluster it's in. Additionally, `pg_stat_statements` results for utility commands are unreliable.",
+                          "example": false,
+                          "type": "boolean"
+                        },
+                        "pglookout": {
+                          "description": "Parameter used to apply PGLookout settings.",
+                          "properties": {
+                            "max_failover_replication_time_lag": {
+                              "description": "Number of seconds of master unavailability before triggering database failover to standby.",
+                              "example": 10,
+                              "maximum": 999999,
+                              "minimum": 10,
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "shared_buffers_percentage": {
+                          "description": "Percentage of total RAM that the database server uses for shared memory buffers. Valid range is 20-60 (float), which corresponds to 20% - 60%. This setting adjusts the `shared_buffers` configuration value.",
+                          "example": 41.5,
+                          "maximum": 60,
+                          "minimum": 20,
+                          "type": "number"
+                        },
+                        "work_mem": {
+                          "description": "Sets the maximum amount of memory in MB to be used by a query operation, such as a sort or hash table, before writing to temporary disk files. Default is 1MB + 0.075% of total RAM, up to 32 MB.",
+                          "example": 4,
+                          "maximum": 4,
+                          "minimum": 1,
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "x-akamai": {
+                        "file-path": "schemas/database-postgresql-engine-config.yaml"
+                      },
+                      "x-linode-cli-display": 7
+                    },
                     "fork": {
                       "additionalProperties": false,
-                      "description": "Details on the database that was the target of the fork. Only exists if the database was forked from another.",
+                      "description": "Details on the database that was the target of the fork. This only exists if the database was restored by creating a fork from another [MySQL](https://techdocs.akamai.com/linode-api/reference/post-databases-mysql-instances) or [PostgreSQL](https://techdocs.akamai.com/linode-api/reference/post-databases-postgre-sql-instances) database.",
                       "properties": {
                         "restore_time": {
                           "description": "The database timestamp from which it was restored. This is _not_ when the fork was created.",
@@ -27985,7 +34527,7 @@
                     },
                     "ssl_connection": {
                       "default": true,
-                      "description": "Currently required to be `true`. Whether to require SSL credentials to establish a connection to the Managed Database.\n\nRun the [Get managed PostgreSQL database credentials](https://techdocs.akamai.com/linode-api/reference/get-databases-postgre-sql-instance-credentials) operation for access information.",
+                      "description": "Currently required to be `true`. Whether to require SSL credentials to establish a connection to the Managed Database. Run the [Get managed PostgreSQL database credentials](https://techdocs.akamai.com/linode-api/reference/get-databases-postgre-sql-instance-credentials) operation for access information.",
                       "example": true,
                       "type": "boolean"
                     },
@@ -28089,7 +34631,7 @@
                             "properties": {
                               "deadline": {
                                 "description": "The time when a mandatory update needs to be applied.",
-                                "example": "2024-10-14 19:55:12",
+                                "example": "2024-10-14T19:55:12",
                                 "format": "date-time",
                                 "nullable": true,
                                 "type": "string"
@@ -28101,7 +34643,7 @@
                               },
                               "planned_for": {
                                 "description": "The date and time a maintenance update will be applied.",
-                                "example": "2024-10-14 19:55:12",
+                                "example": "2024-10-14T19:55:12",
                                 "format": "date-time",
                                 "nullable": true,
                                 "type": "string"
@@ -28138,9 +34680,6 @@
                   "x-akamai": {
                     "file-path": "schemas/database-postgresql.yaml"
                   }
-                },
-                "x-example": {
-                  "x-ref": "../examples/get-databases-postgre-sql-instance-200.json"
                 }
               }
             },
@@ -28215,7 +34754,7 @@
         "x-linode-grant": "read_only"
       },
       "put": {
-        "description": "Make changes to an existing PostgreSQL Managed Database.\n\n- The user needs `read_write` [user grant](https://techdocs.akamai.com/linode-api/reference/get-user-grants) access to the database.\n\n- The database's status needs to be `active`.\n\n- New values set in the `allow_list` overwrite existing values. To keep existing values, run the [List PostgreSQL Managed Databases](https://techdocs.akamai.com/linode-api/reference/get-databases-postgre-sql-instances) operation, store the `allow_list` addresses from the response, and include them with any new addresses in this operation.\n\n- Updates to your `allow_list` may take a short period of time to complete, making this operation inappropriate for rapid successive updates.\n\n- Also allows resizing the database cluster to a larger one. Clusters can't be resized to smaller plans.\n\n- All Managed Databases include automatic updates, which apply security patches to the underlying operating system of the Managed PostgreSQL Database. Use the `updates` object in this operation to modify the maintenance window for these updates.\n\n- If your database cluster is configured with a single node, downtime occurs during maintenance updates. Use the `updates` object to adjust the window to match a time that's the least disruptive to your application and users. Also consider upgrading to a [high availability](https://techdocs.akamai.com/cloud-computing/docs/managed-databases#high-availability) plan to avoid any maintenance downtime.\n\n- Major upgrades are optional until the service reaches end of service, and can be done in place.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli databases postgresql-update 123 \\\n  --label example-db \\\n  --allow_list 203.0.113.1 \\\n  --allow_list 192.0.1.0/24 \\\n  --type g6-standard-1 \\\n  --updates.frequency weekly \\\n  --updates.duration 3 \\\n  --updates.hour_of_day 12 \\\n  --updates.day_of_week 4 \\\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    databases:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Make changes to an existing PostgreSQL Managed Database.\n\n- The user needs `read_write` [user grant](https://techdocs.akamai.com/linode-api/reference/get-user-grants) access to the database.\n\n- The database's status needs to be `active`.\n\n- New values set in the `allow_list` overwrite existing values. To keep existing values, run the [List PostgreSQL Managed Databases](https://techdocs.akamai.com/linode-api/reference/get-databases-postgre-sql-instances) operation, store the `allow_list` addresses from the response, and include them with any new addresses in this operation.\n\n- Updates to your `allow_list` may take a short period of time to complete, making this operation inappropriate for rapid successive updates.\n\n- Also allows resizing the database cluster to a larger one. Clusters can't be resized to smaller plans.\n\n- All Managed Databases include automatic updates, which apply security patches to the underlying operating system of the Managed PostgreSQL Database. Use the `updates` object in this operation to modify the maintenance window for these updates.\n\n- If your database cluster is configured with a single node, downtime occurs during maintenance updates. Use the `updates` object to adjust the window to match a time that's the least disruptive to your application and users. Also consider upgrading to a [high availability](https://techdocs.akamai.com/cloud-computing/docs/managed-databases#high-availability) plan to avoid any maintenance downtime.\n\n- Major upgrades are optional until the service reaches end of service, and can be done in place.\n\n- You can't update `engine_config` advanced parameter settings for a suspended database. You'll need to [resume](https://techdocs.akamai.com/linode-api/reference/resume-databases-postgre-sql-instance) it first.\n\n- A successful request triggers a `database_update` [event](https://techdocs.akamai.com/linode-api/reference/get-events).\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli databases postgresql-update 123 \\\n  --label example-db \\\n  --allow_list 203.0.113.1 \\\n  --allow_list 192.0.1.0/24 \\\n  --type g6-standard-1 \\\n  --updates.frequency weekly \\\n  --updates.duration 3 \\\n  --updates.hour_of_day 12 \\\n  --updates.day_of_week 4 \\\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    databases:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/put-databases-postgre-sql-instance"
@@ -28224,6 +34763,74 @@
         "requestBody": {
           "content": {
             "application/json": {
+              "example": {
+                "allow_list": [
+                  "192.0.2.207/24",
+                  "192.0.2.134/24"
+                ],
+                "engine_config": {
+                  "pg": {
+                    "autovacuum_analyze_scale_factor": 1,
+                    "autovacuum_analyze_threshold": 2147483647,
+                    "autovacuum_max_workers": 20,
+                    "autovacuum_naptime": 86400,
+                    "autovacuum_vacuum_cost_delay": 100,
+                    "autovacuum_vacuum_cost_limit": 10000,
+                    "autovacuum_vacuum_scale_factor": 1,
+                    "autovacuum_vacuum_threshold": 2147483647,
+                    "bgwriter_delay": 200,
+                    "bgwriter_flush_after": 512,
+                    "bgwriter_lru_maxpages": 100,
+                    "bgwriter_lru_multiplier": 2.5,
+                    "deadlock_timeout": 1000,
+                    "default_toast_compression": "lz4",
+                    "idle_in_transaction_session_timeout": 604800000,
+                    "jit": true,
+                    "max_files_per_process": 1024,
+                    "max_locks_per_transaction": 1024,
+                    "max_logical_replication_workers": 64,
+                    "max_parallel_workers": 96,
+                    "max_parallel_workers_per_gather": 96,
+                    "max_pred_locks_per_transaction": 5120,
+                    "max_replication_slots": 64,
+                    "max_slot_wal_keep_size": 1000000,
+                    "max_stack_depth": 2097152,
+                    "max_standby_archive_delay": 1,
+                    "max_standby_streaming_delay": 10,
+                    "max_wal_senders": 20,
+                    "max_worker_processes": 96,
+                    "password_encryption": "scram-sha-256",
+                    "pg_partman_bgw.interval": 3600,
+                    "pg_partman_bgw.role": "myrolename",
+                    "pg_stat_monitor.pgsm_enable_query_plan": true,
+                    "pg_stat_monitor.pgsm_max_buckets": 10,
+                    "pg_stat_statements.track": "all",
+                    "temp_file_limit": 5000000,
+                    "timezone": "Europe/Helsinki",
+                    "track_activity_query_size": 1024,
+                    "track_commit_timestamp": "on",
+                    "track_functions": "on",
+                    "track_io_timing": "off",
+                    "wal_sender_timeout": 60000,
+                    "wal_writer_delay": 200
+                  },
+                  "pg_stat_monitor_enable": false,
+                  "pglookout": {
+                    "max_failover_replication_time_lag": 10
+                  },
+                  "shared_buffers_percentage": 41.5,
+                  "work_mem": 4
+                },
+                "label": "example-db",
+                "type": "g6-standard-1",
+                "updates": {
+                  "day_of_week": 1,
+                  "duration": 3,
+                  "frequency": "weekly",
+                  "hour_of_day": 0
+                },
+                "version": "13.2"
+              },
               "schema": {
                 "additionalProperties": false,
                 "description": "Updated information for the Managed PostgreSQL Database.",
@@ -28240,6 +34847,383 @@
                       "type": "string"
                     },
                     "type": "array"
+                  },
+                  "engine_config": {
+                    "additionalProperties": false,
+                    "description": "Advanced parameters you can apply to a PostgreSQL Managed Database, via our partner [Aiven's specification](https://aiven.io/docs/products/postgresql/reference/advanced-params). Only include the objects for parameters you want to set in your database. Omit objects for parameters you don't want to define or change.\n\n> \ud83d\udcd8\n>\n> Aiven may offer additional parameters in their specification. Currently, only those listed here are supported for use in a PostgreSQL Managed Database. You can also run the [List PostgreSQL Managed Database advanced parameters](https://techdocs.akamai.com/linode-api/reference/get-databases-postgresql-config) operation to see an up-to-date list.",
+                    "properties": {
+                      "pg": {
+                        "additionalProperties": false,
+                        "description": "PostgreSQL-specific advanced configuration parameters.",
+                        "properties": {
+                          "autovacuum_analyze_scale_factor": {
+                            "default": 0.2,
+                            "description": "Specifies a fraction of the table size to add to `autovacuum_analyze_threshold` when deciding whether to trigger an `ANALYZE`.",
+                            "example": 1,
+                            "maximum": 1,
+                            "minimum": 0,
+                            "type": "number"
+                          },
+                          "autovacuum_analyze_threshold": {
+                            "default": 50,
+                            "description": "Specifies the minimum number of inserted, updated, or deleted tuples needed to trigger an `ANALYZE` in any one table. The default is 50 tuples.",
+                            "example": 2147483647,
+                            "maximum": 2147483647,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "autovacuum_max_workers": {
+                            "default": 3,
+                            "description": "Specifies the maximum number of `autovacuum` processes, other than the `autovacuum` launcher, that may be running at any one time. This parameter can only be set at server start.",
+                            "example": 20,
+                            "maximum": 20,
+                            "minimum": 1,
+                            "type": "integer"
+                          },
+                          "autovacuum_naptime": {
+                            "default": 60,
+                            "description": "Specifies the minimum delay between `autovacuum` runs on any given database. The delay is measured in seconds, and the default is one minute.",
+                            "example": 86400,
+                            "maximum": 86400,
+                            "minimum": 1,
+                            "type": "integer"
+                          },
+                          "autovacuum_vacuum_cost_delay": {
+                            "default": 20,
+                            "description": "Specifies the cost delay value that will be used in automatic `VACUUM` operations. If `-1` is specified, the regular `vacuum_cost_delay` value will be used.",
+                            "example": 100,
+                            "maximum": 100,
+                            "minimum": -1,
+                            "type": "integer"
+                          },
+                          "autovacuum_vacuum_cost_limit": {
+                            "default": -1,
+                            "description": "Specifies the cost limit value that will be used in automatic `VACUUM` operations. If `-1` is specified, the regular `vacuum_cost_limit` value will be used.",
+                            "example": 10000,
+                            "maximum": 10000,
+                            "minimum": -1,
+                            "type": "integer"
+                          },
+                          "autovacuum_vacuum_scale_factor": {
+                            "default": 0.2,
+                            "description": "Specifies a fraction of the table size to add to `autovacuum_vacuum_threshold` when deciding whether to trigger a `VACUUM`.",
+                            "example": 1,
+                            "maximum": 1,
+                            "minimum": 0,
+                            "type": "number"
+                          },
+                          "autovacuum_vacuum_threshold": {
+                            "default": 50,
+                            "description": "Specifies the minimum number of updated or deleted tuples needed to trigger a `VACUUM` in any one table.",
+                            "example": 2147483647,
+                            "maximum": 2147483647,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "bgwriter_delay": {
+                            "default": 200,
+                            "description": "Specifies the delay between activity rounds for the background writer in milliseconds.",
+                            "example": 200,
+                            "maximum": 10000,
+                            "minimum": 20,
+                            "type": "integer"
+                          },
+                          "bgwriter_flush_after": {
+                            "default": 512,
+                            "description": "Whenever more than `bgwriter_flush_after` bytes have been written by the background writer, attempt to force the OS to issue these writes to the underlying storage. Specified in kilobytes. Setting of `0` disables forced writeback.",
+                            "example": 512,
+                            "maximum": 2048,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "bgwriter_lru_maxpages": {
+                            "default": 100,
+                            "description": "In each round, no more than this many buffers will be written by the background writer. Setting this to zero disables background writing.",
+                            "example": 100,
+                            "maximum": 1073741823,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "bgwriter_lru_multiplier": {
+                            "default": 2.5,
+                            "description": "The average recent need for new buffers is multiplied by bgwriter_lru_multiplier to arrive at an estimate of the number that will be needed during the next round, (up to `bgwriter_lru_maxpages`). `1.0` represents a `\\u201cjust` in `time\\u201d` policy of writing exactly the number of buffers predicted to be needed. Larger values provide some cushion against spikes in demand, while smaller values intentionally leave writes to be done by server processes.",
+                            "example": 2.5,
+                            "maximum": 10,
+                            "minimum": 0,
+                            "type": "number"
+                          },
+                          "deadlock_timeout": {
+                            "description": "This is the amount of time, in milliseconds, to wait on a lock before checking to see if there is a deadlock condition.",
+                            "example": 1000,
+                            "maximum": 1800000,
+                            "minimum": 500,
+                            "type": "integer"
+                          },
+                          "default_toast_compression": {
+                            "default": "lz4",
+                            "description": "Specifies the default TOAST compression method for values of compressible columns.",
+                            "enum": [
+                              "lz4",
+                              "pglz"
+                            ],
+                            "example": "lz4",
+                            "type": "string"
+                          },
+                          "idle_in_transaction_session_timeout": {
+                            "description": "Time out sessions with open transactions after this number of milliseconds.",
+                            "example": 604800000,
+                            "maximum": 604800000,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "jit": {
+                            "description": "Controls system-wide use of Just-in-Time Compilation (JIT).",
+                            "example": true,
+                            "type": "boolean"
+                          },
+                          "max_files_per_process": {
+                            "description": "PostgreSQL maximum number of files that can be open per process.",
+                            "example": 1024,
+                            "maximum": 4096,
+                            "minimum": 1000,
+                            "type": "integer"
+                          },
+                          "max_locks_per_transaction": {
+                            "description": "PostgreSQL maximum locks per transaction.",
+                            "example": 1024,
+                            "maximum": 6400,
+                            "minimum": 64,
+                            "type": "integer"
+                          },
+                          "max_logical_replication_workers": {
+                            "description": "PostgreSQL maximum logical replication workers, taken from the pool of `max_parallel_workers`.",
+                            "example": 64,
+                            "maximum": 64,
+                            "minimum": 4,
+                            "type": "integer"
+                          },
+                          "max_parallel_workers": {
+                            "description": "Sets the maximum number of workers that the system can support for parallel queries.",
+                            "example": 96,
+                            "maximum": 96,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "max_parallel_workers_per_gather": {
+                            "description": "Sets the maximum number of workers that can be started by a single Gather or Gather Merge node.",
+                            "example": 96,
+                            "maximum": 96,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "max_pred_locks_per_transaction": {
+                            "description": "PostgreSQL maximum predicate locks per transaction.",
+                            "example": 5120,
+                            "maximum": 5120,
+                            "minimum": 64,
+                            "type": "integer"
+                          },
+                          "max_replication_slots": {
+                            "description": "PostgreSQL maximum replication slots.",
+                            "example": 64,
+                            "maximum": 64,
+                            "minimum": 8,
+                            "type": "integer"
+                          },
+                          "max_slot_wal_keep_size": {
+                            "default": -1,
+                            "description": "PostgreSQL maximum write ahead log (WAL) size in MB, reserved for replication slots. A value of `-1` indicates unlimited. The `wal_keep_size` minimum write ahead log (WAL) size setting takes precedence over this.",
+                            "example": 1000000,
+                            "maximum": 2147483647,
+                            "minimum": -1,
+                            "type": "integer"
+                          },
+                          "max_stack_depth": {
+                            "description": "Maximum depth of the stack in bytes.",
+                            "example": 2097152,
+                            "maximum": 6291456,
+                            "minimum": 2097152,
+                            "type": "integer"
+                          },
+                          "max_standby_archive_delay": {
+                            "description": "Maximum standby archive delay in milliseconds.",
+                            "example": 1,
+                            "maximum": 43200000,
+                            "minimum": 1,
+                            "type": "integer"
+                          },
+                          "max_standby_streaming_delay": {
+                            "description": "Maximum standby streaming delay in milliseconds.",
+                            "example": 10,
+                            "maximum": 43200000,
+                            "minimum": 1,
+                            "type": "integer"
+                          },
+                          "max_wal_senders": {
+                            "description": "PostgreSQL maximum write ahead log (WAL) senders.",
+                            "example": 20,
+                            "maximum": 64,
+                            "minimum": 20,
+                            "type": "integer"
+                          },
+                          "max_worker_processes": {
+                            "description": "Maximum number of background processes that the system can support.",
+                            "example": 96,
+                            "maximum": 96,
+                            "minimum": 8,
+                            "type": "integer"
+                          },
+                          "password_encryption": {
+                            "default": "md5",
+                            "description": "Chooses the algorithm for encrypting passwords.",
+                            "enum": [
+                              "scram-sh-256",
+                              "md5"
+                            ],
+                            "example": "scram-sha-256",
+                            "type": "string"
+                          },
+                          "pg_partman_bgw.interval": {
+                            "description": "Sets the time interval to run `pg_partman` scheduled tasks.",
+                            "example": 3600,
+                            "maximum": 604800,
+                            "minimum": 3600,
+                            "type": "integer"
+                          },
+                          "pg_partman_bgw.role": {
+                            "description": "Controls which role to use for `pg_partman`` scheduled background tasks.",
+                            "example": "myrolename",
+                            "type": "string"
+                          },
+                          "pg_stat_monitor.pgsm_enable_query_plan": {
+                            "description": "Enables query plan monitoring.",
+                            "example": true,
+                            "type": "boolean"
+                          },
+                          "pg_stat_monitor.pgsm_max_buckets": {
+                            "description": "Sets the maximum number of buckets.",
+                            "example": 10,
+                            "maximum": 10,
+                            "minimum": 1,
+                            "type": "integer"
+                          },
+                          "pg_stat_statements.track": {
+                            "default": "top",
+                            "description": "Controls which statements are counted. Specify `top` to track top-level statements that are issued directly by clients, `all` to also track nested statements, such as those invoked within functions, or `none` to disable statement statistics collection.",
+                            "enum": [
+                              "all",
+                              "top",
+                              "none"
+                            ],
+                            "example": "all",
+                            "type": "string"
+                          },
+                          "temp_file_limit": {
+                            "description": "PostgreSQL temporary file limit in KB. Set to `-1` for unlimited.",
+                            "example": 5000000,
+                            "maximum": 2147483647,
+                            "minimum": -1,
+                            "type": "integer"
+                          },
+                          "timezone": {
+                            "description": "PostgreSQL service time zone.",
+                            "example": "Europe/Helsinki",
+                            "maxLength": 64,
+                            "pattern": "^[\\\\w/]*$",
+                            "type": "string"
+                          },
+                          "track_activity_query_size": {
+                            "description": "Specifies the number of bytes reserved to track the currently executing command for each active session.",
+                            "example": 1024,
+                            "maximum": 10240,
+                            "minimum": 1024,
+                            "type": "integer"
+                          },
+                          "track_commit_timestamp": {
+                            "description": "Record the commit time of transactions.",
+                            "enum": [
+                              "on",
+                              "off"
+                            ],
+                            "example": "on",
+                            "type": "string"
+                          },
+                          "track_functions": {
+                            "default": "none",
+                            "description": "Enables tracking of function call counts and time used. Specify `pl` to track only procedural-language functions, `all` to also track SQL and C language functions, or `none` to disable function statistics tracking.",
+                            "enum": [
+                              "all",
+                              "pl",
+                              "none"
+                            ],
+                            "example": "all",
+                            "type": "string"
+                          },
+                          "track_io_timing": {
+                            "default": "off",
+                            "description": "Enables timing of database I/O calls. This parameter is `off` by default, because it will repeatedly query the operating system for the current time, which may cause significant overhead on some platforms.",
+                            "enum": [
+                              "on",
+                              "off"
+                            ],
+                            "example": "off",
+                            "type": "string"
+                          },
+                          "wal_sender_timeout": {
+                            "description": "Terminate replication connections that are inactive for longer than this amount of time, in milliseconds. Setting this value to `0` disables the timeout.",
+                            "example": 60000,
+                            "maximum": 60000,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "wal_writer_delay": {
+                            "default": 200,
+                            "description": "Write ahead log (WAL) flush interval in milliseconds. A value lower than 200 milliseconds may negatively impact performance.",
+                            "example": 200,
+                            "maximum": 200,
+                            "minimum": 10,
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "pg_stat_monitor_enable": {
+                        "description": "Enable the `pg_stat_monitor` extension. When this extension is enabled, PostgreSQL restarts the cluster it's in. Additionally, `pg_stat_statements` results for utility commands are unreliable.",
+                        "example": false,
+                        "type": "boolean"
+                      },
+                      "pglookout": {
+                        "description": "Parameter used to apply PGLookout settings.",
+                        "properties": {
+                          "max_failover_replication_time_lag": {
+                            "description": "Number of seconds of master unavailability before triggering database failover to standby.",
+                            "example": 10,
+                            "maximum": 999999,
+                            "minimum": 10,
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "shared_buffers_percentage": {
+                        "description": "Percentage of total RAM that the database server uses for shared memory buffers. Valid range is 20-60 (float), which corresponds to 20% - 60%. This setting adjusts the `shared_buffers` configuration value.",
+                        "example": 41.5,
+                        "maximum": 60,
+                        "minimum": 20,
+                        "type": "number"
+                      },
+                      "work_mem": {
+                        "description": "Sets the maximum amount of memory in MB to be used by a query operation, such as a sort or hash table, before writing to temporary disk files. Default is 1MB + 0.075% of total RAM, up to 32 MB.",
+                        "example": 4,
+                        "maximum": 4,
+                        "minimum": 1,
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object",
+                    "x-akamai": {
+                      "file-path": "schemas/database-postgresql-engine-config.yaml"
+                    }
                   },
                   "label": {
                     "description": "__Filterable__ A unique, user-defined string referring to the Managed Database. This string needs to be unique per Managed Database engine type.",
@@ -28302,7 +35286,7 @@
                           "properties": {
                             "deadline": {
                               "description": "The time when a mandatory update needs to be applied.",
-                              "example": "2024-10-14 19:55:12",
+                              "example": "2024-10-14T19:55:12",
                               "format": "date-time",
                               "nullable": true,
                               "type": "string"
@@ -28314,7 +35298,7 @@
                             },
                             "planned_for": {
                               "description": "The date and time a maintenance update will be applied.",
-                              "example": "2024-10-14 19:55:12",
+                              "example": "2024-10-14T19:55:12",
                               "format": "date-time",
                               "nullable": true,
                               "type": "string"
@@ -28345,9 +35329,6 @@
                 "x-akamai": {
                   "file-path": "schemas/added-put-databases-postgre-sql-instance.yaml"
                 }
-              },
-              "x-example": {
-                "x-ref": "../examples/put-databases-postgre-sql-instance.json"
               }
             }
           },
@@ -28357,6 +35338,100 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "allow_list": [
+                    "192.0.2.133/24",
+                    "192.0.2.92/24"
+                  ],
+                  "cluster_size": 3,
+                  "created": "2022-01-01T00:01:01",
+                  "encrypted": true,
+                  "engine": "postgresql",
+                  "engine_config": {
+                    "pg": {
+                      "autovacuum_analyze_scale_factor": 1,
+                      "autovacuum_analyze_threshold": 2147483647,
+                      "autovacuum_max_workers": 20,
+                      "autovacuum_naptime": 86400,
+                      "autovacuum_vacuum_cost_delay": 100,
+                      "autovacuum_vacuum_cost_limit": 10000,
+                      "autovacuum_vacuum_scale_factor": 1,
+                      "autovacuum_vacuum_threshold": 2147483647,
+                      "bgwriter_delay": 200,
+                      "bgwriter_flush_after": 512,
+                      "bgwriter_lru_maxpages": 100,
+                      "bgwriter_lru_multiplier": 2.5,
+                      "deadlock_timeout": 1000,
+                      "default_toast_compression": "lz4",
+                      "idle_in_transaction_session_timeout": 604800000,
+                      "max_files_per_process": 1024,
+                      "max_locks_per_transaction": 1024,
+                      "max_logical_replication_workers": 64,
+                      "max_parallel_workers": 96,
+                      "max_parallel_workers_per_gather": 96,
+                      "max_pred_locks_per_transaction": 5120,
+                      "max_replication_slots": 64,
+                      "max_slot_wal_keep_size": 1000000,
+                      "max_stack_depth": 2097152,
+                      "max_standby_archive_delay": 1,
+                      "max_standby_streaming_delay": 10,
+                      "max_wal_senders": 20,
+                      "max_worker_processes": 96,
+                      "password_encryption": "scram-sha-256",
+                      "pg_partman_bgw.interval": 3600,
+                      "pg_partman_bgw.role": "myrolename",
+                      "pg_stat_monitor.pgsm_enable_query_plan": true,
+                      "pg_stat_monitor.pgsm_max_buckets": 10,
+                      "pg_stat_statements.track": "all",
+                      "temp_file_limit": 5000000,
+                      "timezone": "Europe/Helsinki",
+                      "track_activity_query_size": 1024,
+                      "track_commit_timestamp": "on",
+                      "track_functions": "on",
+                      "track_io_timing": "off",
+                      "wal_sender_timeout": 60000,
+                      "wal_writer_delay": 200
+                    },
+                    "pg_stat_monitor_enable": false,
+                    "pglookout": {
+                      "max_failover_replication_time_lag": 10
+                    },
+                    "shared_buffers_percentage": 41.5,
+                    "work_mem": 4
+                  },
+                  "fork": {
+                    "restore_time": "2024-10-14T19:55:12",
+                    "source": 176881
+                  },
+                  "hosts": {
+                    "primary": "lin-0000-000-pgsql-primary.servers.linodedb.net",
+                    "secondary": "lin-0000-000-pgsql-primary-private.servers.linodedb.net"
+                  },
+                  "id": 123,
+                  "label": "example-db",
+                  "members": {
+                    "45.56.110.70": "primary",
+                    "45.79.159.239": "failover"
+                  },
+                  "oldest_restore_time": "2024-10-03T20:48:05",
+                  "platform": "rdbms-default",
+                  "port": 3306,
+                  "region": "us-east",
+                  "ssl_connection": true,
+                  "status": "active",
+                  "total_disk_size_gb": 15,
+                  "type": "g6-dedicated-2",
+                  "updated": "2022-01-01T00:01:01",
+                  "updates": {
+                    "day_of_week": 1,
+                    "duration": 3,
+                    "frequency": "weekly",
+                    "hour_of_day": 0,
+                    "pending": []
+                  },
+                  "used_disk_size_gb": 2,
+                  "version": "13.2"
+                },
                 "schema": {
                   "additionalProperties": false,
                   "description": "Managed PostgreSQL Databases object.",
@@ -28413,9 +35488,387 @@
                       "x-linode-cli-display": 6,
                       "x-linode-filterable": true
                     },
+                    "engine_config": {
+                      "additionalProperties": false,
+                      "description": "Advanced parameters you can apply to a PostgreSQL Managed Database, via our partner [Aiven's specification](https://aiven.io/docs/products/postgresql/reference/advanced-params). Only include the objects for parameters you want to set in your database. Omit objects for parameters you don't want to define or change.\n\n> \ud83d\udcd8\n>\n> Aiven may offer additional parameters in their specification. Currently, only those listed here are supported for use in a PostgreSQL Managed Database. You can also run the [List PostgreSQL Managed Database advanced parameters](https://techdocs.akamai.com/linode-api/reference/get-databases-postgresql-config) operation to see an up-to-date list.",
+                      "properties": {
+                        "pg": {
+                          "additionalProperties": false,
+                          "description": "PostgreSQL-specific advanced configuration parameters.",
+                          "properties": {
+                            "autovacuum_analyze_scale_factor": {
+                              "default": 0.2,
+                              "description": "Specifies a fraction of the table size to add to `autovacuum_analyze_threshold` when deciding whether to trigger an `ANALYZE`.",
+                              "example": 1,
+                              "maximum": 1,
+                              "minimum": 0,
+                              "type": "number"
+                            },
+                            "autovacuum_analyze_threshold": {
+                              "default": 50,
+                              "description": "Specifies the minimum number of inserted, updated, or deleted tuples needed to trigger an `ANALYZE` in any one table. The default is 50 tuples.",
+                              "example": 2147483647,
+                              "maximum": 2147483647,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "autovacuum_max_workers": {
+                              "default": 3,
+                              "description": "Specifies the maximum number of `autovacuum` processes, other than the `autovacuum` launcher, that may be running at any one time. This parameter can only be set at server start.",
+                              "example": 20,
+                              "maximum": 20,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "autovacuum_naptime": {
+                              "default": 60,
+                              "description": "Specifies the minimum delay between `autovacuum` runs on any given database. The delay is measured in seconds, and the default is one minute.",
+                              "example": 86400,
+                              "maximum": 86400,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "autovacuum_vacuum_cost_delay": {
+                              "default": 20,
+                              "description": "Specifies the cost delay value that will be used in automatic `VACUUM` operations. If `-1` is specified, the regular `vacuum_cost_delay` value will be used.",
+                              "example": 100,
+                              "maximum": 100,
+                              "minimum": -1,
+                              "type": "integer"
+                            },
+                            "autovacuum_vacuum_cost_limit": {
+                              "default": -1,
+                              "description": "Specifies the cost limit value that will be used in automatic `VACUUM` operations. If `-1` is specified, the regular `vacuum_cost_limit` value will be used.",
+                              "example": 10000,
+                              "maximum": 10000,
+                              "minimum": -1,
+                              "type": "integer"
+                            },
+                            "autovacuum_vacuum_scale_factor": {
+                              "default": 0.2,
+                              "description": "Specifies a fraction of the table size to add to `autovacuum_vacuum_threshold` when deciding whether to trigger a `VACUUM`.",
+                              "example": 1,
+                              "maximum": 1,
+                              "minimum": 0,
+                              "type": "number"
+                            },
+                            "autovacuum_vacuum_threshold": {
+                              "default": 50,
+                              "description": "Specifies the minimum number of updated or deleted tuples needed to trigger a `VACUUM` in any one table.",
+                              "example": 2147483647,
+                              "maximum": 2147483647,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "bgwriter_delay": {
+                              "default": 200,
+                              "description": "Specifies the delay between activity rounds for the background writer in milliseconds.",
+                              "example": 200,
+                              "maximum": 10000,
+                              "minimum": 20,
+                              "type": "integer"
+                            },
+                            "bgwriter_flush_after": {
+                              "default": 512,
+                              "description": "Whenever more than `bgwriter_flush_after` bytes have been written by the background writer, attempt to force the OS to issue these writes to the underlying storage. Specified in kilobytes. Setting of `0` disables forced writeback.",
+                              "example": 512,
+                              "maximum": 2048,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "bgwriter_lru_maxpages": {
+                              "default": 100,
+                              "description": "In each round, no more than this many buffers will be written by the background writer. Setting this to zero disables background writing.",
+                              "example": 100,
+                              "maximum": 1073741823,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "bgwriter_lru_multiplier": {
+                              "default": 2.5,
+                              "description": "The average recent need for new buffers is multiplied by bgwriter_lru_multiplier to arrive at an estimate of the number that will be needed during the next round, (up to `bgwriter_lru_maxpages`). `1.0` represents a `\\u201cjust` in `time\\u201d` policy of writing exactly the number of buffers predicted to be needed. Larger values provide some cushion against spikes in demand, while smaller values intentionally leave writes to be done by server processes.",
+                              "example": 2.5,
+                              "maximum": 10,
+                              "minimum": 0,
+                              "type": "number"
+                            },
+                            "deadlock_timeout": {
+                              "description": "This is the amount of time, in milliseconds, to wait on a lock before checking to see if there is a deadlock condition.",
+                              "example": 1000,
+                              "maximum": 1800000,
+                              "minimum": 500,
+                              "type": "integer"
+                            },
+                            "default_toast_compression": {
+                              "default": "lz4",
+                              "description": "Specifies the default TOAST compression method for values of compressible columns.",
+                              "enum": [
+                                "lz4",
+                                "pglz"
+                              ],
+                              "example": "lz4",
+                              "type": "string"
+                            },
+                            "idle_in_transaction_session_timeout": {
+                              "description": "Time out sessions with open transactions after this number of milliseconds.",
+                              "example": 604800000,
+                              "maximum": 604800000,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "jit": {
+                              "description": "Controls system-wide use of Just-in-Time Compilation (JIT).",
+                              "example": true,
+                              "type": "boolean"
+                            },
+                            "max_files_per_process": {
+                              "description": "PostgreSQL maximum number of files that can be open per process.",
+                              "example": 1024,
+                              "maximum": 4096,
+                              "minimum": 1000,
+                              "type": "integer"
+                            },
+                            "max_locks_per_transaction": {
+                              "description": "PostgreSQL maximum locks per transaction.",
+                              "example": 1024,
+                              "maximum": 6400,
+                              "minimum": 64,
+                              "type": "integer"
+                            },
+                            "max_logical_replication_workers": {
+                              "description": "PostgreSQL maximum logical replication workers, taken from the pool of `max_parallel_workers`.",
+                              "example": 64,
+                              "maximum": 64,
+                              "minimum": 4,
+                              "type": "integer"
+                            },
+                            "max_parallel_workers": {
+                              "description": "Sets the maximum number of workers that the system can support for parallel queries.",
+                              "example": 96,
+                              "maximum": 96,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "max_parallel_workers_per_gather": {
+                              "description": "Sets the maximum number of workers that can be started by a single Gather or Gather Merge node.",
+                              "example": 96,
+                              "maximum": 96,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "max_pred_locks_per_transaction": {
+                              "description": "PostgreSQL maximum predicate locks per transaction.",
+                              "example": 5120,
+                              "maximum": 5120,
+                              "minimum": 64,
+                              "type": "integer"
+                            },
+                            "max_replication_slots": {
+                              "description": "PostgreSQL maximum replication slots.",
+                              "example": 64,
+                              "maximum": 64,
+                              "minimum": 8,
+                              "type": "integer"
+                            },
+                            "max_slot_wal_keep_size": {
+                              "default": -1,
+                              "description": "PostgreSQL maximum write ahead log (WAL) size in MB, reserved for replication slots. A value of `-1` indicates unlimited. The `wal_keep_size` minimum write ahead log (WAL) size setting takes precedence over this.",
+                              "example": 1000000,
+                              "maximum": 2147483647,
+                              "minimum": -1,
+                              "type": "integer"
+                            },
+                            "max_stack_depth": {
+                              "description": "Maximum depth of the stack in bytes.",
+                              "example": 2097152,
+                              "maximum": 6291456,
+                              "minimum": 2097152,
+                              "type": "integer"
+                            },
+                            "max_standby_archive_delay": {
+                              "description": "Maximum standby archive delay in milliseconds.",
+                              "example": 1,
+                              "maximum": 43200000,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "max_standby_streaming_delay": {
+                              "description": "Maximum standby streaming delay in milliseconds.",
+                              "example": 10,
+                              "maximum": 43200000,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "max_wal_senders": {
+                              "description": "PostgreSQL maximum write ahead log (WAL) senders.",
+                              "example": 20,
+                              "maximum": 64,
+                              "minimum": 20,
+                              "type": "integer"
+                            },
+                            "max_worker_processes": {
+                              "description": "Maximum number of background processes that the system can support.",
+                              "example": 96,
+                              "maximum": 96,
+                              "minimum": 8,
+                              "type": "integer"
+                            },
+                            "password_encryption": {
+                              "default": "md5",
+                              "description": "Chooses the algorithm for encrypting passwords.",
+                              "enum": [
+                                "scram-sh-256",
+                                "md5"
+                              ],
+                              "example": "scram-sha-256",
+                              "type": "string"
+                            },
+                            "pg_partman_bgw.interval": {
+                              "description": "Sets the time interval to run `pg_partman` scheduled tasks.",
+                              "example": 3600,
+                              "maximum": 604800,
+                              "minimum": 3600,
+                              "type": "integer"
+                            },
+                            "pg_partman_bgw.role": {
+                              "description": "Controls which role to use for `pg_partman`` scheduled background tasks.",
+                              "example": "myrolename",
+                              "type": "string"
+                            },
+                            "pg_stat_monitor.pgsm_enable_query_plan": {
+                              "description": "Enables query plan monitoring.",
+                              "example": true,
+                              "type": "boolean"
+                            },
+                            "pg_stat_monitor.pgsm_max_buckets": {
+                              "description": "Sets the maximum number of buckets.",
+                              "example": 10,
+                              "maximum": 10,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "pg_stat_statements.track": {
+                              "default": "top",
+                              "description": "Controls which statements are counted. Specify `top` to track top-level statements that are issued directly by clients, `all` to also track nested statements, such as those invoked within functions, or `none` to disable statement statistics collection.",
+                              "enum": [
+                                "all",
+                                "top",
+                                "none"
+                              ],
+                              "example": "all",
+                              "type": "string"
+                            },
+                            "temp_file_limit": {
+                              "description": "PostgreSQL temporary file limit in KB. Set to `-1` for unlimited.",
+                              "example": 5000000,
+                              "maximum": 2147483647,
+                              "minimum": -1,
+                              "type": "integer"
+                            },
+                            "timezone": {
+                              "description": "PostgreSQL service time zone.",
+                              "example": "Europe/Helsinki",
+                              "maxLength": 64,
+                              "pattern": "^[\\\\w/]*$",
+                              "type": "string"
+                            },
+                            "track_activity_query_size": {
+                              "description": "Specifies the number of bytes reserved to track the currently executing command for each active session.",
+                              "example": 1024,
+                              "maximum": 10240,
+                              "minimum": 1024,
+                              "type": "integer"
+                            },
+                            "track_commit_timestamp": {
+                              "description": "Record the commit time of transactions.",
+                              "enum": [
+                                "on",
+                                "off"
+                              ],
+                              "example": "on",
+                              "type": "string"
+                            },
+                            "track_functions": {
+                              "default": "none",
+                              "description": "Enables tracking of function call counts and time used. Specify `pl` to track only procedural-language functions, `all` to also track SQL and C language functions, or `none` to disable function statistics tracking.",
+                              "enum": [
+                                "all",
+                                "pl",
+                                "none"
+                              ],
+                              "example": "all",
+                              "type": "string"
+                            },
+                            "track_io_timing": {
+                              "default": "off",
+                              "description": "Enables timing of database I/O calls. This parameter is `off` by default, because it will repeatedly query the operating system for the current time, which may cause significant overhead on some platforms.",
+                              "enum": [
+                                "on",
+                                "off"
+                              ],
+                              "example": "off",
+                              "type": "string"
+                            },
+                            "wal_sender_timeout": {
+                              "description": "Terminate replication connections that are inactive for longer than this amount of time, in milliseconds. Setting this value to `0` disables the timeout.",
+                              "example": 60000,
+                              "maximum": 60000,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "wal_writer_delay": {
+                              "default": 200,
+                              "description": "Write ahead log (WAL) flush interval in milliseconds. A value lower than 200 milliseconds may negatively impact performance.",
+                              "example": 200,
+                              "maximum": 200,
+                              "minimum": 10,
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "pg_stat_monitor_enable": {
+                          "description": "Enable the `pg_stat_monitor` extension. When this extension is enabled, PostgreSQL restarts the cluster it's in. Additionally, `pg_stat_statements` results for utility commands are unreliable.",
+                          "example": false,
+                          "type": "boolean"
+                        },
+                        "pglookout": {
+                          "description": "Parameter used to apply PGLookout settings.",
+                          "properties": {
+                            "max_failover_replication_time_lag": {
+                              "description": "Number of seconds of master unavailability before triggering database failover to standby.",
+                              "example": 10,
+                              "maximum": 999999,
+                              "minimum": 10,
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "shared_buffers_percentage": {
+                          "description": "Percentage of total RAM that the database server uses for shared memory buffers. Valid range is 20-60 (float), which corresponds to 20% - 60%. This setting adjusts the `shared_buffers` configuration value.",
+                          "example": 41.5,
+                          "maximum": 60,
+                          "minimum": 20,
+                          "type": "number"
+                        },
+                        "work_mem": {
+                          "description": "Sets the maximum amount of memory in MB to be used by a query operation, such as a sort or hash table, before writing to temporary disk files. Default is 1MB + 0.075% of total RAM, up to 32 MB.",
+                          "example": 4,
+                          "maximum": 4,
+                          "minimum": 1,
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "x-akamai": {
+                        "file-path": "schemas/database-postgresql-engine-config.yaml"
+                      },
+                      "x-linode-cli-display": 7
+                    },
                     "fork": {
                       "additionalProperties": false,
-                      "description": "Details on the database that was the target of the fork. Only exists if the database was forked from another.",
+                      "description": "Details on the database that was the target of the fork. This only exists if the database was restored by creating a fork from another [MySQL](https://techdocs.akamai.com/linode-api/reference/post-databases-mysql-instances) or [PostgreSQL](https://techdocs.akamai.com/linode-api/reference/post-databases-postgre-sql-instances) database.",
                       "properties": {
                         "restore_time": {
                           "description": "The database timestamp from which it was restored. This is _not_ when the fork was created.",
@@ -28525,7 +35978,7 @@
                     },
                     "ssl_connection": {
                       "default": true,
-                      "description": "Currently required to be `true`. Whether to require SSL credentials to establish a connection to the Managed Database.\n\nRun the [Get managed PostgreSQL database credentials](https://techdocs.akamai.com/linode-api/reference/get-databases-postgre-sql-instance-credentials) operation for access information.",
+                      "description": "Currently required to be `true`. Whether to require SSL credentials to establish a connection to the Managed Database. Run the [Get managed PostgreSQL database credentials](https://techdocs.akamai.com/linode-api/reference/get-databases-postgre-sql-instance-credentials) operation for access information.",
                       "example": true,
                       "type": "boolean"
                     },
@@ -28629,7 +36082,7 @@
                             "properties": {
                               "deadline": {
                                 "description": "The time when a mandatory update needs to be applied.",
-                                "example": "2024-10-14 19:55:12",
+                                "example": "2024-10-14T19:55:12",
                                 "format": "date-time",
                                 "nullable": true,
                                 "type": "string"
@@ -28641,7 +36094,7 @@
                               },
                               "planned_for": {
                                 "description": "The date and time a maintenance update will be applied.",
-                                "example": "2024-10-14 19:55:12",
+                                "example": "2024-10-14T19:55:12",
                                 "format": "date-time",
                                 "nullable": true,
                                 "type": "string"
@@ -28678,9 +36131,6 @@
                   "x-akamai": {
                     "file-path": "schemas/database-postgresql.yaml"
                   }
-                },
-                "x-example": {
-                  "x-ref": "../examples/get-databases-postgre-sql-instance-200.json"
                 }
               }
             },
@@ -29173,7 +36623,7 @@
     },
     "/{apiVersion}/databases/postgresql/instances/{instanceId}/patch": {
       "post": {
-        "description": "Apply security patches and updates to the underlying operating system of the PostgreSQL Managed Database. This function runs during regular maintenance windows, which you can configure with the [Update a managed PostgreSQL database](https://techdocs.akamai.com/linode-api/reference/put-databases-postgre-sql-instance) operation.\n\n- The user needs `read_write` [user grant](https://techdocs.akamai.com/linode-api/reference/get-user-grants) access to the database.\n\n- The database's status needs to be `active`.\n\n- If your database cluster is configured with a single node, downtime occurs during maintenance updates. Consider upgrading to a [high availability](https://techdocs.akamai.com/cloud-computing/docs/managed-databases#high-availability) plan to avoid any maintenance downtime.\n\n- Major upgrades are optional until the service reaches end of service, and can be done in place.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli databases postgresql-patch 123\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    databases:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Apply security patches and updates to the underlying operating system of the PostgreSQL Managed Database. This function runs during regular maintenance windows, which you can configure with the [Update a managed PostgreSQL database](https://techdocs.akamai.com/linode-api/reference/put-databases-postgre-sql-instance) operation.\n\n- The user needs `read_write` [user grant](https://techdocs.akamai.com/linode-api/reference/get-user-grants) access to the database.\n\n- The database's status needs to be `active`.\n\n- If your database cluster is configured with a single node, downtime occurs during maintenance updates. Consider upgrading to a [high availability](https://techdocs.akamai.com/cloud-computing/docs/managed-databases#high-availability) plan to avoid any maintenance downtime.\n\n- Major upgrades are optional until the service reaches end of service, and can be done in place.\n\n- A successful request triggers a `database_upgrade` [event](https://techdocs.akamai.com/linode-api/reference/get-events).\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli databases postgresql-patch 123\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    databases:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/post-databases-postgre-sql-instance-patch"
@@ -29307,7 +36757,7 @@
     },
     "/{apiVersion}/databases/postgresql/instances/{instanceId}/resume": {
       "post": {
-        "description": "Resume a suspended PostgreSQL Managed Database from your account. This resumes billing for the cluster.\n\n- The user needs `read_write` [user grant](https://techdocs.akamai.com/linode-api/reference/get-user-grants) access to the database.\n\n- The database's status needs to be `suspended`.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    databases:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Resume a suspended PostgreSQL Managed Database from your account. This resumes billing for the cluster.\n\n- The user needs `read_write` [user grant](https://techdocs.akamai.com/linode-api/reference/get-user-grants) access to the database.\n\n- The database's status needs to be `suspended`.\n\n- A successful request triggers a `database_resume` [event](https://techdocs.akamai.com/linode-api/reference/get-events).\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    databases:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/resume-databases-postgre-sql-instance"
@@ -29578,7 +37028,7 @@
     },
     "/{apiVersion}/databases/postgresql/instances/{instanceId}/suspend": {
       "post": {
-        "description": "Suspend a PostgreSQL Managed Database from your account, releasing idle resources and keeping only necessary data. All service data is lost if there are no backups available. This halts billing for the cluster.\n\n- The user needs `read_write` [user grant](https://techdocs.akamai.com/linode-api/reference/get-user-grants) access to the database.\n\n- The database's status needs to be `active`.\n\n- Akamai deletes suspended clusters after 180 days.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    databases:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Suspend a PostgreSQL Managed Database from your account, releasing idle resources and keeping only necessary data. All service data is lost if there are no backups available. This halts billing for the cluster.\n\n- The user needs `read_write` [user grant](https://techdocs.akamai.com/linode-api/reference/get-user-grants) access to the database.\n\n- The database's status needs to be `active`.\n\n- Akamai deletes suspended clusters after 180 days.\n\n- A successful request triggers a `database_suspend` [event](https://techdocs.akamai.com/linode-api/reference/get-events).\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    databases:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/suspend-databases-postgre-sql-instance"
@@ -36753,15 +44203,12 @@
                         "writeOnly": true
                       },
                       "disk_encryption": {
-                        "description": "__Limited availability__ Local disk encryption ensures that your data stored on Linodes is secured. Disk encryption protects against unauthorized data access by keeping the data encrypted if the disk is ever removed from the data center, decommissioned, or disposed of. The platform manages the encryption and decryption for you.\n\nBy default, encryption is `enabled` on all Linodes. If you opted out of encryption or if the Linode was created prior to local disk encryption support, you can encrypt your data using [Rebuild](https://techdocs.akamai.com/linode-api/reference/post-rebuild-linode-instance).",
+                        "description": "Local disk encryption ensures that your data stored on Linodes is secured. Disk encryption protects against unauthorized data access by keeping the data encrypted if the disk is ever removed from the data center, decommissioned, or disposed of. The platform manages the encryption and decryption for you.\n\nBy default, encryption is `enabled` on all Linodes. If you opted out of encryption or if the Linode was created prior to local disk encryption support, you can encrypt your data using [Rebuild](https://techdocs.akamai.com/linode-api/reference/post-rebuild-linode-instance).",
                         "enum": [
                           "enabled",
                           "disabled"
                         ],
                         "type": "string",
-                        "x-akamai": {
-                          "status": "LA"
-                        },
                         "x-linode-cli-display": 8
                       },
                       "image": {
@@ -37578,14 +45025,11 @@
                     },
                     "disk_encryption": {
                       "default": "enabled",
-                      "description": "__Limited availability__, __Read-only__ Indicates the local disk encryption setting for this Linode. If the Linode is part of an LKE cluster, the value is `null`.",
+                      "description": "__Read-only__ Indicates the local disk encryption setting for this Linode. If the Linode is part of an LKE cluster, the value is `null`.",
                       "example": "disabled",
                       "nullable": true,
                       "readOnly": true,
                       "type": "string",
-                      "x-akamai": {
-                        "status": "LA"
-                      },
                       "x-linode-cli-display": 8
                     },
                     "group": {
@@ -38244,7 +45688,7 @@
                           },
                           "disk_encryption": {
                             "default": "enabled",
-                            "description": "__Limited availability__, __Read-only__ Indicates the local disk encryption setting for this Linode. If the Linode is part of an LKE cluster, the value is `null`.",
+                            "description": "__Read-only__ Indicates the local disk encryption setting for this Linode. If the Linode is part of an LKE cluster, the value is `null`.",
                             "enum": [
                               "enabled",
                               "disabled"
@@ -38253,9 +45697,6 @@
                             "nullable": true,
                             "readOnly": true,
                             "type": "string",
-                            "x-akamai": {
-                              "status": "LA"
-                            },
                             "x-linode-cli-display": 8
                           },
                           "group": {
@@ -38279,7 +45720,7 @@
                           },
                           "host_uuid": {
                             "description": "__Read-only__ The Linode's host machine, as a UUID.",
-                            "example": "3a3ddd59d9a78bb8de041391075df44de62bfec8",
+                            "example": "1a2bcd34e5f67gh8ij901234567kl89mn01opqr2",
                             "format": "uuid",
                             "readOnly": true,
                             "type": "string"
@@ -38839,7 +46280,7 @@
                     },
                     "disk_encryption": {
                       "default": "enabled",
-                      "description": "__Limited availability__, __Read-only__ Indicates the local disk encryption setting for this Linode. If the Linode is part of an LKE cluster, the value is `null`.",
+                      "description": "__Read-only__ Indicates the local disk encryption setting for this Linode. If the Linode is part of an LKE cluster, the value is `null`.",
                       "enum": [
                         "enabled",
                         "disabled"
@@ -38848,9 +46289,6 @@
                       "nullable": true,
                       "readOnly": true,
                       "type": "string",
-                      "x-akamai": {
-                        "status": "LA"
-                      },
                       "x-linode-cli-display": 8
                     },
                     "group": {
@@ -38874,7 +46312,7 @@
                     },
                     "host_uuid": {
                       "description": "__Read-only__ The Linode's host machine, as a UUID.",
-                      "example": "3a3ddd59d9a78bb8de041391075df44de62bfec8",
+                      "example": "1a2bcd34e5f67gh8ij901234567kl89mn01opqr2",
                       "format": "uuid",
                       "readOnly": true,
                       "type": "string"
@@ -39440,14 +46878,11 @@
                   },
                   "disk_encryption": {
                     "default": "enabled",
-                    "description": "__Limited availability__, __Read-only__ Indicates the local disk encryption setting for this Linode. If the Linode is part of an LKE cluster, the value is `null`.",
+                    "description": "__Read-only__ Indicates the local disk encryption setting for this Linode. If the Linode is part of an LKE cluster, the value is `null`.",
                     "example": "{{disk_encryption}}",
                     "nullable": true,
                     "readOnly": true,
                     "type": "string",
-                    "x-akamai": {
-                      "status": "LA"
-                    },
                     "x-linode-cli-display": 8
                   },
                   "group": {
@@ -39899,14 +47334,11 @@
                     },
                     "disk_encryption": {
                       "default": "enabled",
-                      "description": "__Limited availability__, __Read-only__ Indicates the local disk encryption setting for this Linode. If the Linode is part of an LKE cluster, the value is `null`.",
+                      "description": "__Read-only__ Indicates the local disk encryption setting for this Linode. If the Linode is part of an LKE cluster, the value is `null`.",
                       "example": "disabled",
                       "nullable": true,
                       "readOnly": true,
                       "type": "string",
-                      "x-akamai": {
-                        "status": "LA"
-                      },
                       "x-linode-cli-display": 8
                     },
                     "group": {
@@ -42465,14 +49897,11 @@
                     },
                     "disk_encryption": {
                       "default": "enabled",
-                      "description": "__Limited availability__, __Read-only__ Indicates the local disk encryption setting for this Linode. If the Linode is part of an LKE cluster, the value is `null`.",
+                      "description": "__Read-only__ Indicates the local disk encryption setting for this Linode. If the Linode is part of an LKE cluster, the value is `null`.",
                       "example": "disabled",
                       "nullable": true,
                       "readOnly": true,
                       "type": "string",
-                      "x-akamai": {
-                        "status": "LA"
-                      },
                       "x-linode-cli-display": 8
                     },
                     "group": {
@@ -47906,13 +55335,10 @@
                     },
                     "disk_encryption": {
                       "default": "enabled",
-                      "description": "__Limited availability__, __Read-only__ Displays if encryption is enabled on this disk. This setting is based on the `disk_encryption` setting of the Linode.",
+                      "description": "__Read-only__ Displays if encryption is enabled on this disk. This setting is based on the `disk_encryption` setting of the Linode.",
                       "example": "disabled",
                       "readOnly": true,
                       "type": "string",
-                      "x-akamai": {
-                        "status": "LA"
-                      },
                       "x-linode-cli-display": 6
                     },
                     "filesystem": {
@@ -48127,13 +55553,10 @@
                           },
                           "disk_encryption": {
                             "default": "enabled",
-                            "description": "__Limited availability__, __Read-only__ Displays if encryption is enabled on this disk. This setting is based on the `disk_encryption` setting of the Linode.",
+                            "description": "__Read-only__ Displays if encryption is enabled on this disk. This setting is based on the `disk_encryption` setting of the Linode.",
                             "example": "disabled",
                             "readOnly": true,
                             "type": "string",
-                            "x-akamai": {
-                              "status": "LA"
-                            },
                             "x-linode-cli-display": 6
                           },
                           "filesystem": {
@@ -48377,13 +55800,10 @@
                     },
                     "disk_encryption": {
                       "default": "enabled",
-                      "description": "__Limited availability__, __Read-only__ Displays if encryption is enabled on this disk. This setting is based on the `disk_encryption` setting of the Linode.",
+                      "description": "__Read-only__ Displays if encryption is enabled on this disk. This setting is based on the `disk_encryption` setting of the Linode.",
                       "example": "disabled",
                       "readOnly": true,
                       "type": "string",
-                      "x-akamai": {
-                        "status": "LA"
-                      },
                       "x-linode-cli-display": 6
                     },
                     "filesystem": {
@@ -48595,13 +56015,10 @@
                     },
                     "disk_encryption": {
                       "default": "enabled",
-                      "description": "__Limited availability__, __Read-only__ Displays if encryption is enabled on this disk. This setting is based on the `disk_encryption` setting of the Linode.",
+                      "description": "__Read-only__ Displays if encryption is enabled on this disk. This setting is based on the `disk_encryption` setting of the Linode.",
                       "example": "disabled",
                       "readOnly": true,
                       "type": "string",
-                      "x-akamai": {
-                        "status": "LA"
-                      },
                       "x-linode-cli-display": 6
                     },
                     "filesystem": {
@@ -48927,13 +56344,10 @@
                     },
                     "disk_encryption": {
                       "default": "enabled",
-                      "description": "__Limited availability__, __Read-only__ Displays if encryption is enabled on this disk. This setting is based on the `disk_encryption` setting of the Linode.",
+                      "description": "__Read-only__ Displays if encryption is enabled on this disk. This setting is based on the `disk_encryption` setting of the Linode.",
                       "example": "disabled",
                       "readOnly": true,
                       "type": "string",
-                      "x-akamai": {
-                        "status": "LA"
-                      },
                       "x-linode-cli-display": 6
                     },
                     "filesystem": {
@@ -52321,7 +59735,7 @@
     },
     "/{apiVersion}/linode/instances/{linodeId}/interfaces/settings": {
       "get": {
-        "description": "Lists a Linode's interface settings, including Network Helper and default route settings. This operation is for Linode interfaces, not for legacy configuration profile interfaces.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli linodes interfaces-settings-list $linodeId\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    linodes: read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "__Beta__ Lists a Linode's interface settings, including Network Helper and default route settings. This operation is for Linode interfaces, not for legacy configuration profile interfaces.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli linodes interfaces-settings-list $linodeId\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    linodes: read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-linode-interface-settings"
@@ -52457,6 +59871,7 @@
           "Linode interfaces"
         ],
         "x-akamai": {
+          "status": "BETA",
           "tabs": [
             {
               "syntax": "linode-cli linodes interfaces-settings-list $linodeId",
@@ -57807,15 +65222,12 @@
                         "writeOnly": true
                       },
                       "disk_encryption": {
-                        "description": "__Limited availability__ Local disk encryption ensures that your data stored on Linodes is secured. Disk encryption protects against unauthorized data access by keeping the data encrypted if the disk is ever removed from the data center, decommissioned, or disposed of. The platform manages the encryption and decryption for you.\n\nBy default, encryption is `enabled` on all Linodes. If you opted out of encryption or if the Linode was created prior to local disk encryption support, you can encrypt your data using [Rebuild](https://techdocs.akamai.com/linode-api/reference/post-rebuild-linode-instance).",
+                        "description": "Local disk encryption ensures that your data stored on Linodes is secured. Disk encryption protects against unauthorized data access by keeping the data encrypted if the disk is ever removed from the data center, decommissioned, or disposed of. The platform manages the encryption and decryption for you.\n\nBy default, encryption is `enabled` on all Linodes. If you opted out of encryption or if the Linode was created prior to local disk encryption support, you can encrypt your data using [Rebuild](https://techdocs.akamai.com/linode-api/reference/post-rebuild-linode-instance).",
                         "enum": [
                           "enabled",
                           "disabled"
                         ],
                         "type": "string",
-                        "x-akamai": {
-                          "status": "LA"
-                        },
                         "x-linode-cli-display": 8
                       },
                       "image": {
@@ -58024,14 +65436,11 @@
                     },
                     "disk_encryption": {
                       "default": "enabled",
-                      "description": "__Limited availability__, __Read-only__ Indicates the local disk encryption setting for this Linode. If the Linode is part of an LKE cluster, the value is `null`.",
+                      "description": "__Read-only__ Indicates the local disk encryption setting for this Linode. If the Linode is part of an LKE cluster, the value is `null`.",
                       "example": "disabled",
                       "nullable": true,
                       "readOnly": true,
                       "type": "string",
-                      "x-akamai": {
-                        "status": "LA"
-                      },
                       "x-linode-cli-display": 8
                     },
                     "group": {
@@ -67579,16 +74988,13 @@
                       "type": "integer"
                     },
                     "disk_encryption": {
-                      "description": "__Limited availability__ Indicates the local disk encryption setting for this LKE node pool.",
+                      "description": "Indicates the local disk encryption setting for this LKE node pool.",
                       "enum": [
                         "enabled",
                         "disabled"
                       ],
                       "example": "disabled",
-                      "type": "string",
-                      "x-akamai": {
-                        "status": "LA"
-                      }
+                      "type": "string"
                     },
                     "disks": {
                       "description": "This Node Pool's custom disk layout.",
@@ -67878,16 +75284,13 @@
                             "type": "integer"
                           },
                           "disk_encryption": {
-                            "description": "__Limited availability__ Indicates the local disk encryption setting for this LKE node pool.",
+                            "description": "Indicates the local disk encryption setting for this LKE node pool.",
                             "enum": [
                               "enabled",
                               "disabled"
                             ],
                             "example": "disabled",
-                            "type": "string",
-                            "x-akamai": {
-                              "status": "LA"
-                            }
+                            "type": "string"
                           },
                           "disks": {
                             "description": "This Node Pool's custom disk layout.",
@@ -68268,16 +75671,13 @@
                       "type": "integer"
                     },
                     "disk_encryption": {
-                      "description": "__Limited availability__ Indicates the local disk encryption setting for this LKE node pool.",
+                      "description": "Indicates the local disk encryption setting for this LKE node pool.",
                       "enum": [
                         "enabled",
                         "disabled"
                       ],
                       "example": "disabled",
-                      "type": "string",
-                      "x-akamai": {
-                        "status": "LA"
-                      }
+                      "type": "string"
                     },
                     "disks": {
                       "description": "This Node Pool's custom disk layout.",
@@ -68647,16 +76047,13 @@
                       "type": "integer"
                     },
                     "disk_encryption": {
-                      "description": "__Limited availability__ Indicates the local disk encryption setting for this LKE node pool.",
+                      "description": "Indicates the local disk encryption setting for this LKE node pool.",
                       "enum": [
                         "enabled",
                         "disabled"
                       ],
                       "example": "disabled",
-                      "type": "string",
-                      "x-akamai": {
-                        "status": "LA"
-                      }
+                      "type": "string"
                     },
                     "disks": {
                       "description": "This Node Pool's custom disk layout.",
@@ -79699,7 +87096,7 @@
                           "x-linode-cli-display": 3
                         },
                         "vpc_interface": {
-                          "description": "The public interface's default firewall.",
+                          "description": "The VPC interface's default firewall.",
                           "example": 200,
                           "type": "integer",
                           "x-linode-cli-display": 4
@@ -79826,7 +87223,7 @@
                         "x-linode-cli-display": 3
                       },
                       "vpc_interface": {
-                        "description": "The public interface's default firewall.",
+                        "description": "The VPC interface's default firewall.",
                         "example": 200,
                         "type": "integer",
                         "x-linode-cli-display": 4
@@ -79879,7 +87276,7 @@
                           "x-linode-cli-display": 3
                         },
                         "vpc_interface": {
-                          "description": "The public interface's default firewall.",
+                          "description": "The VPC interface's default firewall.",
                           "example": 200,
                           "type": "integer",
                           "x-linode-cli-display": 4
@@ -103726,7 +111123,7 @@
     },
     "/{apiVersion}/object-storage/keys": {
       "post": {
-        "description": "Provisions a new Object Storage key for authentication. A successful request triggers an `obj_access_key_create` [event](https://techdocs.akamai.com/linode-api/reference/get-events).\n\n> \ud83d\udcd8\n>\n> Accounts with negative balances can't access this operation.\n\n**The `regions` and `region` parameters**\n\nWhen creating an Object Storage key, specify one or more data centers ([regions](https://techdocs.akamai.com/linode-api/reference/get-regions)) where you want to create and manage Object Storage buckets.\n\n- **The `regions` array**. Populate it with `regionId` values. The resulting Object Storage key grants access to list and create new buckets in these regions. This *doesn't* give access to manage content in these buckets. To address this, you can:\n\n  - Use the `bucket_access` array instead to grant management access, per bucket.\n\n  - Use [bucket policies](https://www.linode.com/docs/products/storage/object-storage/guides/bucket-policies/) to change the access for this key.\n\n- **The `bucket_access` array**. This optional array lets you set up limited keys. Include individual objects naming a `regionId` where the bucket exists, the target `bucket_name` to access, and the `permissions` for the Object Storage key. Use the resulting key to manage content in the `bucket_name`, based on the permission level set. You can also use the key to create new buckets in the named region. The key doesn't have access to manage content in a newly created bucket. You can grant it this access using [bucket policies](https://www.linode.com/docs/products/storage/object-storage/guides/bucket-policies/).\n\n- **Combine the two to apply varying levels of access in the key**. For example, set `regions` to `us-west` to give the key bucket list and create access in that region. Then, set up the `bucket_access` array to give access to a specific `bucket_name` in the `us-east` region. The key has access to manage content in that `bucket_name` and list and create buckets in the `us-east` region, too. If you include the same region in both, the settings applied in the `bucket_access` array take precedence. For example, assume you include `us-east` in the `regions` array, expecting to only give bucket list and creation access to that region. If you also set `us-east` as a `region` in the `bucket_access` array, the Object Storage key gives access to manage content in the specified `bucket_name`, and lets you list and create buckets in that region.\n\n**The `cluster` parameter (legacy)**\n\nFor backward compatibility, include the `cluster` parameter to create an Object Storage key. Use the `clusterId` equivalent (us-west-1) instead of the `regionId` (us-west). Leave the `regions` array out. If including the `bucket_access` array to limit access, omit `region` from each object. Use the resulting key in clusters in all supported regions.\n\n> \ud83d\udcd8\n>\n> While the API supports this method, you should use the `regions` parameters, instead.\n\n- **Unlimited access**. Omit the `bucket_access` array. The Object Storage key has unlimited cluster access to all buckets, with all permissions.\n\n- **Limited access**. Include the `bucket_access` array. Set the target `bucket_name` and the level of `permissions` for access to that bucket. Use the resulting key to manage content in the named bucket. A limited Object Storage key can [list all buckets](https://techdocs.akamai.com/linode-api/reference/get-object-storage-buckets) and [create a new bucket](https://techdocs.akamai.com/linode-api/reference/post-object-storage-bucket). However, you can't use the key to perform any actions on a bucket, unless the key has access to it. You can use [bucket policies](https://www.linode.com/docs/products/storage/object-storage/guides/bucket-policies/) to modify a key's access.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli object-storage keys-create \\\n  --label \"my-object-storage-key\" \\\n  --bucket_access '[{\"region\": \"ap-south\", \"bucket_name\": \"bucket-example-1\", \"permissions\": \"read_write\" }]'\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Provisions a new Object Storage key for authentication. A successful request triggers an `obj_access_key_create` [event](https://techdocs.akamai.com/linode-api/reference/get-events).\n\n> \ud83d\udcd8\n>\n> Accounts with negative balances can't access this operation.\n\n**Call out specific regions**\n\nWhen creating an Object Storage key, name the specific data centers (regions) where you want to create and manage Object Storage buckets.\n\n- **The `regions` array**. Populate it with `regionId` values. Run the [List regions](https://techdocs.akamai.com/linode-api/reference/get-regions) operation, verify that the desired region includes `\"Object Storage\"` amongst its `capabilities`, and store its `id` for use as the `regionId`. The resulting Object Storage key grants access to list and create new buckets in each region. This *doesn't* give access to manage content in these buckets. To address this, you can:\n\n  - Use the `bucket_access` array instead to grant management access, per bucket.\n\n  - Use [bucket policies](https://www.linode.com/docs/products/storage/object-storage/guides/bucket-policies/) to change the access for this key.\n\n- **The `bucket_access` array**. This optional array lets you set up limited keys. Include individual objects naming a `regionId` where the bucket exists, the target `bucket_name` to access, and the `permissions` for the Object Storage key. Use the resulting key to manage content in the `bucket_name`, based on the permission level set. You can also use the key to create new buckets in the named region. The key doesn't have access to manage content in a newly created bucket. You can grant it this access using [bucket policies](https://www.linode.com/docs/products/storage/object-storage/guides/bucket-policies/).\n\n- **Combine the two to apply varying levels of access in the key**. For example, set `regions` to `us-west` to give the key bucket list and create access in that region. Then, set up the `bucket_access` array to give access to a specific `bucket_name` in the `us-east` region. The key has access to manage content in that `bucket_name` and list and create buckets in the `us-east` region, too. If you include the same region in both, the settings applied in the `bucket_access` array take precedence. For example, assume you include `us-east` in the `regions` array, expecting to only give bucket list and creation access to that region. If you also set `us-east` as a `region` in the `bucket_access` array, the Object Storage key gives access to manage content in the specified `bucket_name`, and lets you list and create buckets in that region.\n\n**Call out specific clusters (deprecated)**\n\nFor backward compatibility, you can still target specific clusters where you want to create and manage Object Storage buckets. In this case, you include the `cluster` parameter and populate it with `clusterId` equivalents (us-west-1) instead of the `regionId` (us-west). Run the [List clusters](https://techdocs.akamai.com/linode-api/reference/get-object-storage-clusters) operation and store the `id` for the desired cluster. Leave the `regions` array out. If you include the `bucket_access` array to limit access, omit `region` from each object. Use the resulting key in clusters in all supported regions.\n\n> \ud83d\udcd8\n>\n> The `cluster` parameter has been deprecated. You should use the `regions` parameter instead. You can't include both parameters in the same operation.\n\n- **Unlimited access**. Omit the `bucket_access` array. The Object Storage key has unlimited cluster access to all buckets, with all permissions.\n\n- **Limited access**. Include the `bucket_access` array. Set the target `bucket_name` and the level of `permissions` for access to that bucket. Use the resulting key to manage content in the named bucket. A limited Object Storage key can [list all buckets](https://techdocs.akamai.com/linode-api/reference/get-object-storage-buckets) and [create a new bucket](https://techdocs.akamai.com/linode-api/reference/post-object-storage-bucket). However, you can't use the key to perform any actions on a bucket, unless the key has access to it. You can use [bucket policies](https://www.linode.com/docs/products/storage/object-storage/guides/bucket-policies/) to modify a key's access.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli object-storage keys-create \\\n  --label \"my-object-storage-key\" \\\n  --bucket_access '[{\"region\": \"ap-south\", \"bucket_name\": \"bucket-example-1\", \"permissions\": \"read_write\" }]'\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/post-object-storage-keys"
@@ -103737,52 +111134,117 @@
             "application/json": {
               "schema": {
                 "additionalProperties": false,
-                "properties": {
-                  "bucket_access": {
-                    "description": "Set up the key to limit access to specific buckets, each with a specific permission level. You can create a limited Object Storage key with access to no buckets. Include an empty `bucket_access` array in the request.",
-                    "items": {
-                      "additionalProperties": false,
-                      "properties": {
-                        "bucket_name": {
-                          "description": "The name of the bucket that this key grants access to. Run the [List Object Storage buckets](https://techdocs.akamai.com/linode-api/reference/get-object-storage-buckets) operation and store the label for the desired bucket.",
-                          "example": "example-bucket",
+                "description": "The settings necessary to create a new key.",
+                "oneOf": [
+                  {
+                    "additionalProperties": false,
+                    "description": "Settings applied to use the `regions` parameter to configure an Object Storage key.",
+                    "properties": {
+                      "bucket_access": {
+                        "description": "Set up the key to limit access to specific buckets, each with a specific permission level. You can also create a limited key with access to no buckets, by including an empty `bucket_access` array in the request.\n\n> \ud83d\udcd8\n>\n> You can use this by itself to create a limited key, or along with the `regions` parameter to mix access for the key. See [Call out specific regions](https://techdocs.akamai.com/linode-api/reference/post-object-storage-keys) for more information.",
+                        "items": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "bucket_name": {
+                              "description": "The name of the bucket that this key grants access to. Run the [List Object Storage buckets](https://techdocs.akamai.com/linode-api/reference/get-object-storage-buckets) operation and store the label for the desired bucket.",
+                              "example": "example-bucket",
+                              "type": "string"
+                            },
+                            "permissions": {
+                              "description": "The level of access the key grants to the specified `bucket_name`. Keys with `read_write` access can manage content in the `bucket_name`, while `read_only` can be used to view content.",
+                              "enum": [
+                                "read_write",
+                                "read_only"
+                              ],
+                              "example": "read_write",
+                              "type": "string"
+                            },
+                            "region": {
+                              "description": "The region where the `bucket_name` you want the key to access is located.\n\n> \ud83d\udcd8\n>\n> - If you repeat the same `region` across objects, the response includes a single `s3_endpoint` for this region. Use it to access all `bucket_name` entries.\n>\n> - Once a limited key is active, you can't update a it to remove a `region`. Verify all regions before completing this operation.",
+                              "example": "us-iad",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "label": {
+                        "description": "The label for the Object Storage key, for display purposes only.",
+                        "example": "my-key",
+                        "type": "string"
+                      },
+                      "regions": {
+                        "description": "Set up the key to create new buckets in specific data centers (regions) set in this array.\n\n>  \ud83d\udcd8\n>\n> - You can use this array by itself, or mix it with the `bucket_access` array to mix access for the key. See [Call out specific regions](https://techdocs.akamai.com/linode-api/reference/post-object-storage-keys) for more information.\n>\n> - You can't combine this parameter and the `cluster` parameter in the same request.",
+                        "example": [
+                          "us-iad"
+                        ],
+                        "items": {
                           "type": "string"
                         },
-                        "permissions": {
-                          "description": "The level of access the key grants to the specified `bucket_name`. Keys with `read_write` access can manage content in the `bucket_name`, while `read_only` can be used to view content.",
-                          "enum": [
-                            "read_write",
-                            "read_only"
-                          ],
-                          "example": "read_write",
+                        "type": "array"
+                      }
+                    },
+                    "title": "Regions",
+                    "type": "object",
+                    "x-akamai": {
+                      "file-path": "schemas/obj-key-regions.yaml"
+                    }
+                  },
+                  {
+                    "additionalProperties": false,
+                    "description": "Settings applied to use the deprecated `cluster` parameter to configure an Object Storage key.",
+                    "properties": {
+                      "bucket_access": {
+                        "description": "Set up the key to limit access to specific buckets, each with a specific permission level. You can also create a limited key with access to no buckets, by including an empty `bucket_access` array in the request.\n\n> \ud83d\udcd8\n>\n> You can use this by itself to create a limited key, or along with the `cluster` parameter to mix access for the key. See [Call out specific clusters (deprecated)](https://techdocs.akamai.com/linode-api/reference/post-object-storage-keys) for more information.",
+                        "items": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "bucket_name": {
+                              "description": "The name of the bucket that this key grants access to. Run the [List Object Storage buckets](https://techdocs.akamai.com/linode-api/reference/get-object-storage-buckets) operation and store the label for the desired bucket.",
+                              "example": "example-bucket",
+                              "type": "string"
+                            },
+                            "permissions": {
+                              "description": "The level of access the key grants to the specified `bucket_name`. Keys with `read_write` access can manage content in the `bucket_name`, while `read_only` can be used to view content.",
+                              "enum": [
+                                "read_write",
+                                "read_only"
+                              ],
+                              "example": "read_write",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "cluster": {
+                        "description": "__Deprecated__ Set up the key to create new buckets in supported legacy clusters. You can run the [List clusters](https://techdocs.akamai.com/linode-api/reference/get-object-storage-clusters) operation and store the `id` for applicable clusters.\n\n> \ud83d\udcd8\n>\n> - This parameter has been deprecated. You should use the `regions` parameter instead. See [Call out specific clusters (deprecated)](https://techdocs.akamai.com/linode-api/reference/post-object-storage-keys) for more information.\n>\n> - You can't combine this parameter and the `regions` parameter in the same request.",
+                        "example": [
+                          "us-east-1"
+                        ],
+                        "items": {
                           "type": "string"
                         },
-                        "region": {
-                          "description": "The region where the `bucket_name` you want the key to access is located.\n\n> \ud83d\udcd8\n>\n> If you repeat the same `region` across objects, the response includes a single `s3_endpoint` for this region. Use it to access all `bucket_name` entries.",
-                          "example": "us-iad",
-                          "type": "string"
+                        "type": "array",
+                        "x-akamai": {
+                          "status": "DEPRECATED"
                         }
                       },
-                      "type": "object"
+                      "label": {
+                        "description": "The label for the Object Storage key, for display purposes only.",
+                        "example": "my-key",
+                        "type": "string"
+                      }
                     },
-                    "type": "array"
-                  },
-                  "label": {
-                    "description": "The label for the Object Storage key, for display purposes only.",
-                    "example": "{{label}}",
-                    "type": "string"
-                  },
-                  "regions": {
-                    "description": "You can use a key to create new buckets in regions set in this array. But it can't be used to manage content in those buckets. See [Create an Object Storage key](https://techdocs.akamai.com/linode-api/reference/post-object-storage-keys) for more details.",
-                    "example": [
-                      "us-iad"
-                    ],
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
+                    "title": "Cluster (deprecated)",
+                    "type": "object",
+                    "x-akamai": {
+                      "file-path": "schemas/obj-key-cluster.yaml"
+                    }
                   }
-                },
+                ],
                 "type": "object",
                 "x-akamai": {
                   "file-path": "schemas/added-post-object-storage-key.yaml"
@@ -103792,13 +111254,34 @@
                 "x-ref": "../examples/post-object-storage-keys.json"
               }
             }
-          },
-          "description": "The settings necessary to create a new key."
+          }
         },
         "responses": {
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "access_key": "KVAKUTGBA4WTR2NSJQ81",
+                  "bucket_access": [
+                    {
+                      "bucket_name": "example-bucket",
+                      "cluster": "us-west-1",
+                      "permissions": "read_only",
+                      "region": "us-west"
+                    }
+                  ],
+                  "id": 123,
+                  "label": "my-key",
+                  "limited": true,
+                  "regions": [
+                    {
+                      "endpoint_type": "E1",
+                      "id": "us-west",
+                      "s3_endpoint": "us-west-00.linodeobjects.com"
+                    }
+                  ],
+                  "secret_key": "string"
+                },
                 "schema": {
                   "additionalProperties": false,
                   "description": "A key used to validate requests to an S3 API.",
@@ -103810,7 +111293,7 @@
                       "type": "string"
                     },
                     "bucket_access": {
-                      "description": "Settings that limit access to specific buckets, each with a specific permission level.",
+                      "description": "Settings that limit access to specific buckets, each with a specific permission level. See [Call out specific regions](https://techdocs.akamai.com/linode-api/reference/post-object-storage-keys) for more information.",
                       "items": {
                         "additionalProperties": false,
                         "properties": {
@@ -103820,12 +111303,15 @@
                             "type": "string"
                           },
                           "cluster": {
-                            "description": "Identifies the legacy cluster where this key can be used. The key grants access to each specified `bucket_name`, based on the `permissions` set. To support backward compatibility, the API generates this value, based on the `region` set for a new key. See [Create an Object Storage key](https://techdocs.akamai.com/linode-api/reference/post-object-storage-keys) for more information.",
+                            "description": "__Deprecated__ For backwards compatibility, this is included to identify the legacy cluster equivalent of the `region` where this key can be used. The key grants access to each specified `bucket_name`, based on the `permissions` set.\n\n> \ud83d\udcd8\n>\n> Use of clusters for keys has been deprecated. See [Call out specific clusters (deprecated)](https://techdocs.akamai.com/linode-api/reference/post-object-storage-key) for more information.",
                             "example": "us-west-1",
-                            "type": "string"
+                            "type": "string",
+                            "x-akamai": {
+                              "status": "DEPRECATED"
+                            }
                           },
                           "permissions": {
-                            "description": "The level of access the key grants to the `bucket_name`. Keys with `read_write` access can manage content in the `bucket_name`, while `read_only` can be used to view content. See [Create an Object Storage key(ref:post-object-storage-keys) for more details.",
+                            "description": "The level of access the key grants to the `bucket_name`. Keys with `read_write` access can manage content in the `bucket_name`, while `read_only` can be used to view content. See [Call out specific regions](https://techdocs.akamai.com/linode-api/reference/post-object-storage-keys) for more information.",
                             "enum": [
                               "read_write",
                               "read_only"
@@ -103842,6 +111328,29 @@
                         "type": "object"
                       },
                       "type": "array"
+                    },
+                    "cluster": {
+                      "description": "__Deprecated__ The key can be used in these legacy clusters to create new buckets, but it can't be used to manage content in those buckets. See [Call out specific clusters (deprecated)](https://techdocs.akamai.com/linode-api/reference/post-object-storage-keys) for more information.\n\n> \ud83d\udcd8\n>\n> This only appears in a response if the `cluster` parameter was used to create the key. If the `regions` parameter was used, it's included in the response instead.",
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "id": {
+                            "description": "Identifies each region where you can use the Object Storage key.",
+                            "example": "us-east-1",
+                            "type": "string"
+                          },
+                          "s3_endpoint": {
+                            "description": "The S3-compatible hostname you can use to access the Object Storage buckets in this cluster.",
+                            "example": "us-east-1.linodeobjects.com",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array",
+                      "x-akamai": {
+                        "status": "DEPRECATED"
+                      }
                     },
                     "id": {
                       "description": "__Read-only__ This Object Storage key's unique ID.",
@@ -103861,7 +111370,7 @@
                       "type": "boolean"
                     },
                     "regions": {
-                      "description": "The key can be used in these regions to create new buckets but it can't be used to manage content in those buckets. See [Create an Object Storage key](https://techdocs.akamai.com/linode-api/reference/post-object-storage-keys) for more details.",
+                      "description": "The key can be used in these regions to create new buckets, but it can't be used to manage content in those buckets. See [Call out specific regions](https://techdocs.akamai.com/linode-api/reference/post-object-storage-keys) for more information.\n\n> \ud83d\udcd8\n>\n> This only appears in a response if the `regions` parameter was used to create the key. If the deprecated `cluster` parameter was used, it's included in the response instead.",
                       "items": {
                         "additionalProperties": false,
                         "properties": {
@@ -103901,9 +111410,6 @@
                   "x-akamai": {
                     "file-path": "schemas/object-storage-key.yaml"
                   }
-                },
-                "x-example": {
-                  "x-ref": "../examples/post-object-storage-keys-200.json"
                 }
               }
             },
@@ -103987,6 +111493,35 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": [
+                    {
+                      "access_key": "KVAKUTGBA4WTR2NSJQ81",
+                      "bucket_access": [
+                        {
+                          "bucket_name": "example-bucket",
+                          "cluster": "us-west-1",
+                          "permissions": "read_only",
+                          "region": "us-west"
+                        }
+                      ],
+                      "id": 123,
+                      "label": "my-key",
+                      "limited": true,
+                      "regions": [
+                        {
+                          "endpoint_type": "E1",
+                          "id": "us-west",
+                          "s3_endpoint": "us-west-00.linodeobjects.com"
+                        }
+                      ],
+                      "secret_key": "string"
+                    }
+                  ],
+                  "page": 1,
+                  "pages": 1,
+                  "results": 1
+                },
                 "schema": {
                   "additionalProperties": false,
                   "properties": {
@@ -104002,7 +111537,7 @@
                             "type": "string"
                           },
                           "bucket_access": {
-                            "description": "Settings that limit access to specific buckets, each with a specific permission level.",
+                            "description": "Settings that limit access to specific buckets, each with a specific permission level. See [Call out specific regions](https://techdocs.akamai.com/linode-api/reference/post-object-storage-keys) for more information.",
                             "items": {
                               "additionalProperties": false,
                               "properties": {
@@ -104012,12 +111547,15 @@
                                   "type": "string"
                                 },
                                 "cluster": {
-                                  "description": "Identifies the legacy cluster where this key can be used. The key grants access to each specified `bucket_name`, based on the `permissions` set. To support backward compatibility, the API generates this value, based on the `region` set for a new key. See [Create an Object Storage key](https://techdocs.akamai.com/linode-api/reference/post-object-storage-keys) for more information.",
+                                  "description": "__Deprecated__ For backwards compatibility, this is included to identify the legacy cluster equivalent of the `region` where this key can be used. The key grants access to each specified `bucket_name`, based on the `permissions` set.\n\n> \ud83d\udcd8\n>\n> Use of clusters for keys has been deprecated. See [Call out specific clusters (deprecated)](https://techdocs.akamai.com/linode-api/reference/post-object-storage-key) for more information.",
                                   "example": "us-west-1",
-                                  "type": "string"
+                                  "type": "string",
+                                  "x-akamai": {
+                                    "status": "DEPRECATED"
+                                  }
                                 },
                                 "permissions": {
-                                  "description": "The level of access the key grants to the `bucket_name`. Keys with `read_write` access can manage content in the `bucket_name`, while `read_only` can be used to view content. See [Create an Object Storage key(ref:post-object-storage-keys) for more details.",
+                                  "description": "The level of access the key grants to the `bucket_name`. Keys with `read_write` access can manage content in the `bucket_name`, while `read_only` can be used to view content. See [Call out specific regions](https://techdocs.akamai.com/linode-api/reference/post-object-storage-keys) for more information.",
                                   "enum": [
                                     "read_write",
                                     "read_only"
@@ -104034,6 +111572,29 @@
                               "type": "object"
                             },
                             "type": "array"
+                          },
+                          "cluster": {
+                            "description": "__Deprecated__ The key can be used in these legacy clusters to create new buckets, but it can't be used to manage content in those buckets. See [Call out specific clusters (deprecated)](https://techdocs.akamai.com/linode-api/reference/post-object-storage-keys) for more information.\n\n> \ud83d\udcd8\n>\n> This only appears in a response if the `cluster` parameter was used to create the key. If the `regions` parameter was used, it's included in the response instead.",
+                            "items": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "id": {
+                                  "description": "Identifies each region where you can use the Object Storage key.",
+                                  "example": "us-east-1",
+                                  "type": "string"
+                                },
+                                "s3_endpoint": {
+                                  "description": "The S3-compatible hostname you can use to access the Object Storage buckets in this cluster.",
+                                  "example": "us-east-1.linodeobjects.com",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array",
+                            "x-akamai": {
+                              "status": "DEPRECATED"
+                            }
                           },
                           "id": {
                             "description": "__Read-only__ This Object Storage key's unique ID.",
@@ -104053,7 +111614,7 @@
                             "type": "boolean"
                           },
                           "regions": {
-                            "description": "The key can be used in these regions to create new buckets but it can't be used to manage content in those buckets. See [Create an Object Storage key](https://techdocs.akamai.com/linode-api/reference/post-object-storage-keys) for more details.",
+                            "description": "The key can be used in these regions to create new buckets, but it can't be used to manage content in those buckets. See [Call out specific regions](https://techdocs.akamai.com/linode-api/reference/post-object-storage-keys) for more information.\n\n> \ud83d\udcd8\n>\n> This only appears in a response if the `regions` parameter was used to create the key. If the deprecated `cluster` parameter was used, it's included in the response instead.",
                             "items": {
                               "additionalProperties": false,
                               "properties": {
@@ -104119,9 +111680,6 @@
                   "x-akamai": {
                     "file-path": "schemas/added-get-object-storage-keys-200.yaml"
                   }
-                },
-                "x-example": {
-                  "x-ref": "../examples/get-object-storage-keys-200.json"
                 }
               }
             },
@@ -104231,6 +111789,28 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "access_key": "KVAKUTGBA4WTR2NSJQ81",
+                  "bucket_access": [
+                    {
+                      "bucket_name": "example-bucket",
+                      "cluster": "us-west-1",
+                      "permissions": "read_only",
+                      "region": "us-west"
+                    }
+                  ],
+                  "id": 123,
+                  "label": "my-key",
+                  "limited": true,
+                  "regions": [
+                    {
+                      "endpoint_type": "E1",
+                      "id": "us-west",
+                      "s3_endpoint": "us-west-00.linodeobjects.com"
+                    }
+                  ],
+                  "secret_key": "string"
+                },
                 "schema": {
                   "additionalProperties": false,
                   "description": "A key used to validate requests to an S3 API.",
@@ -104242,7 +111822,7 @@
                       "type": "string"
                     },
                     "bucket_access": {
-                      "description": "Settings that limit access to specific buckets, each with a specific permission level.",
+                      "description": "Settings that limit access to specific buckets, each with a specific permission level. See [Call out specific regions](https://techdocs.akamai.com/linode-api/reference/post-object-storage-keys) for more information.",
                       "items": {
                         "additionalProperties": false,
                         "properties": {
@@ -104252,12 +111832,15 @@
                             "type": "string"
                           },
                           "cluster": {
-                            "description": "Identifies the legacy cluster where this key can be used. The key grants access to each specified `bucket_name`, based on the `permissions` set. To support backward compatibility, the API generates this value, based on the `region` set for a new key. See [Create an Object Storage key](https://techdocs.akamai.com/linode-api/reference/post-object-storage-keys) for more information.",
+                            "description": "__Deprecated__ For backwards compatibility, this is included to identify the legacy cluster equivalent of the `region` where this key can be used. The key grants access to each specified `bucket_name`, based on the `permissions` set.\n\n> \ud83d\udcd8\n>\n> Use of clusters for keys has been deprecated. See [Call out specific clusters (deprecated)](https://techdocs.akamai.com/linode-api/reference/post-object-storage-key) for more information.",
                             "example": "us-west-1",
-                            "type": "string"
+                            "type": "string",
+                            "x-akamai": {
+                              "status": "DEPRECATED"
+                            }
                           },
                           "permissions": {
-                            "description": "The level of access the key grants to the `bucket_name`. Keys with `read_write` access can manage content in the `bucket_name`, while `read_only` can be used to view content. See [Create an Object Storage key(ref:post-object-storage-keys) for more details.",
+                            "description": "The level of access the key grants to the `bucket_name`. Keys with `read_write` access can manage content in the `bucket_name`, while `read_only` can be used to view content. See [Call out specific regions](https://techdocs.akamai.com/linode-api/reference/post-object-storage-keys) for more information.",
                             "enum": [
                               "read_write",
                               "read_only"
@@ -104274,6 +111857,29 @@
                         "type": "object"
                       },
                       "type": "array"
+                    },
+                    "cluster": {
+                      "description": "__Deprecated__ The key can be used in these legacy clusters to create new buckets, but it can't be used to manage content in those buckets. See [Call out specific clusters (deprecated)](https://techdocs.akamai.com/linode-api/reference/post-object-storage-keys) for more information.\n\n> \ud83d\udcd8\n>\n> This only appears in a response if the `cluster` parameter was used to create the key. If the `regions` parameter was used, it's included in the response instead.",
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "id": {
+                            "description": "Identifies each region where you can use the Object Storage key.",
+                            "example": "us-east-1",
+                            "type": "string"
+                          },
+                          "s3_endpoint": {
+                            "description": "The S3-compatible hostname you can use to access the Object Storage buckets in this cluster.",
+                            "example": "us-east-1.linodeobjects.com",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array",
+                      "x-akamai": {
+                        "status": "DEPRECATED"
+                      }
                     },
                     "id": {
                       "description": "__Read-only__ This Object Storage key's unique ID.",
@@ -104293,7 +111899,7 @@
                       "type": "boolean"
                     },
                     "regions": {
-                      "description": "The key can be used in these regions to create new buckets but it can't be used to manage content in those buckets. See [Create an Object Storage key](https://techdocs.akamai.com/linode-api/reference/post-object-storage-keys) for more details.",
+                      "description": "The key can be used in these regions to create new buckets, but it can't be used to manage content in those buckets. See [Call out specific regions](https://techdocs.akamai.com/linode-api/reference/post-object-storage-keys) for more information.\n\n> \ud83d\udcd8\n>\n> This only appears in a response if the `regions` parameter was used to create the key. If the deprecated `cluster` parameter was used, it's included in the response instead.",
                       "items": {
                         "additionalProperties": false,
                         "properties": {
@@ -104333,9 +111939,6 @@
                   "x-akamai": {
                     "file-path": "schemas/object-storage-key.yaml"
                   }
-                },
-                "x-example": {
-                  "x-ref": "../examples/get-object-storage-key-200.json"
                 }
               }
             },
@@ -104427,7 +112030,7 @@
                     "type": "string"
                   },
                   "regions": {
-                    "description": "Replace the current list of `regions` set in a specific key. Include an existing region to maintain it or leave it out to remove it. If you include new `regions` in the key, they can't be used to manage content in buckets in that specific region. You can grant these keys this access using [bucket policies](https://www.linode.com/docs/products/storage/object-storage/guides/bucket-policies/). Omit this to leave the existing list unchanged.\n\n> \ud83d\udea7\n>\n> You can't remove a `region` from a limited key's original `bucket_access` list. If you include the `regions` array in this operation, you need to include all existing `region` entries from the `bucket_access` array, if you included it when [creating](https://techdocs.akamai.com/linode-api/reference/post-object-storage-keys) this key. Otherwise, the operation fails with an error. Run [Get an Object Storage key](https://techdocs.akamai.com/linode-api/reference/get-object-storage-key) to review current `region` entries in a limited key.",
+                    "description": "Replace the current list of `regions` set in a specific key. Include an existing region to keep it, or leave it out to remove it. Omit the `regions` array to leave the existing list unchanged. If you include new `regions` in the key, you can't immediately use the key to manage content in buckets in those regions. You need to grant these keys this access using [bucket policies](https://www.linode.com/docs/products/storage/object-storage/guides/bucket-policies/).\n\n> \ud83d\udea7 Limited keys have restrictions\n>\n> These points apply to keys you've [created](https://techdocs.akamai.com/linode-api/reference/post-object-storage-keys) using the `bucket_access` array:\n>\n> - You can't remove a `region` from a limited key's original `bucket_access` list. If you include the `regions` array in this operation and target a limited key, you need to include all existing `region` entries from the `bucket_access` array. Otherwise, the operation fails with an error. Run [Get an Object Storage key](https://techdocs.akamai.com/linode-api/reference/get-object-storage-key) to review current `region` entries in a limited key.\n>\n> - If you need to remove a specific region from an active limited key, you can [revoke the key](https://techdocs.akamai.com/linode-api/reference/delete-object-storage-key) and create a new Object Storage key, without the specific region.",
                     "example": [
                       "us-iad",
                       "fr-par"
@@ -104721,7 +112324,7 @@
     },
     "/{apiVersion}/object-storage/quotas": {
       "get": {
-        "description": "__Beta__ Returns the active Object Storage-related quotas applied to your account. For example, you may have a quota maximum for the number of buckets you can have on a single endpoint. The operation includes any quota overrides in the response.\n\n> \ud83d\udcd8\n>\n> You can't combine parameters when [filtering](https://techdocs.akamai.com/linode-api/reference//filtering-and-sorting) with this operation. Only a single filterable parameter can be used.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli object-storage quotas-list\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)",
+        "description": "Returns the active Object Storage-related quotas applied to your account. For example, you may have a quota maximum for the number of buckets you can have on a single endpoint. The operation includes any quota overrides in the response.\n\n> \ud83d\udcd8\n>\n> You can't combine parameters when [filtering](https://techdocs.akamai.com/linode-api/reference//filtering-and-sorting) with this operation. Only a single filterable parameter can be used.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli object-storage quotas-list\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-object-storage-quotas"
@@ -104734,7 +112337,7 @@
                 "example": {
                   "data": [
                     {
-                      "description": "Maximum number of buckets this customer is allowed to have on this endpoint",
+                      "description": "Current number of buckets per account, per endpoint",
                       "endpoint_type": "E1",
                       "quota_id": "obj-buckets-eu-central-1.linodeobjects.com",
                       "quota_limit": 50,
@@ -104757,8 +112360,8 @@
                             "description": "The current Object Storage-related quotas on your account.",
                             "properties": {
                               "description": {
-                                "description": "A detailed description for the Object Storage-related quota.",
-                                "example": "Maximum number of buckets this customer is allowed to have on this endpoint",
+                                "description": "A description for the Object Storage-related quota.",
+                                "example": "Current number of buckets per account, per endpoint",
                                 "type": "string",
                                 "x-linode-cli-display": 3
                               },
@@ -104775,7 +112378,7 @@
                                 "x-linode-cli-display": 6
                               },
                               "quota_id": {
-                                "description": "Identifies the Object Storage-related quota. Formatted as `obj-<quota_type>-<s3_endpoint>`, where `<quota_type>` is the `resource_metric` in use, `buckets`, `objects` or `bytes`.",
+                                "description": "Identifies the Object Storage-related quota. Formatted as `obj-<quota_type>-<s3_endpoint>`, where `<quota_type>` is the `resource_metric` in use: `buckets`, `objects` or `bytes`.",
                                 "example": "obj-buckets-eu-central-1.linodeobjects.com",
                                 "type": "string",
                                 "x-linode-cli-display": 1
@@ -104911,22 +112514,34 @@
             "description": "See [Errors](https://techdocs.akamai.com/linode-api/reference/errors) for the range of possible error response codes."
           }
         },
+        "security": [
+          {
+            "personalAccessToken": []
+          },
+          {
+            "oauth": [
+              "object_storage:read_only"
+            ]
+          }
+        ],
         "summary": "List Object Storage quotas",
         "tags": [
           "Object Storage quotas"
         ],
         "x-akamai": {
-          "status": "BETA",
           "tabs": [
             {
               "syntax": "linode-cli object-storage quotas-list",
               "title": "CLI",
               "url": "https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli"
+            },
+            {
+              "syntax": "object_storage:read_only",
+              "title": "OAuth scopes",
+              "url": "https://techdocs.akamai.com/linode-api/reference/get-started#oauth"
             }
           ]
-        },
-        "x-linode-cli-action": "object-storage-quotas",
-        "x-linode-redoc-load-ids": true
+        }
       },
       "parameters": [
         {
@@ -104955,7 +112570,7 @@
     },
     "/{apiVersion}/object-storage/quotas/{object-storage-quotaId}": {
       "get": {
-        "description": "__Beta__ Returns information about a specific Object Storage-related quota on your account. The operation includes any quota overrides in the response.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli object-storage quota-view obj-objects-us-ord-1\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)",
+        "description": "Returns information about a specific Object Storage-related quota on your account. The operation includes any quota overrides in the response.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli object-storage quota-view obj-objects-us-ord-1\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-object-storage-quota"
@@ -104966,7 +112581,7 @@
             "content": {
               "application/json": {
                 "example": {
-                  "description": "Maximum number of buckets this customer is allowed to have on this endpoint",
+                  "description": "Current number of buckets per account, per endpoint",
                   "endpoint_type": "E1",
                   "quota_id": "obj-buckets-eu-central-1.linodeobjects.com",
                   "quota_limit": 50,
@@ -104979,8 +112594,8 @@
                   "description": "The current Object Storage-related quotas on your account.",
                   "properties": {
                     "description": {
-                      "description": "A detailed description for the Object Storage-related quota.",
-                      "example": "Maximum number of buckets this customer is allowed to have on this endpoint",
+                      "description": "A description for the Object Storage-related quota.",
+                      "example": "Current number of buckets per account, per endpoint",
                       "type": "string",
                       "x-linode-cli-display": 3
                     },
@@ -104997,7 +112612,7 @@
                       "x-linode-cli-display": 6
                     },
                     "quota_id": {
-                      "description": "Identifies the Object Storage-related quota. Formatted as `obj-<quota_type>-<s3_endpoint>`, where `<quota_type>` is the `resource_metric` in use, `buckets`, `objects` or `bytes`.",
+                      "description": "Identifies the Object Storage-related quota. Formatted as `obj-<quota_type>-<s3_endpoint>`, where `<quota_type>` is the `resource_metric` in use: `buckets`, `objects` or `bytes`.",
                       "example": "obj-buckets-eu-central-1.linodeobjects.com",
                       "type": "string",
                       "x-linode-cli-display": 1
@@ -105095,21 +112710,34 @@
             "description": "See [Errors](https://techdocs.akamai.com/linode-api/reference/errors) for the range of possible error response codes."
           }
         },
+        "security": [
+          {
+            "personalAccessToken": []
+          },
+          {
+            "oauth": [
+              "object_storage:read_only"
+            ]
+          }
+        ],
         "summary": "Get an Object Storage quota",
         "tags": [
           "Object Storage quotas"
         ],
         "x-akamai": {
-          "status": "BETA",
           "tabs": [
             {
               "syntax": "linode-cli object-storage quota-view obj-objects-us-ord-1",
               "title": "CLI",
               "url": "https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli"
+            },
+            {
+              "syntax": "object_storage:read_only",
+              "title": "OAuth scopes",
+              "url": "https://techdocs.akamai.com/linode-api/reference/get-started#oauth"
             }
           ]
-        },
-        "x-linode-cli-action": "object-storage-quota-view"
+        }
       },
       "parameters": [
         {
@@ -105152,7 +112780,7 @@
     },
     "/{apiVersion}/object-storage/quotas/{object-storage-quotaId}/usage": {
       "get": {
-        "description": "__Beta__ Returns usage data for a specific `object-storage-quotaId`. This includes the maximum number of `object-storage-quotaId` resources you can have for a single endpoint and the current usage for that resource.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli object-storage quotas-usage obj-objects-us-ord-1\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)",
+        "description": "Returns usage data for a specific `object-storage-quotaId`. This includes the maximum number of `object-storage-quotaId` resources you can have for a single endpoint and the current usage for that resource.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli object-storage quotas-usage obj-objects-us-ord-1\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    object_storage:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-object-storage-quota-usage"
@@ -105230,21 +112858,34 @@
             "description": "See [Errors](https://techdocs.akamai.com/linode-api/reference/errors) for the range of possible error response codes."
           }
         },
+        "security": [
+          {
+            "personalAccessToken": []
+          },
+          {
+            "oauth": [
+              "object_storage:read_only"
+            ]
+          }
+        ],
         "summary": "Get Object Storage quota usage data",
         "tags": [
           "Object Storage quotas"
         ],
         "x-akamai": {
-          "status": "BETA",
           "tabs": [
             {
               "syntax": "linode-cli object-storage quotas-usage obj-objects-us-ord-1",
               "title": "CLI",
               "url": "https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli"
+            },
+            {
+              "syntax": "object_storage:read_only",
+              "title": "OAuth scopes",
+              "url": "https://techdocs.akamai.com/linode-api/reference/get-started#oauth"
             }
           ]
-        },
-        "x-linode-cli-action": "object-storage-quota-usage-view"
+        }
       },
       "parameters": [
         {
@@ -112905,7 +120546,8 @@
                               "Block Storage",
                               "Object Storage",
                               "Placement Groups",
-                              "Block Storage Encryption"
+                              "Block Storage Encryption",
+                              "Linode Interfaces"
                             ],
                             "items": {
                               "type": "string"
@@ -113348,7 +120990,8 @@
                         "Block Storage",
                         "Object Storage",
                         "Placement Groups",
-                        "Block Storage Encryption"
+                        "Block Storage Encryption",
+                        "Linode Interfaces"
                       ],
                       "items": {
                         "type": "string"
@@ -115430,7 +123073,7 @@
     },
     "/{apiVersion}/tags": {
       "post": {
-        "description": "Creates a new Tag and optionally tags requested objects with it immediately.\n\n__Important__. You must be an unrestricted User in order to access, add, or modify Tags information.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli tags create \\\n  --label 'example tag' \\\n  --linodes 123 \\\n  --linodes 456 \\\n  --volumes 9082 \\\n  --volumes 10003\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Creates a new tag and lets you optionally add it to specific objects. Tags are labels you can attach to objects in your account. Use them to specify and group attributes of objects that are relevant to you. Currently, you can add a tag to your `linodes`, your `nodebalancers`, the `domains` for your Linodes, and the `volumes` on your Linodes.\n\n> \ud83d\udcd8\n>\n> - This operation can only be accessed by account users with _unrestricted_ access.\n>\n> - If you don't add a tag to a supported object with this operation, you can use that object's update operation to later add the tag you created.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli tags create \\\n  --label 'example tag' \\\n  --linodes 123 \\\n  --linodes 456 \\\n  --volumes 9082 \\\n  --volumes 10003\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/post-tag"
@@ -115439,11 +123082,30 @@
         "requestBody": {
           "content": {
             "application/json": {
+              "example": {
+                "domains": [
+                  564,
+                  565
+                ],
+                "label": "example tag",
+                "linodes": [
+                  123,
+                  456
+                ],
+                "nodebalancers": [
+                  10301,
+                  10501
+                ],
+                "volumes": [
+                  9082,
+                  10003
+                ]
+              },
               "schema": {
                 "additionalProperties": false,
                 "properties": {
                   "domains": {
-                    "description": "A list of Domain IDs to apply the new Tag to.  You must be allowed to `read_write` all of the requested Domains, or the Tag will not be created and an error will be returned.",
+                    "description": "The `id` values for the domains where you want to apply the tag. You need `read_write` access to each domain. If you don't, the API won't create the tag and you'll receive an error. You can run the [List domains](https://techdocs.akamai.com/linode-api/reference/get-domains) operation to store the `id` for desired domains and to review any `tags` currently applied.",
                     "example": [
                       564,
                       565
@@ -115454,14 +123116,14 @@
                     "type": "array"
                   },
                   "label": {
-                    "description": "The new Tag.",
+                    "description": "The name of your tag. This is used for display purposes.",
                     "example": "{{label}}",
                     "maxLength": 50,
                     "minLength": 3,
                     "type": "string"
                   },
                   "linodes": {
-                    "description": "A list of Linode IDs to apply the new Tag to.  You must be allowed to `read_write` all of the requested Linodes, or the Tag will not be created and an error will be returned.",
+                    "description": "The `id` values for the Linodes where you want to apply the tag. You need `read_write` access to each Linode. If you don't, the API won't create the tag and you'll receive an error. You can run the [List Linodes](https://techdocs.akamai.com/linode-api/reference/get-linode-instances) operation to store the `id` for desired Linodes and to review any `tags` currently applied.",
                     "example": [
                       123,
                       456
@@ -115472,7 +123134,7 @@
                     "type": "array"
                   },
                   "nodebalancers": {
-                    "description": "A list of NodeBalancer IDs to apply the new Tag to. You must be allowed to `read_write` all of the requested NodeBalancers, or the Tag will not be created and an error will be returned.",
+                    "description": "The `id` values for the NodeBalancers where you want to apply the tag. You need `read_write` access to each NodeBalancer. If you don't, the API won't create the tag and you'll receive an error. You can run the [List NodeBalancers](https://techdocs.akamai.com/linode-api/reference/get-node-balancers) operation to store the `id` for desired NodeBalancers and to review any `tags` currently applied.",
                     "example": [
                       10301,
                       10501
@@ -115483,7 +123145,7 @@
                     "type": "array"
                   },
                   "volumes": {
-                    "description": "A list of Volume IDs to apply the new Tag to.  You must be allowed to `read_write` all of the requested Volumes, or the Tag will not be created and an error will be returned.",
+                    "description": "The `id` values for the Linode volumes where you want to apply the tag. You need `read_write` access to each volume. If you don't, the API won't create the tag and you'll receive an error. You can run the [List volumes](https://techdocs.akamai.com/linode-api/reference/get-volumes) operation to store the `id` for desired Linode volumes and to review any `tags` currently applied.",
                     "example": [
                       9082,
                       10003
@@ -115501,24 +123163,23 @@
                 "x-akamai": {
                   "file-path": "schemas/added-post-tag.yaml"
                 }
-              },
-              "x-example": {
-                "x-ref": "../examples/post-tag.json"
               }
             }
-          },
-          "description": "The tag to create, and optionally the objects to tag."
+          }
         },
         "responses": {
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "label": "example tag"
+                },
                 "schema": {
                   "additionalProperties": false,
-                  "description": "A tag that has been applied to an object on your Account. Tags are currently for organizational purposes only.",
+                  "description": "A tag you've created to apply to objects on your account. Tags are for organizational purposes only.",
                   "properties": {
                     "label": {
-                      "description": "A Label used for organization of objects on your Account.",
+                      "description": "The name of the tag used for organization of objects on your account.",
                       "example": "example tag",
                       "type": "string"
                     }
@@ -115527,13 +123188,10 @@
                   "x-akamai": {
                     "file-path": "schemas/tag.yaml"
                   }
-                },
-                "x-example": {
-                  "x-ref": "../examples/post-tag-200.json"
                 }
               }
             },
-            "description": "The new Tag."
+            "description": "The new tag."
           },
           "default": {
             "content": {
@@ -115604,7 +123262,7 @@
         "x-linode-grant": "unrestricted only"
       },
       "get": {
-        "description": "Tags are User-defined labels attached to objects in your Account, such as Linodes. They are used for specifying and grouping attributes of objects that are relevant to the User.\n\nThis operation returns a paginated list of Tags on your account.\n\n__Important__. You must be an unrestricted User in order to access, add, or modify Tags information.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli tags list\nlinode-cli tags ls\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Returns a paginated list of tags you've [created](https://techdocs.akamai.com/linode-api/reference/post-tag) on your account.\n> \ud83d\udcd8\n>\n> This operation can only be accessed by account users with _unrestricted_ access.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli tags list\nlinode-cli tags ls\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-tags"
@@ -115648,16 +123306,26 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": [
+                    {
+                      "label": "example tag"
+                    }
+                  ],
+                  "page": 1,
+                  "pages": 1,
+                  "results": 1
+                },
                 "schema": {
                   "additionalProperties": false,
                   "properties": {
                     "data": {
                       "items": {
                         "additionalProperties": false,
-                        "description": "A tag that has been applied to an object on your Account. Tags are currently for organizational purposes only.",
+                        "description": "A tag you've created to apply to objects on your account. Tags are for organizational purposes only.",
                         "properties": {
                           "label": {
-                            "description": "A Label used for organization of objects on your Account.",
+                            "description": "The name of the tag used for organization of objects on your account.",
                             "example": "example tag",
                             "type": "string"
                           }
@@ -115692,13 +123360,10 @@
                   "x-akamai": {
                     "file-path": "schemas/added-get-tags-200.yaml"
                   }
-                },
-                "x-example": {
-                  "x-ref": "../examples/get-tags-200.json"
                 }
               }
             },
-            "description": "A paginated list of Tags."
+            "description": "A paginated list of tags."
           },
           "default": {
             "content": {
@@ -115798,7 +123463,7 @@
     },
     "/{apiVersion}/tags/{tagLabel}": {
       "get": {
-        "description": "Returns a paginated list of all objects you've tagged with the requested Tag. This is a mixed collection of all object types.\n\n__Important__. You must be an unrestricted User in order to access, add, or modify Tags information.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    account:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Returns a paginated list of all objects you've tagged with the specified tag. The response includes a mixed collection of all object types.\n\n> \ud83d\udcd8\n>\n> This operation can only be accessed by account users with _unrestricted_ access.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    account:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-tagged-objects"
@@ -115842,6 +123507,75 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": [
+                    {
+                      "data": {
+                        "alerts": {
+                          "cpu": 180,
+                          "io": 10000,
+                          "network_in": 10,
+                          "network_out": 10,
+                          "transfer_quota": 80
+                        },
+                        "backups": {
+                          "available": true,
+                          "enabled": true,
+                          "last_successful": "2018-01-01T00:01:01",
+                          "schedule": {
+                            "day": "Saturday",
+                            "window": "W22"
+                          }
+                        },
+                        "capabilities": [
+                          "Block Storage Encryption"
+                        ],
+                        "created": "2018-01-01T00:01:01",
+                        "disk_encryption": "disabled",
+                        "group": "Linode-Group",
+                        "has_user_data": true,
+                        "host_uuid": "1a2bcd34e5f67gh8ij901234567kl89mn01opqr2",
+                        "hypervisor": "kvm",
+                        "id": 123,
+                        "image": "linode/debian10",
+                        "interface_generation": "linode",
+                        "ipv4": [
+                          "203.0.113.1",
+                          "192.0.2.1"
+                        ],
+                        "ipv6": "c001:d00d::1337/128",
+                        "label": "linode123",
+                        "lke_cluster_id": 1,
+                        "placement_group": {
+                          "id": 528,
+                          "label": "PG_Miami_failover",
+                          "placement_group_policy": "strict",
+                          "placement_group_type": "anti-affinity:local"
+                        },
+                        "region": "us-east",
+                        "specs": {
+                          "disk": 81920,
+                          "gpus": 0,
+                          "memory": 4096,
+                          "transfer": 4000,
+                          "vcpus": 2
+                        },
+                        "status": "running",
+                        "tags": [
+                          "example tag",
+                          "another example"
+                        ],
+                        "type": "g6-standard-1",
+                        "updated": "2018-01-01T00:01:01",
+                        "watchdog_enabled": true
+                      },
+                      "type": "linode"
+                    }
+                  ],
+                  "page": 1,
+                  "pages": 1,
+                  "results": 1
+                },
                 "schema": {
                   "additionalProperties": false,
                   "properties": {
@@ -115850,9 +123584,7 @@
                         "additionalProperties": false,
                         "properties": {
                           "data": {
-                            "discriminator": {
-                              "propertyName": "type"
-                            },
+                            "description": "Details on the the specific object `type` the tag is assigned to.",
                             "oneOf": [
                               {
                                 "additionalProperties": false,
@@ -115980,14 +123712,11 @@
                                   },
                                   "disk_encryption": {
                                     "default": "enabled",
-                                    "description": "__Limited availability__, __Read-only__ Indicates the local disk encryption setting for this Linode. If the Linode is part of an LKE cluster, the value is `null`.",
+                                    "description": "__Read-only__ Indicates the local disk encryption setting for this Linode. If the Linode is part of an LKE cluster, the value is `null`.",
                                     "example": "disabled",
                                     "nullable": true,
                                     "readOnly": true,
                                     "type": "string",
-                                    "x-akamai": {
-                                      "status": "LA"
-                                    },
                                     "x-linode-cli-display": 8
                                   },
                                   "group": {
@@ -116299,8 +124028,7 @@
                                 "type": "object",
                                 "x-akamai": {
                                   "file-path": "schemas/linode.yaml"
-                                },
-                                "x-linode-ref-name": "linode"
+                                }
                               },
                               {
                                 "additionalProperties": false,
@@ -116449,8 +124177,7 @@
                                 "type": "object",
                                 "x-akamai": {
                                   "file-path": "schemas/domain.yaml"
-                                },
-                                "x-linode-ref-name": "domain"
+                                }
                               },
                               {
                                 "additionalProperties": false,
@@ -116588,8 +124315,7 @@
                                 "type": "object",
                                 "x-akamai": {
                                   "file-path": "schemas/volume.yaml"
-                                },
-                                "x-linode-ref-name": "volume"
+                                }
                               },
                               {
                                 "additionalProperties": false,
@@ -116774,12 +124500,18 @@
                                 "type": "object",
                                 "x-akamai": {
                                   "file-path": "schemas/node-balancer.yaml"
-                                },
-                                "x-linode-ref-name": "nodeBalancer"
+                                }
                               }
                             ]
                           },
                           "type": {
+                            "description": "The type of object the tag is applied to.",
+                            "enum": [
+                              "domain",
+                              "linode",
+                              "nodebalancer",
+                              "volume"
+                            ],
                             "example": "linode",
                             "type": "string"
                           }
@@ -116811,13 +124543,10 @@
                   "x-akamai": {
                     "file-path": "schemas/added-get-tagged-objects-200.yaml"
                   }
-                },
-                "x-example": {
-                  "x-ref": "../examples/get-tagged-objects-200.json"
                 }
               }
             },
-            "description": "A paginated list of objects, organized by type, that have been tagged with the requested Tag."
+            "description": "A paginated list of objects, organized by type, that have been tagged with the requested tag."
           },
           "default": {
             "content": {
@@ -116883,12 +124612,12 @@
         "x-linode-cli-skip": true
       },
       "delete": {
-        "description": "Remove a Tag from all objects and delete it.\n\n__Important__. You must be an unrestricted User in order to access, add, or modify Tags information.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli tags delete\nlinode-cli tags rm\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Removes a tag from all objects and deletes it.\n\n> \ud83d\udcd8\n>\n> This operation can only be accessed by account users with _unrestricted_ access.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli tags delete\nlinode-cli tags rm\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
-          "url": "https://techdocs.akamai.com/linode-api/reference/delete-ag"
+          "url": "https://techdocs.akamai.com/linode-api/reference/delete-tag"
         },
-        "operationId": "delete-ag",
+        "operationId": "delete-tag",
         "responses": {
           "200": {
             "content": {
@@ -116902,7 +124631,7 @@
                   }
                 },
                 "x-example": {
-                  "x-ref": "../examples/delete-ag-200.json"
+                  "x-ref": "../examples/delete-tag-200.json"
                 }
               }
             },


### PR DESCRIPTION
Updates to include support for advanced configuration in MySQL and PostgreSQL Managed Databases.

# Added

Use these operations to view the advanced configuration options available for use:

- **List MySQL Managed Database advanced parameters** ([GET /databases/mysql/config](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-config))
- **List PostgreSQL Managed Database advanced parameters** ([GET /databases/postgresql/config](https://techdocs.akamai.com/linode-api/reference/get-databases-postgresql-config))

# Updated

These operations have been updated for advanced configuration support:

- **Create or restore a MySQL Managed Database** ([POST /databases/mysql/instances](https://techdocs.akamai.com/linode-api/reference/post-databases-mysql-instances))
- **List MySQL Managed Databases** ([GET /databases/mysql/instances](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-instances))
- **Get a MySQL Managed Database** ([GET /databases/mysql/instances/{instanceId}](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-instance))
- **Update a MySQL Managed Database** ([PUT /databases/mysql/instances/{instanceId}](https://techdocs.akamai.com/linode-api/reference/put-databases-mysql-instance))
- **Create or restore a PostgreSQL Managed Database** ([POST /databases/postgresql/instances](https://techdocs.akamai.com/linode-api/reference/post-databases-postgre-sql-instances))
- **List PostgreSQL Managed Databases** ([GET /databases/postgresql/instances](https://techdocs.akamai.com/linode-api/reference/get-databases-postgre-sql-instances))
- **Get a PostgreSQL Managed Database** ([GET /databases/postgresql/instances/{instanceId}](https://techdocs.akamai.com/linode-api/reference/get-databases-postgre-sql-instance))
- **Update a PostgreSQL Managed Database** ([PUT /databases/postgresql/instances/{instanceId}](https://techdocs.akamai.com/linode-api/reference/put-databases-postgre-sql-instance))