### PR TITLE
Update openapi.json file (2025-08-26)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -726,6 +726,19 @@
             "type": "string",
             "x-linode-cli-display": 2
           },
+          "maintenance_policy": {
+            "description": "__Beta__ Defines the default maintenance policy for new Linodes created on this account. Review [maintenance policy](https://techdocs.akamai.com/cloud-computing/docs/host-maintenance-policy) documentation for more details.",
+            "enum": [
+              "linode/migrate",
+              "linode/power_off_on"
+            ],
+            "example": "linode/migrate",
+            "type": "string",
+            "x-akamai": {
+              "status": "BETA"
+            },
+            "x-linode-cli-display": 7
+          },
           "managed": {
             "description": "__Read-only__ Our 24/7 incident response service. This robust, multi-homed monitoring system distributes monitoring checks to ensure that your servers remain online and available at all times. Linode Managed can monitor any service or software stack reachable over TCP or HTTP. Once you add a service to Linode Managed, we'll monitor it for connectivity, response, and total request time.",
             "example": true,
@@ -1821,17 +1834,42 @@
               "additionalProperties": false,
               "description": "Information about maintenance affecting an entity.",
               "properties": {
+                "complete_time": {
+                  "description": "__Beta__, __Filterable__ The time the maintenance completed. This field is [filterable](https://techdocs.akamai.com/linode-api/reference/filtering-and-sorting) based on these parameters:\n\n- A single ISO 8601 timestamp (`yyyy-mm-ddThh:mm:ss`), which returns only matches for that value.\n\n- Pairs of operator string keys (`+or`, `+gt`, `+gte`, `+lt`, `+lte`, or `+neq`) and single ISO 8601 timestamp. The `+or` operator accepts an array of values that can consist of single date-time strings or dictionaries of inequality operator pairs.",
+                  "example": "2020-07-09T00:01:01",
+                  "format": "date-time",
+                  "type": "string",
+                  "x-akamai": {
+                    "labels": [
+                      "Filterable"
+                    ],
+                    "status": "BETA"
+                  },
+                  "x-linode-filterable": true
+                },
+                "description": {
+                  "description": "__Beta__ Differentiates between scheduled and emergency maintenance.",
+                  "enum": [
+                    "Scheduled Maintenance",
+                    "Emergency Maintenance"
+                  ],
+                  "example": "Scheduled Maintenance",
+                  "type": "string",
+                  "x-akamai": {
+                    "status": "BETA"
+                  }
+                },
                 "entity": {
                   "additionalProperties": false,
-                  "description": "The entity being affected by maintenance.",
+                  "description": "The entity affected by the maintenance.",
                   "properties": {
                     "id": {
-                      "description": "The id of the entity being affected by maintenance.",
+                      "description": "The unique identifier of the entity targeted by the maintenance.",
                       "example": 1234,
                       "type": "number"
                     },
                     "label": {
-                      "description": "The label of the entity being affected by maintenance.",
+                      "description": "The name of the entity targeted by the maintenance.",
                       "example": "demo-linode",
                       "type": "string"
                     },
@@ -1841,24 +1879,77 @@
                       "type": "string"
                     },
                     "url": {
-                      "description": "The API endpoint prefix to use in combination with the entity id to find specific information about the entity.",
+                      "description": "A combination of the API operation prefix and the entity's `id` that can be used to review the entity.",
                       "example": "https://api.linode.com/v4/linode/instances/{linodeId}",
                       "type": "string"
                     }
                   },
                   "type": "object"
                 },
+                "maintenance_policy_set": {
+                  "description": "__Beta__, __Filterable__ The maintenance policy configured by the user.",
+                  "example": "linode/migrate",
+                  "type": "string",
+                  "x-akamai": {
+                    "labels": [
+                      "Filterable"
+                    ],
+                    "status": "BETA"
+                  },
+                  "x-linode-filterable": true
+                },
+                "not_before": {
+                  "description": "__Beta__, __Filterable__ The earliest time when the maintenance can start. This field is [filterable](https://techdocs.akamai.com/linode-api/reference/filtering-and-sorting) based on these parameters:\n\n- A single ISO 8601 timestamp (`yyyy-mm-ddThh:mm:ss`), which returns only matches for that value.\n\n- Pairs of operator string keys (`+or`, `+gt`, `+gte`, `+lt`, `+lte`, or `+neq`) and single ISO 8601 timestamp. The `+or` operator accepts an array of values that can consist of single date-time strings or dictionaries of inequality operator pairs.",
+                  "example": "2020-07-09T00:01:01",
+                  "format": "date-time",
+                  "type": "string",
+                  "x-akamai": {
+                    "labels": [
+                      "Filterable"
+                    ],
+                    "status": "BETA"
+                  },
+                  "x-linode-filterable": true
+                },
                 "reason": {
                   "description": "The reason maintenance is being performed.",
                   "example": "This maintenance will allow us to update the BIOS on the host's motherboard.",
                   "type": "string"
                 },
-                "status": {
-                  "description": "__Filterable__ The maintenance status.\n\nMaintenance progresses in the following sequence: pending, started, then completed.",
+                "source": {
+                  "description": "__Beta__ The origin of the maintenance. A `platform` source indicates that the maintenance was initiated by Akamai. A `user` source indicates that the maintenance was initiated by the user.",
                   "enum": [
-                    "completed",
+                    "platform",
+                    "user"
+                  ],
+                  "example": "platform",
+                  "type": "string",
+                  "x-akamai": {
+                    "status": "BETA"
+                  }
+                },
+                "start_time": {
+                  "description": "__Beta__, __Filterable__ The time the maintenance started. This field is [filterable](https://techdocs.akamai.com/linode-api/reference/filtering-and-sorting) based on these parameters:\n\n- A single ISO 8601 timestamp (`yyyy-mm-ddThh:mm:ss`), which returns only matches for that value.\n\n- Pairs of operator string keys (`+or`, `+gt`, `+gte`, `+lt`, `+lte`, or `+neq`) and single ISO 8601 timestamp. The `+or` operator accepts an array of values that can consist of single date-time strings or dictionaries of inequality operator pairs.",
+                  "example": "2020-07-09T00:01:01",
+                  "format": "date-time",
+                  "type": "string",
+                  "x-akamai": {
+                    "labels": [
+                      "Filterable"
+                    ],
+                    "status": "BETA"
+                  },
+                  "x-linode-filterable": true
+                },
+                "status": {
+                  "description": "__Filterable__ The maintenance status. Maintenance progress follows the sequence `pending`, `scheduled`, `started`, and `completed`. A `scheduled` status is unique to Linodes that require a reboot for [QEMU maintenance](https://techdocs.akamai.com/linode-api/reference/reboot-your-linodes-for-qemu-maintenance).",
+                  "enum": [
                     "pending",
-                    "started"
+                    "scheduled",
+                    "started",
+                    "in-progress",
+                    "completed",
+                    "canceled"
                   ],
                   "example": "started",
                   "type": "string",
@@ -1874,7 +1965,9 @@
                   "enum": [
                     "reboot",
                     "cold_migration",
-                    "live_migration"
+                    "live_migration",
+                    "migrate",
+                    "power_off_on"
                   ],
                   "example": "reboot",
                   "type": "string",
@@ -1886,7 +1979,7 @@
                   "x-linode-filterable": true
                 },
                 "when": {
-                  "description": "__Filterable__ When the maintenance will begin.\n\n[Filterable](https://techdocs.akamai.com/linode-api/reference/filtering-and-sorting) with the following parameters:\n\n- A single value in date-time string format (`%Y-%m-%dT%H:%M:%S`), which returns only matches to that value.\n\n- A dictionary containing pairs of inequality operator string keys (`+or`, `+gt`, `+gte`, `+lt`, `+lte`, or `+neq`) and single date-time string format values (`%Y-%m-%dT%H:%M:%S`). `+or` accepts an array of values that may consist of single date-time strings or dictionaries of inequality operator pairs.",
+                  "description": "__Filterable__ The start time for the maintenance. This field is [filterable](https://techdocs.akamai.com/linode-api/reference/filtering-and-sorting) based on these parameters:\n\n- A single ISO 8601 timestamp (yyyy-mm-ddThh:mm:ss), which returns only matches for that value.\n\n- Pairs of operator string keys (`+or`, `+gt`, `+gte`, `+lt`, `+lte`, or `+neq`) and single ISO 8601 timestamp. The `+or` operator accepts an array of values that can consist of single date-time strings or dictionaries of inequality operator pairs.",
                   "example": "2020-07-09T00:01:01",
                   "format": "date-time",
                   "type": "string",
@@ -1938,15 +2031,15 @@
               "description": "An important, often time-sensitive item related to your account.",
               "properties": {
                 "body": {
-                  "description": "__Read-only__ A full description of this notification, in markdown format. Not all notifications include a `body`.",
+                  "description": "A full description of this notification, in markdown format. Not all notifications include a `body`. Returned as `null` for an event `type` of `security_reboot_maintenance_scheduled`.",
                   "example": null,
                   "nullable": true,
-                  "readOnly": true,
                   "type": "string"
                 },
                 "entity": {
                   "additionalProperties": false,
-                  "description": "__Read-only__ Detailed information about the notification.",
+                  "description": "Detailed information about the notification. Returned as `null` for an event `type` of `security_reboot_maintenance_scheduled`.",
+                  "nullable": true,
                   "properties": {
                     "id": {
                       "description": "The unique ID of the notification's entity, based on the entity type. Returns `null` for an `account` or `promotion` entity.",
@@ -1955,13 +2048,13 @@
                       "type": "integer"
                     },
                     "label": {
-                      "description": "The current label for this notification's entity.\n\nReturns `null` for the following entity types:\n\n- `entity_transfer`\n- `promotion`\n- `region`",
+                      "description": "The current name of this notification's entity. Returns `null` for the following `entity` types:\n\n- `entity_transfer`\n\n- `promotion`\n\n- `region`",
                       "example": "Linode not booting.",
                       "nullable": true,
                       "type": "string"
                     },
                     "type": {
-                      "description": "The type of entity this is related to.",
+                      "description": "__Filterable__ The type of entity this is related to. An entity can be product or service-specific, such as a `linode`, `loadbalancers`, or `nodebalancers`. It can apply to a specific component, such as your `account`, a specific `promotion` your participating in, a data center (`region`) where you're using services, a transfer from one component to another (an `entity_transfer`), a support `ticket` you've opened, or a `volume` on a specific Linode.",
                       "enum": [
                         "account",
                         "entity_transfer",
@@ -1974,7 +2067,13 @@
                         "volume"
                       ],
                       "example": "ticket",
-                      "type": "string"
+                      "type": "string",
+                      "x-akamai": {
+                        "labels": [
+                          "Filterable"
+                        ]
+                      },
+                      "x-linode-filterable": true
                     },
                     "url": {
                       "description": "The URL where you can access the notification's object. The URL is relative to the domain where you retrieved the notification. This value is `null` for the `promotion` entity type.",
@@ -1983,32 +2082,28 @@
                       "type": "string"
                     }
                   },
-                  "readOnly": true,
                   "type": "object"
                 },
                 "label": {
-                  "description": "__Read-only__ A short description of this notification.",
+                  "description": "A short description of this notification.",
                   "example": "You have an important ticket open!",
-                  "readOnly": true,
                   "type": "string",
                   "x-linode-cli-display": 1
                 },
                 "message": {
-                  "description": "__Read-only__ A human-readable description of the notification.",
+                  "description": "A human-readable description of the notification.",
                   "example": "You have an important ticket open!",
-                  "readOnly": true,
                   "type": "string",
                   "x-linode-cli-display": 2
                 },
                 "severity": {
-                  "description": "__Read-only__ The severity of this notification. This field determines how prominently the notification is displayed and the color of the display text.",
+                  "description": "The severity of this notification. This field determines how prominently the notification is displayed and the color of the display text.",
                   "enum": [
                     "minor",
                     "major",
                     "critical"
                   ],
                   "example": "major",
-                  "readOnly": true,
                   "type": "string",
                   "x-linode-cli-color": {
                     "critical": "b",
@@ -2018,7 +2113,7 @@
                   "x-linode-cli-display": 3
                 },
                 "type": {
-                  "description": "__Read-only__ The type of notification.",
+                  "description": "__Filterable__ The type of notification.\n\n> \ud83d\udcd8\n>\n> A `security_reboot_maintenance_scheduled` event is a global notice that a Linode needs to be rebooted for QEMU upgrade maintenance. Have a look at [this workflow](https://techdocs.akamai.com/linode-api/reference/reboot-your-linodes-for-qemu-maintenance) for guidance on reboooting your Linodes for this maintenance.",
                   "enum": [
                     "migration_scheduled",
                     "migration_imminent",
@@ -2030,19 +2125,25 @@
                     "ticket_abuse",
                     "notice",
                     "maintenance",
+                    "maintenance_scheduled",
                     "promotion",
+                    "security_reboot_maintenance_scheduled",
                     "tax_id_verifying"
                   ],
                   "example": "ticket_important",
-                  "readOnly": true,
-                  "type": "string"
+                  "type": "string",
+                  "x-akamai": {
+                    "labels": [
+                      "Filterable"
+                    ]
+                  },
+                  "x-linode-filterable": true
                 },
                 "until": {
-                  "description": "__Read-only__ If this notification has a duration, this is when the event or action will complete. For example, if there's scheduled maintenance for one of our systems, `until` represents the end of the maintenance window.",
+                  "description": "If this notification has a duration, this is when the event or action will complete. For example, if there's scheduled maintenance for one of our systems, `until` represents the end of the maintenance window. Returned as `null` for an event `type` of `security_reboot_maintenance_scheduled`.",
                   "example": null,
                   "format": "date-time",
                   "nullable": true,
-                  "readOnly": true,
                   "type": "string",
                   "x-linode-cli-color": {
                     "None": "black",
@@ -2051,11 +2152,10 @@
                   "x-linode-cli-display": 5
                 },
                 "when": {
-                  "description": "__Read-only__ If this notification is for an event in the future, this specifies when the action occurs. For example, if a compute instance needs to migrate in response to a security advisory, this field sets the approximate time the compute instance will be taken offline for migration.",
+                  "description": "If this notification is for an event in the future, this specifies when the action occurs. For example, if a compute instance needs to migrate in response to a security advisory, this field sets the approximate time the compute instance will be taken offline for migration. Returned as `null` for an event `type` of `security_reboot_maintenance_scheduled`.",
                   "example": null,
                   "format": "date-time",
                   "nullable": true,
-                  "readOnly": true,
                   "type": "string",
                   "x-linode-cli-color": {
                     "None": "black",
@@ -2550,7 +2650,7 @@
             "description": "The type of user on an account. Mostly applies to the use of the parent and child accounts for Akamai partners functionality.",
             "properties": {
               "user_type": {
-                "description": "__Read-only__ If the user belongs to a [parent or child account](https://www.linode.com/docs/guides/parent-child-accounts/) relationship, this defines the user type in the respective account. Possible values include:\n\n- `parent`. This is a user in an Akamai partner account. Akamai partners have a contractural relationship with their end customers, to sell Akamai services. This user can either have full access (a parent account admin user) or limited access. Limited users don't have access to manage child accounts, but they can be granted this access by an admin user.\n\n- `child`. This is an Akamai partner's end customer user, in a child account. A child user can have either full or limited access. Full access lets the user manage other child users and the proxy user in a child account.\n\n- `proxy`. This is a user on a child account that gives parent account users access to that child account. A parent account user with the `child_account_access` grant can [Create a proxy user token](https://techdocs.akamai.com/linode-api/reference/post-child-account-token) from the parent account. The parent user can use this token to run API operations from the child account, as if they were a child user.\n\n- `default`. This applies to all regular, non-parent-child account users.",
+                "description": "__Read-only__ If the user belongs to a [parent or child account](https://www.linode.com/docs/guides/parent-child-accounts/) relationship, this defines the user type in the respective account. Possible values include:\n\n- `parent`. This is a user in an Akamai partner account. Akamai partners have a contractual relationship with their end customers, to sell Akamai services. This user can either have full access (a parent account admin user) or limited access. Limited users don't have access to manage child accounts, but they can be granted this access by an admin user.\n\n- `child`. This is an Akamai partner's end customer user, in a child account. A child user can have either full or limited access. Full access lets the user manage other child users and the proxy user in a child account.\n\n- `proxy`. This is a user on a child account that gives parent account users access to that child account. A parent account user with the `child_account_access` grant can [Create a proxy user token](https://techdocs.akamai.com/linode-api/reference/post-child-account-token) from the parent account. The parent user can use this token to run API operations from the child account, as if they were a child user.\n\n- `default`. This applies to all regular, non-parent-child account users.",
                 "enum": [
                   "parent",
                   "child",
@@ -2681,7 +2781,7 @@
                   "description": "The type of user on an account. Mostly applies to the use of the parent and child accounts for Akamai partners functionality.",
                   "properties": {
                     "user_type": {
-                      "description": "__Read-only__ If the user belongs to a [parent or child account](https://www.linode.com/docs/guides/parent-child-accounts/) relationship, this defines the user type in the respective account. Possible values include:\n\n- `parent`. This is a user in an Akamai partner account. Akamai partners have a contractural relationship with their end customers, to sell Akamai services. This user can either have full access (a parent account admin user) or limited access. Limited users don't have access to manage child accounts, but they can be granted this access by an admin user.\n\n- `child`. This is an Akamai partner's end customer user, in a child account. A child user can have either full or limited access. Full access lets the user manage other child users and the proxy user in a child account.\n\n- `proxy`. This is a user on a child account that gives parent account users access to that child account. A parent account user with the `child_account_access` grant can [Create a proxy user token](https://techdocs.akamai.com/linode-api/reference/post-child-account-token) from the parent account. The parent user can use this token to run API operations from the child account, as if they were a child user.\n\n- `default`. This applies to all regular, non-parent-child account users.",
+                      "description": "__Read-only__ If the user belongs to a [parent or child account](https://www.linode.com/docs/guides/parent-child-accounts/) relationship, this defines the user type in the respective account. Possible values include:\n\n- `parent`. This is a user in an Akamai partner account. Akamai partners have a contractual relationship with their end customers, to sell Akamai services. This user can either have full access (a parent account admin user) or limited access. Limited users don't have access to manage child accounts, but they can be granted this access by an admin user.\n\n- `child`. This is an Akamai partner's end customer user, in a child account. A child user can have either full or limited access. Full access lets the user manage other child users and the proxy user in a child account.\n\n- `proxy`. This is a user on a child account that gives parent account users access to that child account. A parent account user with the `child_account_access` grant can [Create a proxy user token](https://techdocs.akamai.com/linode-api/reference/post-child-account-token) from the parent account. The parent user can use this token to run API operations from the child account, as if they were a child user.\n\n- `default`. This applies to all regular, non-parent-child account users.",
                       "enum": [
                         "parent",
                         "child",
@@ -3322,7 +3422,7 @@
             "description": "The type of user on an account. Mostly applies to the use of the parent and child accounts for Akamai partners functionality.",
             "properties": {
               "user_type": {
-                "description": "__Read-only__ If the user belongs to a [parent or child account](https://www.linode.com/docs/guides/parent-child-accounts/) relationship, this defines the user type in the respective account. Possible values include:\n\n- `parent`. This is a user in an Akamai partner account. Akamai partners have a contractural relationship with their end customers, to sell Akamai services. This user can either have full access (a parent account admin user) or limited access. Limited users don't have access to manage child accounts, but they can be granted this access by an admin user.\n\n- `child`. This is an Akamai partner's end customer user, in a child account. A child user can have either full or limited access. Full access lets the user manage other child users and the proxy user in a child account.\n\n- `proxy`. This is a user on a child account that gives parent account users access to that child account. A parent account user with the `child_account_access` grant can [Create a proxy user token](https://techdocs.akamai.com/linode-api/reference/post-child-account-token) from the parent account. The parent user can use this token to run API operations from the child account, as if they were a child user.\n\n- `default`. This applies to all regular, non-parent-child account users.",
+                "description": "__Read-only__ If the user belongs to a [parent or child account](https://www.linode.com/docs/guides/parent-child-accounts/) relationship, this defines the user type in the respective account. Possible values include:\n\n- `parent`. This is a user in an Akamai partner account. Akamai partners have a contractual relationship with their end customers, to sell Akamai services. This user can either have full access (a parent account admin user) or limited access. Limited users don't have access to manage child accounts, but they can be granted this access by an admin user.\n\n- `child`. This is an Akamai partner's end customer user, in a child account. A child user can have either full or limited access. Full access lets the user manage other child users and the proxy user in a child account.\n\n- `proxy`. This is a user on a child account that gives parent account users access to that child account. A parent account user with the `child_account_access` grant can [Create a proxy user token](https://techdocs.akamai.com/linode-api/reference/post-child-account-token) from the parent account. The parent user can use this token to run API operations from the child account, as if they were a child user.\n\n- `default`. This applies to all regular, non-parent-child account users.",
                 "enum": [
                   "parent",
                   "child",
@@ -3995,6 +4095,7 @@
               "linode_migrate_datacenter_create",
               "linode_mutate",
               "linode_mutate_create",
+              "linode_poweroff_on",
               "linode_reboot",
               "linode_rebuild",
               "linode_resize",
@@ -4102,6 +4203,15 @@
             "type": "string",
             "x-linode-cli-display": 3
           },
+          "complete_time": {
+            "description": "__Beta__ The time the maintenance completed. This field is [filterable](https://techdocs.akamai.com/linode-api/reference/filtering-and-sorting) based on these parameters:\n\n- A single ISO 8601 timestamp (`yyyy-mm-ddThh:mm:ss`), which returns only matches for that value.\n\n- Pairs of operator string keys (`+or`, `+gt`, `+gte`, `+lt`, `+lte`, or `+neq`) and single ISO 8601 timestamp. The `+or` operator accepts an array of values that can consist of single date-time strings or dictionaries of inequality operator pairs.",
+            "example": "2020-07-09T00:01:01",
+            "format": "date-time",
+            "type": "string",
+            "x-akamai": {
+              "status": "BETA"
+            }
+          },
           "created": {
             "description": "__Read-only__ When the system created this event.",
             "example": "2018-01-01T00:01:01",
@@ -4109,6 +4219,18 @@
             "readOnly": true,
             "type": "string",
             "x-linode-cli-display": 6
+          },
+          "description": {
+            "description": "__Beta__ Differentiates between scheduled and emergency maintenance.",
+            "enum": [
+              "Scheduled Maintenance",
+              "Emergency Maintenance"
+            ],
+            "example": "Scheduled Maintenance",
+            "type": "string",
+            "x-akamai": {
+              "status": "BETA"
+            }
           },
           "duration": {
             "description": "__Read-only__ The number of seconds that it takes for the event to complete.",
@@ -4179,12 +4301,29 @@
             "type": "integer",
             "x-linode-cli-display": 1
           },
+          "maintenance_policy_set": {
+            "description": "__Beta__ The maintenance policy configured by the user for this event.",
+            "example": "linode/migrate",
+            "type": "string",
+            "x-akamai": {
+              "status": "BETA"
+            }
+          },
           "message": {
             "description": "Additional information about the event. This can be a more detailed representation of an event that can help you diagnose non-obvious failures.",
             "example": "None",
             "nullable": true,
             "type": "string",
             "x-linode-cli-display": 9
+          },
+          "not_before": {
+            "description": "__Beta__ The scheduled start time for the event. This field is [filterable](https://techdocs.akamai.com/linode-api/reference/filtering-and-sorting) based on these parameters:\n\n- A single ISO 8601 timestamp (`yyyy-mm-ddThh:mm:ss`), which returns only matches for that value.\n\n- Pairs of operator string keys (`+or`, `+gt`, `+gte`, `+lt`, `+lte`, or `+neq`) and single ISO 8601 timestamp. The `+or` operator accepts an array of values that can consist of single date-time strings or dictionaries of inequality operator pairs.",
+            "example": "2020-07-09T00:01:01",
+            "format": "date-time",
+            "type": "string",
+            "x-akamai": {
+              "status": "BETA"
+            }
           },
           "percent_complete": {
             "description": "__Read-only__ A percentage estimating the amount of time remaining for an event. Returned as `null` for notification events.",
@@ -4240,6 +4379,27 @@
             "example": true,
             "readOnly": true,
             "type": "boolean"
+          },
+          "source": {
+            "description": "__Beta__ The origin of the event. A `platform` source indicates that the event was initiated by Akamai. A `user` source indicates that the event was initiated by the user.",
+            "enum": [
+              "platform",
+              "user"
+            ],
+            "example": "platform",
+            "type": "string",
+            "x-akamai": {
+              "status": "BETA"
+            }
+          },
+          "start_time": {
+            "description": "__Beta__ The actual start time for the event. This field is [filterable](https://techdocs.akamai.com/linode-api/reference/filtering-and-sorting) based on these parameters:\n\n- A single ISO 8601 timestamp (`yyyy-mm-ddThh:mm:ss`), which returns only matches for that value.\n\n- Pairs of operator string keys (`+or`, `+gt`, `+gte`, `+lt`, `+lte`, or `+neq`) and single ISO 8601 timestamp. The `+or` operator accepts an array of values that can consist of single date-time strings or dictionaries of inequality operator pairs.",
+            "example": "2020-07-09T00:01:01",
+            "format": "date-time",
+            "type": "string",
+            "x-akamai": {
+              "status": "BETA"
+            }
           },
           "status": {
             "description": "__Read-only__ The current status of this event.",
@@ -4374,6 +4534,7 @@
                     "linode_migrate_datacenter_create",
                     "linode_mutate",
                     "linode_mutate_create",
+                    "linode_poweroff_on",
                     "linode_reboot",
                     "linode_rebuild",
                     "linode_resize",
@@ -4486,6 +4647,19 @@
                   "x-linode-cli-display": 3,
                   "x-linode-filterable": true
                 },
+                "complete_time": {
+                  "description": "__Beta__, __Filterable__ The time the maintenance completed. This field is [filterable](https://techdocs.akamai.com/linode-api/reference/filtering-and-sorting) based on these parameters:\n\n- A single ISO 8601 timestamp (`yyyy-mm-ddThh:mm:ss`), which returns only matches for that value.\n\n- Pairs of operator string keys (`+or`, `+gt`, `+gte`, `+lt`, `+lte`, or `+neq`) and single ISO 8601 timestamp. The `+or` operator accepts an array of values that can consist of single date-time strings or dictionaries of inequality operator pairs.",
+                  "example": "2020-07-09T00:01:01",
+                  "format": "date-time",
+                  "type": "string",
+                  "x-akamai": {
+                    "labels": [
+                      "Filterable"
+                    ],
+                    "status": "BETA"
+                  },
+                  "x-linode-filterable": true
+                },
                 "created": {
                   "description": "__Filterable__ When the system created this event.",
                   "example": "2018-01-01T00:01:01",
@@ -4497,6 +4671,22 @@
                     ]
                   },
                   "x-linode-cli-display": 6,
+                  "x-linode-filterable": true
+                },
+                "description": {
+                  "description": "__Beta__, __Filterable__ Differentiates between scheduled and emergency maintenance.",
+                  "enum": [
+                    "Scheduled Maintenance",
+                    "Emergency Maintenance"
+                  ],
+                  "example": "Scheduled Maintenance",
+                  "type": "string",
+                  "x-akamai": {
+                    "labels": [
+                      "Filterable"
+                    ],
+                    "status": "BETA"
+                  },
                   "x-linode-filterable": true
                 },
                 "duration": {
@@ -4582,12 +4772,37 @@
                   "x-linode-cli-display": 1,
                   "x-linode-filterable": true
                 },
+                "maintenance_policy_set": {
+                  "description": "__Beta__, __Filterable__ The maintenance policy configured by the user for this event.",
+                  "example": "linode/migrate",
+                  "type": "string",
+                  "x-akamai": {
+                    "labels": [
+                      "Filterable"
+                    ],
+                    "status": "BETA"
+                  },
+                  "x-linode-filterable": true
+                },
                 "message": {
                   "description": "Additional information about the event. This can be a more detailed representation of an event that can help you diagnose non-obvious failures.",
                   "example": "None",
                   "nullable": true,
                   "type": "string",
                   "x-linode-cli-display": 9
+                },
+                "not_before": {
+                  "description": "__Beta__, __Filterable__ The scheduled start time for the event. This field is [filterable](https://techdocs.akamai.com/linode-api/reference/filtering-and-sorting) based on these parameters:\n\n- A single ISO 8601 timestamp (`yyyy-mm-ddThh:mm:ss`), which returns only matches for that value.\n\n- Pairs of operator string keys (`+or`, `+gt`, `+gte`, `+lt`, `+lte`, or `+neq`) and single ISO 8601 timestamp. The `+or` operator accepts an array of values that can consist of single date-time strings or dictionaries of inequality operator pairs.",
+                  "example": "2020-07-09T00:01:01",
+                  "format": "date-time",
+                  "type": "string",
+                  "x-akamai": {
+                    "labels": [
+                      "Filterable"
+                    ],
+                    "status": "BETA"
+                  },
+                  "x-linode-filterable": true
                 },
                 "percent_complete": {
                   "description": "A percentage estimating the amount of time remaining for an event. Returned as `null` for notification events.",
@@ -4644,20 +4859,53 @@
                   "example": true,
                   "type": "boolean"
                 },
+                "source": {
+                  "description": "__Beta__, __Filterable__ The origin of the event. A `platform` source indicates that the event was initiated by Akamai. A `user` source indicates that the event was initiated by the user.",
+                  "enum": [
+                    "platform",
+                    "user"
+                  ],
+                  "example": "platform",
+                  "type": "string",
+                  "x-akamai": {
+                    "labels": [
+                      "Filterable"
+                    ],
+                    "status": "BETA"
+                  },
+                  "x-linode-filterable": true
+                },
+                "start_time": {
+                  "description": "__Beta__, __Filterable__ The actual start time for the event. This field is [filterable](https://techdocs.akamai.com/linode-api/reference/filtering-and-sorting) based on these parameters:\n\n- A single ISO 8601 timestamp (`yyyy-mm-ddThh:mm:ss`), which returns only matches for that value.\n\n- Pairs of operator string keys (`+or`, `+gt`, `+gte`, `+lt`, `+lte`, or `+neq`) and single ISO 8601 timestamp. The `+or` operator accepts an array of values that can consist of single date-time strings or dictionaries of inequality operator pairs.",
+                  "example": "2020-07-09T00:01:01",
+                  "format": "date-time",
+                  "type": "string",
+                  "x-akamai": {
+                    "labels": [
+                      "Filterable"
+                    ],
+                    "status": "BETA"
+                  },
+                  "x-linode-filterable": true
+                },
                 "status": {
                   "description": "The current status of this event.",
                   "enum": [
+                    "completed",
                     "failed",
                     "finished",
+                    "in_progress",
                     "notification",
                     "scheduled",
                     "started"
                   ],
                   "type": "string",
                   "x-linode-cli-color": {
+                    "completed": "green",
                     "default_": "white",
                     "failed": "red",
                     "finished": "green",
+                    "in_progress": "yellow",
                     "started": "yellow"
                   },
                   "x-linode-cli-display": 8
@@ -5484,17 +5732,42 @@
         "additionalProperties": false,
         "description": "Information about maintenance affecting an entity.",
         "properties": {
+          "complete_time": {
+            "description": "__Beta__, __Filterable__ The time the maintenance completed. This field is [filterable](https://techdocs.akamai.com/linode-api/reference/filtering-and-sorting) based on these parameters:\n\n- A single ISO 8601 timestamp (`yyyy-mm-ddThh:mm:ss`), which returns only matches for that value.\n\n- Pairs of operator string keys (`+or`, `+gt`, `+gte`, `+lt`, `+lte`, or `+neq`) and single ISO 8601 timestamp. The `+or` operator accepts an array of values that can consist of single date-time strings or dictionaries of inequality operator pairs.",
+            "example": "2020-07-09T00:01:01",
+            "format": "date-time",
+            "type": "string",
+            "x-akamai": {
+              "labels": [
+                "Filterable"
+              ],
+              "status": "BETA"
+            },
+            "x-linode-filterable": true
+          },
+          "description": {
+            "description": "__Beta__ Differentiates between scheduled and emergency maintenance.",
+            "enum": [
+              "Scheduled Maintenance",
+              "Emergency Maintenance"
+            ],
+            "example": "Scheduled Maintenance",
+            "type": "string",
+            "x-akamai": {
+              "status": "BETA"
+            }
+          },
           "entity": {
             "additionalProperties": false,
-            "description": "The entity being affected by maintenance.",
+            "description": "The entity affected by the maintenance.",
             "properties": {
               "id": {
-                "description": "The id of the entity being affected by maintenance.",
+                "description": "The unique identifier of the entity targeted by the maintenance.",
                 "example": 1234,
                 "type": "number"
               },
               "label": {
-                "description": "The label of the entity being affected by maintenance.",
+                "description": "The name of the entity targeted by the maintenance.",
                 "example": "demo-linode",
                 "type": "string"
               },
@@ -5504,24 +5777,77 @@
                 "type": "string"
               },
               "url": {
-                "description": "The API endpoint prefix to use in combination with the entity id to find specific information about the entity.",
+                "description": "A combination of the API operation prefix and the entity's `id` that can be used to review the entity.",
                 "example": "https://api.linode.com/v4/linode/instances/{linodeId}",
                 "type": "string"
               }
             },
             "type": "object"
           },
+          "maintenance_policy_set": {
+            "description": "__Beta__, __Filterable__ The maintenance policy configured by the user.",
+            "example": "linode/migrate",
+            "type": "string",
+            "x-akamai": {
+              "labels": [
+                "Filterable"
+              ],
+              "status": "BETA"
+            },
+            "x-linode-filterable": true
+          },
+          "not_before": {
+            "description": "__Beta__, __Filterable__ The earliest time when the maintenance can start. This field is [filterable](https://techdocs.akamai.com/linode-api/reference/filtering-and-sorting) based on these parameters:\n\n- A single ISO 8601 timestamp (`yyyy-mm-ddThh:mm:ss`), which returns only matches for that value.\n\n- Pairs of operator string keys (`+or`, `+gt`, `+gte`, `+lt`, `+lte`, or `+neq`) and single ISO 8601 timestamp. The `+or` operator accepts an array of values that can consist of single date-time strings or dictionaries of inequality operator pairs.",
+            "example": "2020-07-09T00:01:01",
+            "format": "date-time",
+            "type": "string",
+            "x-akamai": {
+              "labels": [
+                "Filterable"
+              ],
+              "status": "BETA"
+            },
+            "x-linode-filterable": true
+          },
           "reason": {
             "description": "The reason maintenance is being performed.",
             "example": "This maintenance will allow us to update the BIOS on the host's motherboard.",
             "type": "string"
           },
-          "status": {
-            "description": "__Filterable__ The maintenance status.\n\nMaintenance progresses in the following sequence: pending, started, then completed.",
+          "source": {
+            "description": "__Beta__ The origin of the maintenance. A `platform` source indicates that the maintenance was initiated by Akamai. A `user` source indicates that the maintenance was initiated by the user.",
             "enum": [
-              "completed",
+              "platform",
+              "user"
+            ],
+            "example": "platform",
+            "type": "string",
+            "x-akamai": {
+              "status": "BETA"
+            }
+          },
+          "start_time": {
+            "description": "__Beta__, __Filterable__ The time the maintenance started. This field is [filterable](https://techdocs.akamai.com/linode-api/reference/filtering-and-sorting) based on these parameters:\n\n- A single ISO 8601 timestamp (`yyyy-mm-ddThh:mm:ss`), which returns only matches for that value.\n\n- Pairs of operator string keys (`+or`, `+gt`, `+gte`, `+lt`, `+lte`, or `+neq`) and single ISO 8601 timestamp. The `+or` operator accepts an array of values that can consist of single date-time strings or dictionaries of inequality operator pairs.",
+            "example": "2020-07-09T00:01:01",
+            "format": "date-time",
+            "type": "string",
+            "x-akamai": {
+              "labels": [
+                "Filterable"
+              ],
+              "status": "BETA"
+            },
+            "x-linode-filterable": true
+          },
+          "status": {
+            "description": "__Filterable__ The maintenance status. Maintenance progress follows the sequence `pending`, `scheduled`, `started`, and `completed`. A `scheduled` status is unique to Linodes that require a reboot for [QEMU maintenance](https://techdocs.akamai.com/linode-api/reference/reboot-your-linodes-for-qemu-maintenance).",
+            "enum": [
               "pending",
-              "started"
+              "scheduled",
+              "started",
+              "in-progress",
+              "completed",
+              "canceled"
             ],
             "example": "started",
             "type": "string",
@@ -5537,7 +5863,9 @@
             "enum": [
               "reboot",
               "cold_migration",
-              "live_migration"
+              "live_migration",
+              "migrate",
+              "power_off_on"
             ],
             "example": "reboot",
             "type": "string",
@@ -5549,7 +5877,7 @@
             "x-linode-filterable": true
           },
           "when": {
-            "description": "__Filterable__ When the maintenance will begin.\n\n[Filterable](https://techdocs.akamai.com/linode-api/reference/filtering-and-sorting) with the following parameters:\n\n- A single value in date-time string format (`%Y-%m-%dT%H:%M:%S`), which returns only matches to that value.\n\n- A dictionary containing pairs of inequality operator string keys (`+or`, `+gt`, `+gte`, `+lt`, `+lte`, or `+neq`) and single date-time string format values (`%Y-%m-%dT%H:%M:%S`). `+or` accepts an array of values that may consist of single date-time strings or dictionaries of inequality operator pairs.",
+            "description": "__Filterable__ The start time for the maintenance. This field is [filterable](https://techdocs.akamai.com/linode-api/reference/filtering-and-sorting) based on these parameters:\n\n- A single ISO 8601 timestamp (yyyy-mm-ddThh:mm:ss), which returns only matches for that value.\n\n- Pairs of operator string keys (`+or`, `+gt`, `+gte`, `+lt`, `+lte`, or `+neq`) and single ISO 8601 timestamp. The `+or` operator accepts an array of values that can consist of single date-time strings or dictionaries of inequality operator pairs.",
             "example": "2020-07-09T00:01:01",
             "format": "date-time",
             "type": "string",
@@ -5571,15 +5899,15 @@
         "description": "An important, often time-sensitive item related to your account.",
         "properties": {
           "body": {
-            "description": "__Read-only__ A full description of this notification, in markdown format. Not all notifications include a `body`.",
+            "description": "A full description of this notification, in markdown format. Not all notifications include a `body`. Returned as `null` for an event `type` of `security_reboot_maintenance_scheduled`.",
             "example": null,
             "nullable": true,
-            "readOnly": true,
             "type": "string"
           },
           "entity": {
             "additionalProperties": false,
-            "description": "__Read-only__ Detailed information about the notification.",
+            "description": "Detailed information about the notification. Returned as `null` for an event `type` of `security_reboot_maintenance_scheduled`.",
+            "nullable": true,
             "properties": {
               "id": {
                 "description": "The unique ID of the notification's entity, based on the entity type. Returns `null` for an `account` or `promotion` entity.",
@@ -5588,13 +5916,13 @@
                 "type": "integer"
               },
               "label": {
-                "description": "The current label for this notification's entity.\n\nReturns `null` for the following entity types:\n\n- `entity_transfer`\n- `promotion`\n- `region`",
+                "description": "The current name of this notification's entity. Returns `null` for the following `entity` types:\n\n- `entity_transfer`\n\n- `promotion`\n\n- `region`",
                 "example": "Linode not booting.",
                 "nullable": true,
                 "type": "string"
               },
               "type": {
-                "description": "The type of entity this is related to.",
+                "description": "__Filterable__ The type of entity this is related to. An entity can be product or service-specific, such as a `linode`, `loadbalancers`, or `nodebalancers`. It can apply to a specific component, such as your `account`, a specific `promotion` your participating in, a data center (`region`) where you're using services, a transfer from one component to another (an `entity_transfer`), a support `ticket` you've opened, or a `volume` on a specific Linode.",
                 "enum": [
                   "account",
                   "entity_transfer",
@@ -5607,7 +5935,13 @@
                   "volume"
                 ],
                 "example": "ticket",
-                "type": "string"
+                "type": "string",
+                "x-akamai": {
+                  "labels": [
+                    "Filterable"
+                  ]
+                },
+                "x-linode-filterable": true
               },
               "url": {
                 "description": "The URL where you can access the notification's object. The URL is relative to the domain where you retrieved the notification. This value is `null` for the `promotion` entity type.",
@@ -5616,32 +5950,28 @@
                 "type": "string"
               }
             },
-            "readOnly": true,
             "type": "object"
           },
           "label": {
-            "description": "__Read-only__ A short description of this notification.",
+            "description": "A short description of this notification.",
             "example": "You have an important ticket open!",
-            "readOnly": true,
             "type": "string",
             "x-linode-cli-display": 1
           },
           "message": {
-            "description": "__Read-only__ A human-readable description of the notification.",
+            "description": "A human-readable description of the notification.",
             "example": "You have an important ticket open!",
-            "readOnly": true,
             "type": "string",
             "x-linode-cli-display": 2
           },
           "severity": {
-            "description": "__Read-only__ The severity of this notification. This field determines how prominently the notification is displayed and the color of the display text.",
+            "description": "The severity of this notification. This field determines how prominently the notification is displayed and the color of the display text.",
             "enum": [
               "minor",
               "major",
               "critical"
             ],
             "example": "major",
-            "readOnly": true,
             "type": "string",
             "x-linode-cli-color": {
               "critical": "b",
@@ -5651,7 +5981,7 @@
             "x-linode-cli-display": 3
           },
           "type": {
-            "description": "__Read-only__ The type of notification.",
+            "description": "__Filterable__ The type of notification.\n\n> \ud83d\udcd8\n>\n> A `security_reboot_maintenance_scheduled` event is a global notice that a Linode needs to be rebooted for QEMU upgrade maintenance. Have a look at [this workflow](https://techdocs.akamai.com/linode-api/reference/reboot-your-linodes-for-qemu-maintenance) for guidance on reboooting your Linodes for this maintenance.",
             "enum": [
               "migration_scheduled",
               "migration_imminent",
@@ -5663,19 +5993,25 @@
               "ticket_abuse",
               "notice",
               "maintenance",
+              "maintenance_scheduled",
               "promotion",
+              "security_reboot_maintenance_scheduled",
               "tax_id_verifying"
             ],
             "example": "ticket_important",
-            "readOnly": true,
-            "type": "string"
+            "type": "string",
+            "x-akamai": {
+              "labels": [
+                "Filterable"
+              ]
+            },
+            "x-linode-filterable": true
           },
           "until": {
-            "description": "__Read-only__ If this notification has a duration, this is when the event or action will complete. For example, if there's scheduled maintenance for one of our systems, `until` represents the end of the maintenance window.",
+            "description": "If this notification has a duration, this is when the event or action will complete. For example, if there's scheduled maintenance for one of our systems, `until` represents the end of the maintenance window. Returned as `null` for an event `type` of `security_reboot_maintenance_scheduled`.",
             "example": null,
             "format": "date-time",
             "nullable": true,
-            "readOnly": true,
             "type": "string",
             "x-linode-cli-color": {
               "None": "black",
@@ -5684,11 +6020,10 @@
             "x-linode-cli-display": 5
           },
           "when": {
-            "description": "__Read-only__ If this notification is for an event in the future, this specifies when the action occurs. For example, if a compute instance needs to migrate in response to a security advisory, this field sets the approximate time the compute instance will be taken offline for migration.",
+            "description": "If this notification is for an event in the future, this specifies when the action occurs. For example, if a compute instance needs to migrate in response to a security advisory, this field sets the approximate time the compute instance will be taken offline for migration. Returned as `null` for an event `type` of `security_reboot_maintenance_scheduled`.",
             "example": null,
             "format": "date-time",
             "nullable": true,
-            "readOnly": true,
             "type": "string",
             "x-linode-cli-color": {
               "None": "black",
@@ -6506,7 +6841,7 @@
         "description": "The type of user on an account. Mostly applies to the use of the parent and child accounts for Akamai partners functionality.",
         "properties": {
           "user_type": {
-            "description": "__Read-only__ If the user belongs to a [parent or child account](https://www.linode.com/docs/guides/parent-child-accounts/) relationship, this defines the user type in the respective account. Possible values include:\n\n- `parent`. This is a user in an Akamai partner account. Akamai partners have a contractural relationship with their end customers, to sell Akamai services. This user can either have full access (a parent account admin user) or limited access. Limited users don't have access to manage child accounts, but they can be granted this access by an admin user.\n\n- `child`. This is an Akamai partner's end customer user, in a child account. A child user can have either full or limited access. Full access lets the user manage other child users and the proxy user in a child account.\n\n- `proxy`. This is a user on a child account that gives parent account users access to that child account. A parent account user with the `child_account_access` grant can [Create a proxy user token](https://techdocs.akamai.com/linode-api/reference/post-child-account-token) from the parent account. The parent user can use this token to run API operations from the child account, as if they were a child user.\n\n- `default`. This applies to all regular, non-parent-child account users.",
+            "description": "__Read-only__ If the user belongs to a [parent or child account](https://www.linode.com/docs/guides/parent-child-accounts/) relationship, this defines the user type in the respective account. Possible values include:\n\n- `parent`. This is a user in an Akamai partner account. Akamai partners have a contractual relationship with their end customers, to sell Akamai services. This user can either have full access (a parent account admin user) or limited access. Limited users don't have access to manage child accounts, but they can be granted this access by an admin user.\n\n- `child`. This is an Akamai partner's end customer user, in a child account. A child user can have either full or limited access. Full access lets the user manage other child users and the proxy user in a child account.\n\n- `proxy`. This is a user on a child account that gives parent account users access to that child account. A parent account user with the `child_account_access` grant can [Create a proxy user token](https://techdocs.akamai.com/linode-api/reference/post-child-account-token) from the parent account. The parent user can use this token to run API operations from the child account, as if they were a child user.\n\n- `default`. This applies to all regular, non-parent-child account users.",
             "enum": [
               "parent",
               "child",
@@ -6607,7 +6942,7 @@
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
     "title": "Akamai: Linode API",
-    "version": "4.208.1"
+    "version": "4.209.3"
   },
   "openapi": "3.0.1",
   "paths": {
@@ -11240,6 +11575,7 @@
                               "linode_migrate_datacenter_create",
                               "linode_mutate",
                               "linode_mutate_create",
+                              "linode_poweroff_on",
                               "linode_reboot",
                               "linode_rebuild",
                               "linode_resize",
@@ -11352,6 +11688,19 @@
                             "x-linode-cli-display": 3,
                             "x-linode-filterable": true
                           },
+                          "complete_time": {
+                            "description": "__Beta__, __Filterable__ The time the maintenance completed. This field is [filterable](https://techdocs.akamai.com/linode-api/reference/filtering-and-sorting) based on these parameters:\n\n- A single ISO 8601 timestamp (`yyyy-mm-ddThh:mm:ss`), which returns only matches for that value.\n\n- Pairs of operator string keys (`+or`, `+gt`, `+gte`, `+lt`, `+lte`, or `+neq`) and single ISO 8601 timestamp. The `+or` operator accepts an array of values that can consist of single date-time strings or dictionaries of inequality operator pairs.",
+                            "example": "2020-07-09T00:01:01",
+                            "format": "date-time",
+                            "type": "string",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ],
+                              "status": "BETA"
+                            },
+                            "x-linode-filterable": true
+                          },
                           "created": {
                             "description": "__Filterable__ When the system created this event.",
                             "example": "2018-01-01T00:01:01",
@@ -11363,6 +11712,22 @@
                               ]
                             },
                             "x-linode-cli-display": 6,
+                            "x-linode-filterable": true
+                          },
+                          "description": {
+                            "description": "__Beta__, __Filterable__ Differentiates between scheduled and emergency maintenance.",
+                            "enum": [
+                              "Scheduled Maintenance",
+                              "Emergency Maintenance"
+                            ],
+                            "example": "Scheduled Maintenance",
+                            "type": "string",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ],
+                              "status": "BETA"
+                            },
                             "x-linode-filterable": true
                           },
                           "duration": {
@@ -11448,12 +11813,37 @@
                             "x-linode-cli-display": 1,
                             "x-linode-filterable": true
                           },
+                          "maintenance_policy_set": {
+                            "description": "__Beta__, __Filterable__ The maintenance policy configured by the user for this event.",
+                            "example": "linode/migrate",
+                            "type": "string",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ],
+                              "status": "BETA"
+                            },
+                            "x-linode-filterable": true
+                          },
                           "message": {
                             "description": "Additional information about the event. This can be a more detailed representation of an event that can help you diagnose non-obvious failures.",
                             "example": "None",
                             "nullable": true,
                             "type": "string",
                             "x-linode-cli-display": 9
+                          },
+                          "not_before": {
+                            "description": "__Beta__, __Filterable__ The scheduled start time for the event. This field is [filterable](https://techdocs.akamai.com/linode-api/reference/filtering-and-sorting) based on these parameters:\n\n- A single ISO 8601 timestamp (`yyyy-mm-ddThh:mm:ss`), which returns only matches for that value.\n\n- Pairs of operator string keys (`+or`, `+gt`, `+gte`, `+lt`, `+lte`, or `+neq`) and single ISO 8601 timestamp. The `+or` operator accepts an array of values that can consist of single date-time strings or dictionaries of inequality operator pairs.",
+                            "example": "2020-07-09T00:01:01",
+                            "format": "date-time",
+                            "type": "string",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ],
+                              "status": "BETA"
+                            },
+                            "x-linode-filterable": true
                           },
                           "percent_complete": {
                             "description": "A percentage estimating the amount of time remaining for an event. Returned as `null` for notification events.",
@@ -11510,20 +11900,53 @@
                             "example": true,
                             "type": "boolean"
                           },
+                          "source": {
+                            "description": "__Beta__, __Filterable__ The origin of the event. A `platform` source indicates that the event was initiated by Akamai. A `user` source indicates that the event was initiated by the user.",
+                            "enum": [
+                              "platform",
+                              "user"
+                            ],
+                            "example": "platform",
+                            "type": "string",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ],
+                              "status": "BETA"
+                            },
+                            "x-linode-filterable": true
+                          },
+                          "start_time": {
+                            "description": "__Beta__, __Filterable__ The actual start time for the event. This field is [filterable](https://techdocs.akamai.com/linode-api/reference/filtering-and-sorting) based on these parameters:\n\n- A single ISO 8601 timestamp (`yyyy-mm-ddThh:mm:ss`), which returns only matches for that value.\n\n- Pairs of operator string keys (`+or`, `+gt`, `+gte`, `+lt`, `+lte`, or `+neq`) and single ISO 8601 timestamp. The `+or` operator accepts an array of values that can consist of single date-time strings or dictionaries of inequality operator pairs.",
+                            "example": "2020-07-09T00:01:01",
+                            "format": "date-time",
+                            "type": "string",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ],
+                              "status": "BETA"
+                            },
+                            "x-linode-filterable": true
+                          },
                           "status": {
                             "description": "The current status of this event.",
                             "enum": [
+                              "completed",
                               "failed",
                               "finished",
+                              "in_progress",
                               "notification",
                               "scheduled",
                               "started"
                             ],
                             "type": "string",
                             "x-linode-cli-color": {
+                              "completed": "green",
                               "default_": "white",
                               "failed": "red",
                               "finished": "green",
+                              "in_progress": "yellow",
                               "started": "yellow"
                             },
                             "x-linode-cli-display": 8
@@ -11795,6 +12218,7 @@
                         "linode_migrate_datacenter_create",
                         "linode_mutate",
                         "linode_mutate_create",
+                        "linode_poweroff_on",
                         "linode_reboot",
                         "linode_rebuild",
                         "linode_resize",
@@ -11902,6 +12326,15 @@
                       "type": "string",
                       "x-linode-cli-display": 3
                     },
+                    "complete_time": {
+                      "description": "__Beta__ The time the maintenance completed. This field is [filterable](https://techdocs.akamai.com/linode-api/reference/filtering-and-sorting) based on these parameters:\n\n- A single ISO 8601 timestamp (`yyyy-mm-ddThh:mm:ss`), which returns only matches for that value.\n\n- Pairs of operator string keys (`+or`, `+gt`, `+gte`, `+lt`, `+lte`, or `+neq`) and single ISO 8601 timestamp. The `+or` operator accepts an array of values that can consist of single date-time strings or dictionaries of inequality operator pairs.",
+                      "example": "2020-07-09T00:01:01",
+                      "format": "date-time",
+                      "type": "string",
+                      "x-akamai": {
+                        "status": "BETA"
+                      }
+                    },
                     "created": {
                       "description": "__Read-only__ When the system created this event.",
                       "example": "2018-01-01T00:01:01",
@@ -11909,6 +12342,18 @@
                       "readOnly": true,
                       "type": "string",
                       "x-linode-cli-display": 6
+                    },
+                    "description": {
+                      "description": "__Beta__ Differentiates between scheduled and emergency maintenance.",
+                      "enum": [
+                        "Scheduled Maintenance",
+                        "Emergency Maintenance"
+                      ],
+                      "example": "Scheduled Maintenance",
+                      "type": "string",
+                      "x-akamai": {
+                        "status": "BETA"
+                      }
                     },
                     "duration": {
                       "description": "__Read-only__ The number of seconds that it takes for the event to complete.",
@@ -11979,12 +12424,29 @@
                       "type": "integer",
                       "x-linode-cli-display": 1
                     },
+                    "maintenance_policy_set": {
+                      "description": "__Beta__ The maintenance policy configured by the user for this event.",
+                      "example": "linode/migrate",
+                      "type": "string",
+                      "x-akamai": {
+                        "status": "BETA"
+                      }
+                    },
                     "message": {
                       "description": "Additional information about the event. This can be a more detailed representation of an event that can help you diagnose non-obvious failures.",
                       "example": "None",
                       "nullable": true,
                       "type": "string",
                       "x-linode-cli-display": 9
+                    },
+                    "not_before": {
+                      "description": "__Beta__ The scheduled start time for the event. This field is [filterable](https://techdocs.akamai.com/linode-api/reference/filtering-and-sorting) based on these parameters:\n\n- A single ISO 8601 timestamp (`yyyy-mm-ddThh:mm:ss`), which returns only matches for that value.\n\n- Pairs of operator string keys (`+or`, `+gt`, `+gte`, `+lt`, `+lte`, or `+neq`) and single ISO 8601 timestamp. The `+or` operator accepts an array of values that can consist of single date-time strings or dictionaries of inequality operator pairs.",
+                      "example": "2020-07-09T00:01:01",
+                      "format": "date-time",
+                      "type": "string",
+                      "x-akamai": {
+                        "status": "BETA"
+                      }
                     },
                     "percent_complete": {
                       "description": "__Read-only__ A percentage estimating the amount of time remaining for an event. Returned as `null` for notification events.",
@@ -12040,6 +12502,27 @@
                       "example": true,
                       "readOnly": true,
                       "type": "boolean"
+                    },
+                    "source": {
+                      "description": "__Beta__ The origin of the event. A `platform` source indicates that the event was initiated by Akamai. A `user` source indicates that the event was initiated by the user.",
+                      "enum": [
+                        "platform",
+                        "user"
+                      ],
+                      "example": "platform",
+                      "type": "string",
+                      "x-akamai": {
+                        "status": "BETA"
+                      }
+                    },
+                    "start_time": {
+                      "description": "__Beta__ The actual start time for the event. This field is [filterable](https://techdocs.akamai.com/linode-api/reference/filtering-and-sorting) based on these parameters:\n\n- A single ISO 8601 timestamp (`yyyy-mm-ddThh:mm:ss`), which returns only matches for that value.\n\n- Pairs of operator string keys (`+or`, `+gt`, `+gte`, `+lt`, `+lte`, or `+neq`) and single ISO 8601 timestamp. The `+or` operator accepts an array of values that can consist of single date-time strings or dictionaries of inequality operator pairs.",
+                      "example": "2020-07-09T00:01:01",
+                      "format": "date-time",
+                      "type": "string",
+                      "x-akamai": {
+                        "status": "BETA"
+                      }
                     },
                     "status": {
                       "description": "__Read-only__ The current status of this event.",
@@ -13504,7 +13987,7 @@
     },
     "/{apiVersion}/account/maintenance": {
       "get": {
-        "description": "Returns a collection of Maintenance objects for any entity a user has permissions to view. Canceled Maintenance objects are not returned.\n\nCurrently, Linodes are the only entities available for viewing.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli account maintenance-list\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)",
+        "description": "Returns maintenance information for any entity your user has permissions to view. If a maintenance object has been canceled, it's not returned.\n\n> \ud83d\udcd8\n>\n> Currently, only Linodes are included as entities for viewing.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli account maintenance-list\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-maintenance"
@@ -13522,17 +14005,42 @@
                         "additionalProperties": false,
                         "description": "Information about maintenance affecting an entity.",
                         "properties": {
+                          "complete_time": {
+                            "description": "__Beta__, __Filterable__ The time the maintenance completed. This field is [filterable](https://techdocs.akamai.com/linode-api/reference/filtering-and-sorting) based on these parameters:\n\n- A single ISO 8601 timestamp (`yyyy-mm-ddThh:mm:ss`), which returns only matches for that value.\n\n- Pairs of operator string keys (`+or`, `+gt`, `+gte`, `+lt`, `+lte`, or `+neq`) and single ISO 8601 timestamp. The `+or` operator accepts an array of values that can consist of single date-time strings or dictionaries of inequality operator pairs.",
+                            "example": "2020-07-09T00:01:01",
+                            "format": "date-time",
+                            "type": "string",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ],
+                              "status": "BETA"
+                            },
+                            "x-linode-filterable": true
+                          },
+                          "description": {
+                            "description": "__Beta__ Differentiates between scheduled and emergency maintenance.",
+                            "enum": [
+                              "Scheduled Maintenance",
+                              "Emergency Maintenance"
+                            ],
+                            "example": "Scheduled Maintenance",
+                            "type": "string",
+                            "x-akamai": {
+                              "status": "BETA"
+                            }
+                          },
                           "entity": {
                             "additionalProperties": false,
-                            "description": "The entity being affected by maintenance.",
+                            "description": "The entity affected by the maintenance.",
                             "properties": {
                               "id": {
-                                "description": "The id of the entity being affected by maintenance.",
+                                "description": "The unique identifier of the entity targeted by the maintenance.",
                                 "example": 1234,
                                 "type": "number"
                               },
                               "label": {
-                                "description": "The label of the entity being affected by maintenance.",
+                                "description": "The name of the entity targeted by the maintenance.",
                                 "example": "demo-linode",
                                 "type": "string"
                               },
@@ -13542,24 +14050,77 @@
                                 "type": "string"
                               },
                               "url": {
-                                "description": "The API endpoint prefix to use in combination with the entity id to find specific information about the entity.",
+                                "description": "A combination of the API operation prefix and the entity's `id` that can be used to review the entity.",
                                 "example": "https://api.linode.com/v4/linode/instances/{linodeId}",
                                 "type": "string"
                               }
                             },
                             "type": "object"
                           },
+                          "maintenance_policy_set": {
+                            "description": "__Beta__, __Filterable__ The maintenance policy configured by the user.",
+                            "example": "linode/migrate",
+                            "type": "string",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ],
+                              "status": "BETA"
+                            },
+                            "x-linode-filterable": true
+                          },
+                          "not_before": {
+                            "description": "__Beta__, __Filterable__ The earliest time when the maintenance can start. This field is [filterable](https://techdocs.akamai.com/linode-api/reference/filtering-and-sorting) based on these parameters:\n\n- A single ISO 8601 timestamp (`yyyy-mm-ddThh:mm:ss`), which returns only matches for that value.\n\n- Pairs of operator string keys (`+or`, `+gt`, `+gte`, `+lt`, `+lte`, or `+neq`) and single ISO 8601 timestamp. The `+or` operator accepts an array of values that can consist of single date-time strings or dictionaries of inequality operator pairs.",
+                            "example": "2020-07-09T00:01:01",
+                            "format": "date-time",
+                            "type": "string",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ],
+                              "status": "BETA"
+                            },
+                            "x-linode-filterable": true
+                          },
                           "reason": {
                             "description": "The reason maintenance is being performed.",
                             "example": "This maintenance will allow us to update the BIOS on the host's motherboard.",
                             "type": "string"
                           },
-                          "status": {
-                            "description": "__Filterable__ The maintenance status.\n\nMaintenance progresses in the following sequence: pending, started, then completed.",
+                          "source": {
+                            "description": "__Beta__ The origin of the maintenance. A `platform` source indicates that the maintenance was initiated by Akamai. A `user` source indicates that the maintenance was initiated by the user.",
                             "enum": [
-                              "completed",
+                              "platform",
+                              "user"
+                            ],
+                            "example": "platform",
+                            "type": "string",
+                            "x-akamai": {
+                              "status": "BETA"
+                            }
+                          },
+                          "start_time": {
+                            "description": "__Beta__, __Filterable__ The time the maintenance started. This field is [filterable](https://techdocs.akamai.com/linode-api/reference/filtering-and-sorting) based on these parameters:\n\n- A single ISO 8601 timestamp (`yyyy-mm-ddThh:mm:ss`), which returns only matches for that value.\n\n- Pairs of operator string keys (`+or`, `+gt`, `+gte`, `+lt`, `+lte`, or `+neq`) and single ISO 8601 timestamp. The `+or` operator accepts an array of values that can consist of single date-time strings or dictionaries of inequality operator pairs.",
+                            "example": "2020-07-09T00:01:01",
+                            "format": "date-time",
+                            "type": "string",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ],
+                              "status": "BETA"
+                            },
+                            "x-linode-filterable": true
+                          },
+                          "status": {
+                            "description": "__Filterable__ The maintenance status. Maintenance progress follows the sequence `pending`, `scheduled`, `started`, and `completed`. A `scheduled` status is unique to Linodes that require a reboot for [QEMU maintenance](https://techdocs.akamai.com/linode-api/reference/reboot-your-linodes-for-qemu-maintenance).",
+                            "enum": [
                               "pending",
-                              "started"
+                              "scheduled",
+                              "started",
+                              "in-progress",
+                              "completed",
+                              "canceled"
                             ],
                             "example": "started",
                             "type": "string",
@@ -13575,7 +14136,9 @@
                             "enum": [
                               "reboot",
                               "cold_migration",
-                              "live_migration"
+                              "live_migration",
+                              "migrate",
+                              "power_off_on"
                             ],
                             "example": "reboot",
                             "type": "string",
@@ -13587,7 +14150,7 @@
                             "x-linode-filterable": true
                           },
                           "when": {
-                            "description": "__Filterable__ When the maintenance will begin.\n\n[Filterable](https://techdocs.akamai.com/linode-api/reference/filtering-and-sorting) with the following parameters:\n\n- A single value in date-time string format (`%Y-%m-%dT%H:%M:%S`), which returns only matches to that value.\n\n- A dictionary containing pairs of inequality operator string keys (`+or`, `+gt`, `+gte`, `+lt`, `+lte`, or `+neq`) and single date-time string format values (`%Y-%m-%dT%H:%M:%S`). `+or` accepts an array of values that may consist of single date-time strings or dictionaries of inequality operator pairs.",
+                            "description": "__Filterable__ The start time for the maintenance. This field is [filterable](https://techdocs.akamai.com/linode-api/reference/filtering-and-sorting) based on these parameters:\n\n- A single ISO 8601 timestamp (yyyy-mm-ddThh:mm:ss), which returns only matches for that value.\n\n- Pairs of operator string keys (`+or`, `+gt`, `+gte`, `+lt`, `+lte`, or `+neq`) and single ISO 8601 timestamp. The `+or` operator accepts an array of values that can consist of single date-time strings or dictionaries of inequality operator pairs.",
                             "example": "2020-07-09T00:01:01",
                             "format": "date-time",
                             "type": "string",
@@ -13725,7 +14288,7 @@
     },
     "/{apiVersion}/account/notifications": {
       "get": {
-        "description": "Returns a collection of notification objects that represent important, often time-sensitive details about your account. You can't interact directly with notifications, and a notification disappears when the circumstances that caused it have been resolved. For example, if you have an important ticket open, you can respond to that ticket to dismiss its notification.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli account notifications-list\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Returns notifications that represent important, often time-sensitive details about your account. You can't interact directly with notifications, and a notification disappears when you've resolved its cause. For example, if you have an important ticket open, you can respond to that ticket to dismiss its notification.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli account notifications-list\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-notifications"
@@ -13744,15 +14307,15 @@
                         "description": "An important, often time-sensitive item related to your account.",
                         "properties": {
                           "body": {
-                            "description": "__Read-only__ A full description of this notification, in markdown format. Not all notifications include a `body`.",
+                            "description": "A full description of this notification, in markdown format. Not all notifications include a `body`. Returned as `null` for an event `type` of `security_reboot_maintenance_scheduled`.",
                             "example": null,
                             "nullable": true,
-                            "readOnly": true,
                             "type": "string"
                           },
                           "entity": {
                             "additionalProperties": false,
-                            "description": "__Read-only__ Detailed information about the notification.",
+                            "description": "Detailed information about the notification. Returned as `null` for an event `type` of `security_reboot_maintenance_scheduled`.",
+                            "nullable": true,
                             "properties": {
                               "id": {
                                 "description": "The unique ID of the notification's entity, based on the entity type. Returns `null` for an `account` or `promotion` entity.",
@@ -13761,13 +14324,13 @@
                                 "type": "integer"
                               },
                               "label": {
-                                "description": "The current label for this notification's entity.\n\nReturns `null` for the following entity types:\n\n- `entity_transfer`\n- `promotion`\n- `region`",
+                                "description": "The current name of this notification's entity. Returns `null` for the following `entity` types:\n\n- `entity_transfer`\n\n- `promotion`\n\n- `region`",
                                 "example": "Linode not booting.",
                                 "nullable": true,
                                 "type": "string"
                               },
                               "type": {
-                                "description": "The type of entity this is related to.",
+                                "description": "__Filterable__ The type of entity this is related to. An entity can be product or service-specific, such as a `linode`, `loadbalancers`, or `nodebalancers`. It can apply to a specific component, such as your `account`, a specific `promotion` your participating in, a data center (`region`) where you're using services, a transfer from one component to another (an `entity_transfer`), a support `ticket` you've opened, or a `volume` on a specific Linode.",
                                 "enum": [
                                   "account",
                                   "entity_transfer",
@@ -13780,7 +14343,13 @@
                                   "volume"
                                 ],
                                 "example": "ticket",
-                                "type": "string"
+                                "type": "string",
+                                "x-akamai": {
+                                  "labels": [
+                                    "Filterable"
+                                  ]
+                                },
+                                "x-linode-filterable": true
                               },
                               "url": {
                                 "description": "The URL where you can access the notification's object. The URL is relative to the domain where you retrieved the notification. This value is `null` for the `promotion` entity type.",
@@ -13789,32 +14358,28 @@
                                 "type": "string"
                               }
                             },
-                            "readOnly": true,
                             "type": "object"
                           },
                           "label": {
-                            "description": "__Read-only__ A short description of this notification.",
+                            "description": "A short description of this notification.",
                             "example": "You have an important ticket open!",
-                            "readOnly": true,
                             "type": "string",
                             "x-linode-cli-display": 1
                           },
                           "message": {
-                            "description": "__Read-only__ A human-readable description of the notification.",
+                            "description": "A human-readable description of the notification.",
                             "example": "You have an important ticket open!",
-                            "readOnly": true,
                             "type": "string",
                             "x-linode-cli-display": 2
                           },
                           "severity": {
-                            "description": "__Read-only__ The severity of this notification. This field determines how prominently the notification is displayed and the color of the display text.",
+                            "description": "The severity of this notification. This field determines how prominently the notification is displayed and the color of the display text.",
                             "enum": [
                               "minor",
                               "major",
                               "critical"
                             ],
                             "example": "major",
-                            "readOnly": true,
                             "type": "string",
                             "x-linode-cli-color": {
                               "critical": "b",
@@ -13824,7 +14389,7 @@
                             "x-linode-cli-display": 3
                           },
                           "type": {
-                            "description": "__Read-only__ The type of notification.",
+                            "description": "__Filterable__ The type of notification.\n\n> \ud83d\udcd8\n>\n> A `security_reboot_maintenance_scheduled` event is a global notice that a Linode needs to be rebooted for QEMU upgrade maintenance. Have a look at [this workflow](https://techdocs.akamai.com/linode-api/reference/reboot-your-linodes-for-qemu-maintenance) for guidance on reboooting your Linodes for this maintenance.",
                             "enum": [
                               "migration_scheduled",
                               "migration_imminent",
@@ -13836,19 +14401,25 @@
                               "ticket_abuse",
                               "notice",
                               "maintenance",
+                              "maintenance_scheduled",
                               "promotion",
+                              "security_reboot_maintenance_scheduled",
                               "tax_id_verifying"
                             ],
                             "example": "ticket_important",
-                            "readOnly": true,
-                            "type": "string"
+                            "type": "string",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ]
+                            },
+                            "x-linode-filterable": true
                           },
                           "until": {
-                            "description": "__Read-only__ If this notification has a duration, this is when the event or action will complete. For example, if there's scheduled maintenance for one of our systems, `until` represents the end of the maintenance window.",
+                            "description": "If this notification has a duration, this is when the event or action will complete. For example, if there's scheduled maintenance for one of our systems, `until` represents the end of the maintenance window. Returned as `null` for an event `type` of `security_reboot_maintenance_scheduled`.",
                             "example": null,
                             "format": "date-time",
                             "nullable": true,
-                            "readOnly": true,
                             "type": "string",
                             "x-linode-cli-color": {
                               "None": "black",
@@ -13857,11 +14428,10 @@
                             "x-linode-cli-display": 5
                           },
                           "when": {
-                            "description": "__Read-only__ If this notification is for an event in the future, this specifies when the action occurs. For example, if a compute instance needs to migrate in response to a security advisory, this field sets the approximate time the compute instance will be taken offline for migration.",
+                            "description": "If this notification is for an event in the future, this specifies when the action occurs. For example, if a compute instance needs to migrate in response to a security advisory, this field sets the approximate time the compute instance will be taken offline for migration. Returned as `null` for an event `type` of `security_reboot_maintenance_scheduled`.",
                             "example": null,
                             "format": "date-time",
                             "nullable": true,
-                            "readOnly": true,
                             "type": "string",
                             "x-linode-cli-color": {
                               "None": "black",
@@ -18658,6 +19228,19 @@
                       "type": "string",
                       "x-linode-cli-display": 2
                     },
+                    "maintenance_policy": {
+                      "description": "__Beta__ Defines the default maintenance policy for new Linodes created on this account. Review [maintenance policy](https://techdocs.akamai.com/cloud-computing/docs/host-maintenance-policy) documentation for more details.",
+                      "enum": [
+                        "linode/migrate",
+                        "linode/power_off_on"
+                      ],
+                      "example": "linode/migrate",
+                      "type": "string",
+                      "x-akamai": {
+                        "status": "BETA"
+                      },
+                      "x-linode-cli-display": 7
+                    },
                     "managed": {
                       "description": "__Read-only__ Our 24/7 incident response service. This robust, multi-homed monitoring system distributes monitoring checks to ensure that your servers remain online and available at all times. Linode Managed can monitor any service or software stack reachable over TCP or HTTP. Once you add a service to Linode Managed, we'll monitor it for connectivity, response, and total request time.",
                       "example": true,
@@ -18807,6 +19390,19 @@
                     "type": "string",
                     "x-linode-cli-display": 2
                   },
+                  "maintenance_policy": {
+                    "description": "__Beta__ Defines the default maintenance policy for new Linodes created on this account. Review [maintenance policy](https://techdocs.akamai.com/cloud-computing/docs/host-maintenance-policy) documentation for more details.",
+                    "enum": [
+                      "linode/migrate",
+                      "linode/power_off_on"
+                    ],
+                    "example": "{{maintenance_policy}}",
+                    "type": "string",
+                    "x-akamai": {
+                      "status": "BETA"
+                    },
+                    "x-linode-cli-display": 7
+                  },
                   "managed": {
                     "description": "__Read-only__ Our 24/7 incident response service. This robust, multi-homed monitoring system distributes monitoring checks to ensure that your servers remain online and available at all times. Linode Managed can monitor any service or software stack reachable over TCP or HTTP. Once you add a service to Linode Managed, we'll monitor it for connectivity, response, and total request time.",
                     "example": "{{managed}}",
@@ -18882,6 +19478,19 @@
                       "readOnly": true,
                       "type": "string",
                       "x-linode-cli-display": 2
+                    },
+                    "maintenance_policy": {
+                      "description": "__Beta__ Defines the default maintenance policy for new Linodes created on this account. Review [maintenance policy](https://techdocs.akamai.com/cloud-computing/docs/host-maintenance-policy) documentation for more details.",
+                      "enum": [
+                        "linode/migrate",
+                        "linode/power_off_on"
+                      ],
+                      "example": "linode/migrate",
+                      "type": "string",
+                      "x-akamai": {
+                        "status": "BETA"
+                      },
+                      "x-linode-cli-display": 7
                     },
                     "managed": {
                       "description": "__Read-only__ Our 24/7 incident response service. This robust, multi-homed monitoring system distributes monitoring checks to ensure that your servers remain online and available at all times. Linode Managed can monitor any service or software stack reachable over TCP or HTTP. Once you add a service to Linode Managed, we'll monitor it for connectivity, response, and total request time.",
@@ -19315,7 +19924,7 @@
     },
     "/{apiVersion}/account/users": {
       "post": {
-        "description": "Creates a user on your account. You determine the new user's account access by setting it to restricted or unrestricted and by defining its grants. After completion, the API sends a confirmation message containing password creation and login instructions to the user's `email` address.\n\n> \ud83d\udcd8\n>\n> This operation can only be accessed by account users with _unrestricted_ access.\n\n__Parent and child accounts__\n\nIn a [parent and child account](https://www.linode.com/docs/guides/parent-child-accounts/) environment, the following apply:\n\n- A parent account user can create new parent account users.\n\n- A child account can [update](https://techdocs.akamai.com/linode-api/reference/put-user) the child account parent user (proxy user) to `unrestricted`. This gives the proxy user access to create new child account users.\n\n- A child account user can create new child account users.\n\n- You can't create a proxy user. The proxy user in a child account is predefined when you initially provision the parent-child relationship.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli users create \\\n  --username example_user \\\n  --email example_user@linode.com \\\n  --restricted true\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Creates a user on your account. You determine the new user's account access by setting it to restricted or unrestricted and by defining its grants. After completion, the API sends a confirmation message containing password creation and login instructions to the user's `email` address.\n\n> \ud83d\udcd8\n>\n> This operation can only be accessed by account users with _unrestricted_ access. Talk to your local account administrator about access management.\n\n__Parent and child accounts__\n\nIn a [parent and child account](https://www.linode.com/docs/guides/parent-child-accounts/) environment, the following apply:\n\n- A parent account user can create new parent account users.\n\n- A child account can [update](https://techdocs.akamai.com/linode-api/reference/put-user) the child account parent user (proxy user) to `unrestricted`. This gives the proxy user access to create new child account users.\n\n- A child account user can create new child account users.\n\n- You can't create a proxy user. The proxy user in a child account is predefined when you initially provision the parent-child relationship.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli users create \\\n  --username example_user \\\n  --email example_user@linode.com \\\n  --restricted true\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/post-user"
@@ -19618,7 +20227,7 @@
         "x-linode-grant": "unrestricted only"
       },
       "get": {
-        "description": "Returns a paginated list of all users on your account.\n\n> \ud83d\udcd8\n>\n> This operation can only be accessed by account users with _unrestricted_ access.\n\nA user can access all or part of an account based on their access status and grants:\n\n- __Unrestricted access__. These users can access everything on an account.\n\n- __Restricted access__. These users can only access entities or perform actions they've been given specific grants to.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli users list\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Returns a paginated list of all users on your account.\n\n> \ud83d\udcd8\n>\n> This operation can only be accessed by account users with _unrestricted_ access. Talk to your local account administrator about access management.\n\nA user can access all or part of an account based on their access status and grants:\n\n- __Unrestricted access__. These users can access everything on an account.\n\n- __Restricted access__. These users can only access entities or perform actions they've been given specific grants to.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli users list\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-users"
@@ -19795,7 +20404,7 @@
                             "description": "The type of user on an account. Mostly applies to the use of the parent and child accounts for Akamai partners functionality.",
                             "properties": {
                               "user_type": {
-                                "description": "__Read-only__ If the user belongs to a [parent or child account](https://www.linode.com/docs/guides/parent-child-accounts/) relationship, this defines the user type in the respective account. Possible values include:\n\n- `parent`. This is a user in an Akamai partner account. Akamai partners have a contractural relationship with their end customers, to sell Akamai services. This user can either have full access (a parent account admin user) or limited access. Limited users don't have access to manage child accounts, but they can be granted this access by an admin user.\n\n- `child`. This is an Akamai partner's end customer user, in a child account. A child user can have either full or limited access. Full access lets the user manage other child users and the proxy user in a child account.\n\n- `proxy`. This is a user on a child account that gives parent account users access to that child account. A parent account user with the `child_account_access` grant can [Create a proxy user token](https://techdocs.akamai.com/linode-api/reference/post-child-account-token) from the parent account. The parent user can use this token to run API operations from the child account, as if they were a child user.\n\n- `default`. This applies to all regular, non-parent-child account users.",
+                                "description": "__Read-only__ If the user belongs to a [parent or child account](https://www.linode.com/docs/guides/parent-child-accounts/) relationship, this defines the user type in the respective account. Possible values include:\n\n- `parent`. This is a user in an Akamai partner account. Akamai partners have a contractual relationship with their end customers, to sell Akamai services. This user can either have full access (a parent account admin user) or limited access. Limited users don't have access to manage child accounts, but they can be granted this access by an admin user.\n\n- `child`. This is an Akamai partner's end customer user, in a child account. A child user can have either full or limited access. Full access lets the user manage other child users and the proxy user in a child account.\n\n- `proxy`. This is a user on a child account that gives parent account users access to that child account. A parent account user with the `child_account_access` grant can [Create a proxy user token](https://techdocs.akamai.com/linode-api/reference/post-child-account-token) from the parent account. The parent user can use this token to run API operations from the child account, as if they were a child user.\n\n- `default`. This applies to all regular, non-parent-child account users.",
                                 "enum": [
                                   "parent",
                                   "child",
@@ -19942,7 +20551,7 @@
     },
     "/{apiVersion}/account/users/{username}": {
       "get": {
-        "description": "Returns information about a single user on your account.\n\n> \ud83d\udcd8\n>\n> This operation can only be accessed by account users with _unrestricted_ access.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli users view example_user\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Returns information about a single user on your account.\n\n> \ud83d\udcd8\n>\n> This operation can only be accessed by account users with _unrestricted_ access. Talk to your local account administrator about access management.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli users view example_user\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-user"
@@ -20060,7 +20669,7 @@
                       "description": "The type of user on an account. Mostly applies to the use of the parent and child accounts for Akamai partners functionality.",
                       "properties": {
                         "user_type": {
-                          "description": "__Read-only__ If the user belongs to a [parent or child account](https://www.linode.com/docs/guides/parent-child-accounts/) relationship, this defines the user type in the respective account. Possible values include:\n\n- `parent`. This is a user in an Akamai partner account. Akamai partners have a contractural relationship with their end customers, to sell Akamai services. This user can either have full access (a parent account admin user) or limited access. Limited users don't have access to manage child accounts, but they can be granted this access by an admin user.\n\n- `child`. This is an Akamai partner's end customer user, in a child account. A child user can have either full or limited access. Full access lets the user manage other child users and the proxy user in a child account.\n\n- `proxy`. This is a user on a child account that gives parent account users access to that child account. A parent account user with the `child_account_access` grant can [Create a proxy user token](https://techdocs.akamai.com/linode-api/reference/post-child-account-token) from the parent account. The parent user can use this token to run API operations from the child account, as if they were a child user.\n\n- `default`. This applies to all regular, non-parent-child account users.",
+                          "description": "__Read-only__ If the user belongs to a [parent or child account](https://www.linode.com/docs/guides/parent-child-accounts/) relationship, this defines the user type in the respective account. Possible values include:\n\n- `parent`. This is a user in an Akamai partner account. Akamai partners have a contractual relationship with their end customers, to sell Akamai services. This user can either have full access (a parent account admin user) or limited access. Limited users don't have access to manage child accounts, but they can be granted this access by an admin user.\n\n- `child`. This is an Akamai partner's end customer user, in a child account. A child user can have either full or limited access. Full access lets the user manage other child users and the proxy user in a child account.\n\n- `proxy`. This is a user on a child account that gives parent account users access to that child account. A parent account user with the `child_account_access` grant can [Create a proxy user token](https://techdocs.akamai.com/linode-api/reference/post-child-account-token) from the parent account. The parent user can use this token to run API operations from the child account, as if they were a child user.\n\n- `default`. This applies to all regular, non-parent-child account users.",
                           "enum": [
                             "parent",
                             "child",
@@ -20155,7 +20764,7 @@
         "x-linode-grant": "unrestricted only"
       },
       "put": {
-        "description": "Update information about a user on your account, including its restricted status. When setting a user to `restricted`, the API sets no grants for it. You need to set grants so that user can access things on the account.\n\n> \ud83d\udcd8\n>\n> This operation can only be accessed by account users with _unrestricted_ access.\n\n__Parent and child accounts__\n\nIn a [parent and child account](https://www.linode.com/docs/guides/parent-child-accounts/) environment, the following apply:\n\n- You can't edit the `username` or `email` values for the child account parent user (proxy user). These are predefined for the proxy user when you initially provision the parent-child relationship. Only a proxy user's `restricted` status can be modified. This can only be done by an unrestricted child account user.\n\n- A parent account using an unrestricted proxy user in a child account can modify the `username`, `email`, and `restricted` status for an existing child account user.\n\n- A restricted account user--parent or child--can't change their user to `unrestricted`.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli users update example_user \\\n  --username example_user \\\n  --email example@linode.com \\\n  --restricted true\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Update information about a user on your account, including its restricted status. When setting a user to `restricted`, the API sets no grants for it. You need to set grants so that user can access things on the account.\n\n> \ud83d\udcd8\n>\n> This operation can only be accessed by account users with _unrestricted_ access. Talk to your local account administrator about access management.\n\n__Parent and child accounts__\n\nIn a [parent and child account](https://www.linode.com/docs/guides/parent-child-accounts/) environment, the following apply:\n\n- You can't edit the `username` or `email` values for the child account parent user (proxy user). These are predefined for the proxy user when you initially provision the parent-child relationship. Only a proxy user's `restricted` status can be modified. This can only be done by an unrestricted child account user.\n\n- A parent account using an unrestricted proxy user in a child account can modify the `username`, `email`, and `restricted` status for an existing child account user.\n\n- A restricted account user--parent or child--can't change their user to `unrestricted`.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli users update example_user \\\n  --username example_user \\\n  --email example@linode.com \\\n  --restricted true\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/put-user"
@@ -20395,7 +21004,7 @@
                       "description": "The type of user on an account. Mostly applies to the use of the parent and child accounts for Akamai partners functionality.",
                       "properties": {
                         "user_type": {
-                          "description": "__Read-only__ If the user belongs to a [parent or child account](https://www.linode.com/docs/guides/parent-child-accounts/) relationship, this defines the user type in the respective account. Possible values include:\n\n- `parent`. This is a user in an Akamai partner account. Akamai partners have a contractural relationship with their end customers, to sell Akamai services. This user can either have full access (a parent account admin user) or limited access. Limited users don't have access to manage child accounts, but they can be granted this access by an admin user.\n\n- `child`. This is an Akamai partner's end customer user, in a child account. A child user can have either full or limited access. Full access lets the user manage other child users and the proxy user in a child account.\n\n- `proxy`. This is a user on a child account that gives parent account users access to that child account. A parent account user with the `child_account_access` grant can [Create a proxy user token](https://techdocs.akamai.com/linode-api/reference/post-child-account-token) from the parent account. The parent user can use this token to run API operations from the child account, as if they were a child user.\n\n- `default`. This applies to all regular, non-parent-child account users.",
+                          "description": "__Read-only__ If the user belongs to a [parent or child account](https://www.linode.com/docs/guides/parent-child-accounts/) relationship, this defines the user type in the respective account. Possible values include:\n\n- `parent`. This is a user in an Akamai partner account. Akamai partners have a contractual relationship with their end customers, to sell Akamai services. This user can either have full access (a parent account admin user) or limited access. Limited users don't have access to manage child accounts, but they can be granted this access by an admin user.\n\n- `child`. This is an Akamai partner's end customer user, in a child account. A child user can have either full or limited access. Full access lets the user manage other child users and the proxy user in a child account.\n\n- `proxy`. This is a user on a child account that gives parent account users access to that child account. A parent account user with the `child_account_access` grant can [Create a proxy user token](https://techdocs.akamai.com/linode-api/reference/post-child-account-token) from the parent account. The parent user can use this token to run API operations from the child account, as if they were a child user.\n\n- `default`. This applies to all regular, non-parent-child account users.",
                           "enum": [
                             "parent",
                             "child",
@@ -20490,7 +21099,7 @@
         "x-linode-grant": "unrestricted only"
       },
       "delete": {
-        "description": "Deletes a user. The API immediately logs the user out and removes all of its `grants`.\n\n> \ud83d\udcd8\n>\n> This operation can only be accessed by account users with _unrestricted_ access.\n\n__Parent and child accounts__\n\nIn a [parent and child account](https://www.linode.com/docs/guides/parent-child-accounts/) environment, the following apply:\n\n- You can't delete a child account parent user (proxy user). The API returns a 403 error if you target a proxy user with this operation.\n\n- A parent account using an unrestricted proxy user can use this operation to delete a child account user.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli users delete example_user\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Deletes a user. The API immediately logs the user out and removes all of its `grants`.\n\n> \ud83d\udcd8\n>\n> This operation can only be accessed by account users with _unrestricted_ access. Talk to your local account administrator about access management.\n\n__Parent and child accounts__\n\nIn a [parent and child account](https://www.linode.com/docs/guides/parent-child-accounts/) environment, the following apply:\n\n- You can't delete a child account parent user (proxy user). The API returns a 403 error if you target a proxy user with this operation.\n\n- A parent account using an unrestricted proxy user can use this operation to delete a child account user.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli users delete example_user\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/delete-user"
@@ -20626,7 +21235,7 @@
     },
     "/{apiVersion}/account/users/{username}/grants": {
       "get": {
-        "description": "Returns the full grants structure for an account username you specify. This includes all entities on the account, and the level of access this user has to each of them.\n\nThis doesn't apply to the account owner or the current authenticated user. You can run the [List grants](https://techdocs.akamai.com/linode-api/reference/get-profile-grants) operation to view those grants. However, this doesn't show the entities that they _don't_ have access to.\n\n> \ud83d\udcd8\n>\n> This operation can only be accessed by account users with _unrestricted_ access.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    account:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Returns the full grants structure for an account username you specify. This includes all entities on the account, and the level of access this user has to each of them.\n\nThis doesn't apply to the account owner or the current authenticated user. You can run the [List grants](https://techdocs.akamai.com/linode-api/reference/get-profile-grants) operation to view those grants. However, this doesn't show the entities that they _don't_ have access to.\n\n> \ud83d\udcd8\n>\n> This operation can only be accessed by account users with _unrestricted_ access. Talk to your local account administrator about access management.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    account:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-user-grants"
@@ -21154,7 +21763,7 @@
         "x-linode-grant": "unrestricted only"
       },
       "put": {
-        "description": "Update the grants for a [restricted](https://techdocs.akamai.com/linode-api/reference/post-user) user. This can be used to give a user access to new entities or actions, or take access away. Omit a grant object from the request to keep its current setting.\n\n> \ud83d\udcd8\n>\n> - This operation can only be accessed by account users with _unrestricted_ access.\n>\n> - This operation only applies to _restricted_ users. An unrestricted user has access to everything and doesn't use grants.\n\n__Parent and child accounts__\n\nIn a [parent and child account](https://www.linode.com/docs/guides/parent-child-accounts/) environment, the following apply:\n\n- No child account user can modify the `account_access` grant for the child account parent user (proxy user).\n\n- An unrestricted child account user can configure all other grants for the proxy user, with the `global` object.\n\n- An unrestricted child account user can enable the `account_access` grant for other child account users. However, enabled child users are still subject to child user restrictions--they can't perform write operations for any billing or account information.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    account:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Update the grants for a [restricted](https://techdocs.akamai.com/linode-api/reference/post-user) user. This can be used to give a user access to new entities or actions, or take access away. Omit a grant object from the request to keep its current setting.\n\n> \ud83d\udcd8\n>\n> - This operation can only be accessed by account users with _unrestricted_ access. Talk to your local account administrator about access management.\n>\n> - This operation only applies to _restricted_ users. An unrestricted user has access to everything and doesn't use grants.\n\n__Parent and child accounts__\n\nIn a [parent and child account](https://www.linode.com/docs/guides/parent-child-accounts/) environment, the following apply:\n\n- No child account user can modify the `account_access` grant for the child account parent user (proxy user).\n\n- An unrestricted child account user can configure all other grants for the proxy user, with the `global` object.\n\n- An unrestricted child account user can enable the `account_access` grant for other child account users. However, enabled child users are still subject to child user restrictions--they can't perform write operations for any billing or account information.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    account:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/put-user-grants"
@@ -41545,14 +42154,117 @@
                     },
                     "id": {
                       "description": "__Read-only__ The unique identifier for each image.",
-                      "example": "linode/debian11",
+                      "example": "private/15",
                       "readOnly": true,
                       "type": "string",
                       "x-linode-cli-display": 1
                     },
+                    "image_sharing": {
+                      "description": "This object represents the sharing status of an image.",
+                      "oneOf": [
+                        {
+                          "additionalProperties": false,
+                          "example": {
+                            "shared_by": null,
+                            "shared_with": {
+                              "image_sharegroup_list_url": "/images/private/15/sharegroups",
+                              "sharegroup_count": 0
+                            }
+                          },
+                          "properties": {
+                            "shared_by": {
+                              "description": "This field is `null` in this case, meaning the image is not shared by any group. The `shared_with` field provides details on the image's share group.",
+                              "nullable": true,
+                              "type": "object"
+                            },
+                            "shared_with": {
+                              "additionalProperties": false,
+                              "description": "Specifies the group that the image is shared with, including the count of share groups and a URL to view the share groups.",
+                              "properties": {
+                                "image_sharegroup_list_url": {
+                                  "description": "A URL to view the list of share groups the image is shared with.",
+                                  "type": "string"
+                                },
+                                "sharegroup_count": {
+                                  "description": "The number of share groups the image is shared with.",
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "sharegroup_count",
+                                "image_sharegroup_list_url"
+                              ],
+                              "type": "object"
+                            }
+                          },
+                          "required": [
+                            "shared_with",
+                            "shared_by"
+                          ],
+                          "title": "shared_with",
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "example": {
+                            "shared_by": {
+                              "sharegroup_id": 3,
+                              "sharegroup_label": "label",
+                              "sharegroup_uuid": "8003abfe-6b03-41a1-9e4c-a234ae3060c8",
+                              "source_image_id": null
+                            },
+                            "shared_with": null
+                          },
+                          "properties": {
+                            "shared_by": {
+                              "additionalProperties": false,
+                              "description": "This object contains the details of the share group that is sharing the image. The share group details are specified in this object.",
+                              "properties": {
+                                "sharegroup_id": {
+                                  "description": "The ID of the share group.",
+                                  "type": "integer"
+                                },
+                                "sharegroup_label": {
+                                  "description": "A label linked to the share group.",
+                                  "type": "string"
+                                },
+                                "sharegroup_uuid": {
+                                  "description": "The unique identifier of the share group.",
+                                  "format": "uuid",
+                                  "type": "string"
+                                },
+                                "source_image_id": {
+                                  "description": "The ID of the source image being shared. This can be null if no specific source image is being referenced.",
+                                  "nullable": true,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "sharegroup_id",
+                                "sharegroup_uuid",
+                                "sharegroup_label",
+                                "source_image_id"
+                              ],
+                              "type": "object"
+                            },
+                            "shared_with": {
+                              "description": "This field is null in this case, meaning the image is not shared with anyone. The details of sharing are contained in the `shared_by` field.",
+                              "nullable": true,
+                              "type": "object"
+                            }
+                          },
+                          "required": [
+                            "shared_with",
+                            "shared_by"
+                          ],
+                          "title": "shared_by",
+                          "type": "object"
+                        }
+                      ]
+                    },
                     "is_public": {
                       "description": "__Filterable__, __Read-only__ Revealed as `true` if the image is a public distribution image. Private, account-specific images are listed as `false`.",
-                      "example": true,
+                      "example": false,
                       "readOnly": true,
                       "type": "boolean",
                       "x-akamai": {
@@ -41561,6 +42273,18 @@
                         ]
                       },
                       "x-linode-cli-display": 5,
+                      "x-linode-filterable": true
+                    },
+                    "is_shared": {
+                      "description": "__Filterable__, __Read-only__ Indicates if the image is a private image shared with other users.",
+                      "example": false,
+                      "readOnly": true,
+                      "type": "boolean",
+                      "x-akamai": {
+                        "labels": [
+                          "Filterable"
+                        ]
+                      },
                       "x-linode-filterable": true
                     },
                     "label": {
@@ -41707,6 +42431,28 @@
                       "x-linode-filterable": true
                     }
                   },
+                  "required": [
+                    "id",
+                    "tags",
+                    "type",
+                    "description",
+                    "label",
+                    "created",
+                    "updated",
+                    "size",
+                    "status",
+                    "capabilities",
+                    "is_public",
+                    "is_shared",
+                    "deprecated",
+                    "regions",
+                    "total_size",
+                    "image_sharing",
+                    "created_by",
+                    "expiry",
+                    "eol",
+                    "vendor"
+                  ],
                   "type": "object",
                   "x-akamai": {
                     "file-path": "schemas/image.yaml"
@@ -41789,7 +42535,7 @@
         "x-linode-grant": "add_images"
       },
       "get": {
-        "description": "Returns a paginated list of images. An image can be one of two types:\n\n- **Public image**. The `id` for these images begins with `linode/`. These images are generally available to all users. To limit the response to public images, don't include [authentication](https://techdocs.akamai.com/linode-api/reference/get-started#authentication) when calling this operation.\n\n- **Private image**. The `id` for these images begins with `private/`. These images are account-specific and only accessible to users with appropriate [grants](https://techdocs.akamai.com/linode-api/reference/get-user-grants). To view private images, you need to include authentication when calling this operation. The response includes both private and public images.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli images list\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    images:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Returns a paginated list of images. An image can be one of two types:\n\n- **Public image**. The `id` for these images begins with `linode/`. These images are generally available to all users. To limit the response to public images, don't include [authentication](https://techdocs.akamai.com/linode-api/reference/get-started#authentication) when calling this operation.\n\n- **Private image**. The `id` for these images begins with `private/`. These images are account-specific and only accessible to users with appropriate [grants](https://techdocs.akamai.com/linode-api/reference/get-user-grants). To view private images, you need to include authentication when calling this operation. The response includes both private and public images.\n\n- **Shared image**. The `id` for these images begins with `shared/`. These are the images that are shared with the user.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli images list\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    images:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-images"
@@ -41910,14 +42656,117 @@
                           },
                           "id": {
                             "description": "__Read-only__ The unique identifier for each image.",
-                            "example": "linode/debian11",
+                            "example": "private/15",
                             "readOnly": true,
                             "type": "string",
                             "x-linode-cli-display": 1
                           },
+                          "image_sharing": {
+                            "description": "This object represents the sharing status of an image.",
+                            "oneOf": [
+                              {
+                                "additionalProperties": false,
+                                "example": {
+                                  "shared_by": null,
+                                  "shared_with": {
+                                    "image_sharegroup_list_url": "/images/private/15/sharegroups",
+                                    "sharegroup_count": 0
+                                  }
+                                },
+                                "properties": {
+                                  "shared_by": {
+                                    "description": "This field is `null` in this case, meaning the image is not shared by any group. The `shared_with` field provides details on the image's share group.",
+                                    "nullable": true,
+                                    "type": "object"
+                                  },
+                                  "shared_with": {
+                                    "additionalProperties": false,
+                                    "description": "Specifies the group that the image is shared with, including the count of share groups and a URL to view the share groups.",
+                                    "properties": {
+                                      "image_sharegroup_list_url": {
+                                        "description": "A URL to view the list of share groups the image is shared with.",
+                                        "type": "string"
+                                      },
+                                      "sharegroup_count": {
+                                        "description": "The number of share groups the image is shared with.",
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "sharegroup_count",
+                                      "image_sharegroup_list_url"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "shared_with",
+                                  "shared_by"
+                                ],
+                                "title": "shared_with",
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "example": {
+                                  "shared_by": {
+                                    "sharegroup_id": 3,
+                                    "sharegroup_label": "label",
+                                    "sharegroup_uuid": "8003abfe-6b03-41a1-9e4c-a234ae3060c8",
+                                    "source_image_id": null
+                                  },
+                                  "shared_with": null
+                                },
+                                "properties": {
+                                  "shared_by": {
+                                    "additionalProperties": false,
+                                    "description": "This object contains the details of the share group that is sharing the image. The share group details are specified in this object.",
+                                    "properties": {
+                                      "sharegroup_id": {
+                                        "description": "The ID of the share group.",
+                                        "type": "integer"
+                                      },
+                                      "sharegroup_label": {
+                                        "description": "A label linked to the share group.",
+                                        "type": "string"
+                                      },
+                                      "sharegroup_uuid": {
+                                        "description": "The unique identifier of the share group.",
+                                        "format": "uuid",
+                                        "type": "string"
+                                      },
+                                      "source_image_id": {
+                                        "description": "The ID of the source image being shared. This can be null if no specific source image is being referenced.",
+                                        "nullable": true,
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "sharegroup_id",
+                                      "sharegroup_uuid",
+                                      "sharegroup_label",
+                                      "source_image_id"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "shared_with": {
+                                    "description": "This field is null in this case, meaning the image is not shared with anyone. The details of sharing are contained in the `shared_by` field.",
+                                    "nullable": true,
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "shared_with",
+                                  "shared_by"
+                                ],
+                                "title": "shared_by",
+                                "type": "object"
+                              }
+                            ]
+                          },
                           "is_public": {
                             "description": "__Filterable__, __Read-only__ Revealed as `true` if the image is a public distribution image. Private, account-specific images are listed as `false`.",
-                            "example": true,
+                            "example": false,
                             "readOnly": true,
                             "type": "boolean",
                             "x-akamai": {
@@ -41926,6 +42775,18 @@
                               ]
                             },
                             "x-linode-cli-display": 5,
+                            "x-linode-filterable": true
+                          },
+                          "is_shared": {
+                            "description": "__Filterable__, __Read-only__ Indicates if the image is a private image shared with other users.",
+                            "example": false,
+                            "readOnly": true,
+                            "type": "boolean",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ]
+                            },
                             "x-linode-filterable": true
                           },
                           "label": {
@@ -42072,6 +42933,28 @@
                             "x-linode-filterable": true
                           }
                         },
+                        "required": [
+                          "id",
+                          "tags",
+                          "type",
+                          "description",
+                          "label",
+                          "created",
+                          "updated",
+                          "size",
+                          "status",
+                          "capabilities",
+                          "is_public",
+                          "is_shared",
+                          "deprecated",
+                          "regions",
+                          "total_size",
+                          "image_sharing",
+                          "created_by",
+                          "expiry",
+                          "eol",
+                          "vendor"
+                        ],
                         "type": "object",
                         "x-akamai": {
                           "file-path": "schemas/image.yaml"
@@ -42205,6 +43088,4704 @@
         "path-info": "/{apiVersion}/images"
       },
       "x-linode-cli-command": "images"
+    },
+    "/{apiVersion}/images/sharegroups": {
+      "post": {
+        "description": "Create a share group.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    images:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "externalDocs": {
+          "description": "See documentation for this operation in Akamai's Linode API",
+          "url": "https://techdocs.akamai.com/linode-api/reference/post-sharegroups"
+        },
+        "operationId": "post-sharegroups",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "description": {
+                    "description": "A detailed description of this share group.",
+                    "example": "{{description}}",
+                    "type": "string"
+                  },
+                  "images": {
+                    "description": "List of image objects associated with this share group.",
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "description": {
+                          "description": "Image share description.",
+                          "example": "Official Debian Linux image for server deployment",
+                          "type": "string"
+                        },
+                        "id": {
+                          "description": "Private image id.",
+                          "example": "private/7",
+                          "type": "string"
+                        },
+                        "label": {
+                          "description": "Image share label.",
+                          "example": "Linux Debian",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "label": {
+                    "description": "Label for the share group.",
+                    "example": "{{label}}",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "label"
+                ],
+                "type": "object",
+                "x-akamai": {
+                  "file-path": "schemas/post-sharegroup.yaml"
+                }
+              },
+              "x-example": {
+                "x-ref": "../examples/post-sharegroup.json"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "description": "ShareGroup object.",
+                  "properties": {
+                    "created": {
+                      "description": "__Read-only__ The time when this share group was created.",
+                      "example": "2025-04-14T22:44:02",
+                      "format": "date-time",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "description": {
+                      "description": "A detailed description of this share group.",
+                      "example": "Group of base operating system images and engineers used for CI/CD pipelines and infrastructure automation",
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "expiry": {
+                      "description": "__Read-only__ The time when the share group expires.",
+                      "example": null,
+                      "format": "date-time",
+                      "nullable": true,
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "id": {
+                      "description": "A numeric identifier for the share group. This is primarily used within the system for database operations and is read-only.",
+                      "example": 1,
+                      "type": "integer"
+                    },
+                    "images_count": {
+                      "description": "__Read-only__ The total number of images currently belonging to the share group.",
+                      "readOnly": true,
+                      "type": "integer"
+                    },
+                    "is_suspended": {
+                      "description": "__Read-only__ Indicates whether the share group is currently suspended.",
+                      "example": false,
+                      "readOnly": true,
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "description": "Label for the share group.",
+                      "example": "DevOps Base Images",
+                      "type": "string"
+                    },
+                    "members_count": {
+                      "description": "__Read-only__ The number of members who have access to the share group.",
+                      "readOnly": true,
+                      "type": "integer"
+                    },
+                    "updated": {
+                      "description": "__Read-only__ The time when this share group was last updated.",
+                      "example": null,
+                      "format": "date-time",
+                      "nullable": true,
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "uuid": {
+                      "description": "__Read-only__ A universally unique identifier for the share group. Used by clients to reference a specific share group when creating a single-use token.",
+                      "example": "1533863e-16a4-47b5-b829-ac0f35c13278",
+                      "format": "uuid",
+                      "readOnly": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "uuid",
+                    "label",
+                    "description",
+                    "is_suspended",
+                    "created",
+                    "updated",
+                    "expiry",
+                    "images_count",
+                    "members_count"
+                  ],
+                  "type": "object",
+                  "x-akamai": {
+                    "file-path": "schemas/sharegroup.yaml"
+                  }
+                },
+                "x-example": {
+                  "x-ref": "../examples/post-sharegroup-200.json"
+                }
+              }
+            },
+            "description": "New share group created successfully."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "errors": {
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "An object for describing a single error that occurred during the processing of a request.",
+                        "properties": {
+                          "field": {
+                            "description": "The field in the request that caused this error. This may be a path, separated by periods in the case of nested fields. In some cases this may come back as `null` if the error is not specific to any single element of the request.",
+                            "example": "fieldname",
+                            "type": "string"
+                          },
+                          "reason": {
+                            "description": "What happened to cause this error. In most cases, this can be fixed immediately by changing the data you sent in the request, but in some cases you will be instructed to [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) or perform some other action before you can complete the request successfully.",
+                            "example": "fieldname must be a valid value",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-akamai": {
+                          "file-path": "schemas/error-object.yaml"
+                        }
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "See [Errors](https://techdocs.akamai.com/linode-api/reference/errors) for the range of possible error response codes."
+          }
+        },
+        "security": [
+          {
+            "personalAccessToken": []
+          },
+          {
+            "oauth": [
+              "images:read_write"
+            ]
+          }
+        ],
+        "summary": "Create a share group",
+        "tags": [
+          "Private image sharing"
+        ],
+        "x-akamai": {
+          "tabs": [
+            {
+              "syntax": "images:read_write",
+              "title": "OAuth scopes",
+              "url": "https://techdocs.akamai.com/linode-api/reference/get-started#oauth"
+            }
+          ]
+        }
+      },
+      "get": {
+        "description": "Returns a paginated list of share groups.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    images:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "externalDocs": {
+          "description": "See documentation for this operation in Akamai's Linode API",
+          "url": "https://techdocs.akamai.com/linode-api/reference/get-sharegroups"
+        },
+        "operationId": "get-sharegroups",
+        "parameters": [
+          {
+            "description": "The page of a collection to return.",
+            "example": "{{page}}",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "example": 6,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "x-akamai": {
+              "file-path": "parameters/page-offset.yaml"
+            }
+          },
+          {
+            "description": "The number of items to return per page.",
+            "example": "{{page_size}}",
+            "in": "query",
+            "name": "page_size",
+            "schema": {
+              "default": 100,
+              "example": 50,
+              "maximum": 500,
+              "minimum": 25,
+              "type": "integer"
+            },
+            "x-akamai": {
+              "file-path": "parameters/page-size.yaml"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "ShareGroup object.",
+                        "properties": {
+                          "created": {
+                            "description": "__Read-only__ The time when this share group was created.",
+                            "example": "2025-04-14T22:44:02",
+                            "format": "date-time",
+                            "readOnly": true,
+                            "type": "string"
+                          },
+                          "description": {
+                            "description": "A detailed description of this share group.",
+                            "example": "Group of base operating system images and engineers used for CI/CD pipelines and infrastructure automation",
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "expiry": {
+                            "description": "__Read-only__ The time when the share group expires.",
+                            "example": null,
+                            "format": "date-time",
+                            "nullable": true,
+                            "readOnly": true,
+                            "type": "string"
+                          },
+                          "id": {
+                            "description": "A numeric identifier for the share group. This is primarily used within the system for database operations and is read-only.",
+                            "example": 1,
+                            "type": "integer"
+                          },
+                          "images_count": {
+                            "description": "__Read-only__ The total number of images currently belonging to the share group.",
+                            "readOnly": true,
+                            "type": "integer"
+                          },
+                          "is_suspended": {
+                            "description": "__Read-only__ Indicates whether the share group is currently suspended.",
+                            "example": false,
+                            "readOnly": true,
+                            "type": "boolean"
+                          },
+                          "label": {
+                            "description": "__Filterable__ Label for the share group.",
+                            "example": "DevOps Base Images",
+                            "type": "string",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ]
+                            },
+                            "x-linode-filterable": true
+                          },
+                          "members_count": {
+                            "description": "__Read-only__ The number of members who have access to the share group.",
+                            "readOnly": true,
+                            "type": "integer"
+                          },
+                          "updated": {
+                            "description": "__Read-only__ The time when this share group was last updated.",
+                            "example": null,
+                            "format": "date-time",
+                            "nullable": true,
+                            "readOnly": true,
+                            "type": "string"
+                          },
+                          "uuid": {
+                            "description": "A universally unique identifier for the share group. Used by clients to reference a specific share group when creating a single-use token.",
+                            "example": "1533863e-16a4-47b5-b829-ac0f35c13278",
+                            "format": "uuid",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "uuid",
+                          "label",
+                          "description",
+                          "is_suspended",
+                          "created",
+                          "updated",
+                          "expiry",
+                          "images_count",
+                          "members_count"
+                        ],
+                        "type": "object",
+                        "x-akamai": {
+                          "file-path": "schemas/sharegroups.yaml"
+                        }
+                      },
+                      "type": "array"
+                    },
+                    "page": {
+                      "description": "__Read-only__ The current [page](https://techdocs.akamai.com/linode-api/reference/pagination).",
+                      "example": 1,
+                      "readOnly": true,
+                      "type": "integer"
+                    },
+                    "pages": {
+                      "description": "__Read-only__ The total number of [pages](https://techdocs.akamai.com/linode-api/reference/pagination).",
+                      "example": 1,
+                      "readOnly": true,
+                      "type": "integer"
+                    },
+                    "results": {
+                      "description": "__Read-only__ The total number of results.",
+                      "example": 1,
+                      "readOnly": true,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "page",
+                    "pages",
+                    "results"
+                  ],
+                  "type": "object",
+                  "x-akamai": {
+                    "file-path": "schemas/get-sharegroups-200.yaml"
+                  }
+                },
+                "x-example": {
+                  "x-ref": "../examples/post-sharegroup-images-200.json"
+                }
+              }
+            },
+            "description": "A paginated list of sharegroups."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "errors": {
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "An object for describing a single error that occurred during the processing of a request.",
+                        "properties": {
+                          "field": {
+                            "description": "The field in the request that caused this error. This may be a path, separated by periods in the case of nested fields. In some cases this may come back as `null` if the error is not specific to any single element of the request.",
+                            "example": "fieldname",
+                            "type": "string"
+                          },
+                          "reason": {
+                            "description": "What happened to cause this error. In most cases, this can be fixed immediately by changing the data you sent in the request, but in some cases you will be instructed to [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) or perform some other action before you can complete the request successfully.",
+                            "example": "fieldname must be a valid value",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-akamai": {
+                          "file-path": "schemas/error-object.yaml"
+                        }
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "See [Errors](https://techdocs.akamai.com/linode-api/reference/errors) for the range of possible error response codes."
+          }
+        },
+        "security": [
+          {
+            "personalAccessToken": []
+          },
+          {
+            "oauth": [
+              "images:read_only"
+            ]
+          }
+        ],
+        "summary": "List share groups",
+        "tags": [
+          "Private image sharing"
+        ],
+        "x-akamai": {
+          "tabs": [
+            {
+              "syntax": "images:read_only",
+              "title": "OAuth scopes",
+              "url": "https://techdocs.akamai.com/linode-api/reference/get-started#oauth"
+            }
+          ]
+        },
+        "x-linode-redoc-load-ids": true
+      },
+      "parameters": [
+        {
+          "description": "__Enum__ Call either the `v4` URL, or `v4beta` for operations still in Beta.",
+          "example": "{{apiVersion}}",
+          "in": "path",
+          "name": "apiVersion",
+          "required": true,
+          "schema": {
+            "enum": [
+              "v4",
+              "v4beta"
+            ],
+            "type": "string"
+          },
+          "x-akamai": {
+            "file-path": "parameters/api-version-path.yaml"
+          }
+        }
+      ],
+      "x-akamai": {
+        "file-path": "paths/images-sharegroups.yaml",
+        "path-info": "/{apiVersion}/images/sharegroups"
+      }
+    },
+    "/{apiVersion}/images/sharegroups/tokens": {
+      "post": {
+        "description": "Allows a customer to create a single-use token.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    images:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "externalDocs": {
+          "description": "See documentation for this operation in Akamai's Linode API",
+          "url": "https://techdocs.akamai.com/linode-api/reference/post-sharegroup-tokens"
+        },
+        "operationId": "post-sharegroup-tokens",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "label": {
+                    "description": "Token label.",
+                    "example": "{{label}}",
+                    "type": "string"
+                  },
+                  "valid_for_sharegroup_uuid": {
+                    "description": "UUID of the share group to link to.",
+                    "example": "{{valid_for_sharegroup_uuid}}",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "valid_for_sharegroup_uuid"
+                ],
+                "type": "object",
+                "x-akamai": {
+                  "file-path": "schemas/post-sharegroup-token.yaml"
+                }
+              },
+              "x-example": {
+                "x-ref": "../examples/post-sharegroup-tokens.json"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "description": "ImageShareGroupMemberTokens object.",
+                  "properties": {
+                    "created": {
+                      "description": "__Read-only__ The creation time of this token.",
+                      "example": "2025-08-04T10:09:09",
+                      "format": "date-time",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "expiry": {
+                      "description": "__Read-only__ The time when this token expires.",
+                      "example": null,
+                      "format": "date-time",
+                      "nullable": true,
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "label": {
+                      "description": "A short description of the token.",
+                      "example": "Backend Services - Engineering",
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "sharegroup_label": {
+                      "description": "__Read-only__ Associated share group label.",
+                      "example": "DevOps Base Images",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "sharegroup_uuid": {
+                      "description": "__Read-only__ UUID identifying the associated share group.",
+                      "example": "e1d0e58b-f89f-4237-84ab-b82077342359",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "status": {
+                      "description": "__Read-only__ Represents the current token status.\n\n- `pending`: The token has been created but is not yet active.\n- `active`: The token is currently active and usable.\n- `revoked`: The token has been deleted and is no longer valid.\n- `expired`: The token has passed its validity period and is no longer usable.",
+                      "enum": [
+                        "pending",
+                        "active",
+                        "revoked",
+                        "expired"
+                      ],
+                      "example": "active",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "token": {
+                      "description": "__Read-only__ A JWT token encoded as a string. It consists of three parts: header, payload, and signature.",
+                      "example": "eyJhbGciOiJIUzI1 ... VNKDTt2yEiJVGSos",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "token_uuid": {
+                      "description": "__Read-only__ A unique identifier representing the token.",
+                      "example": "13428362-5458-4dad-b14b-8d0d4d648f8c",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "updated": {
+                      "description": "__Read-only__ The time when this token was last updated.",
+                      "example": null,
+                      "format": "date-time",
+                      "nullable": true,
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "valid_for_sharegroup_uuid": {
+                      "description": "__Read-only__ UUID identifying the associated share group.",
+                      "example": "e1d0e58b-f89f-4237-84ab-b82077342359",
+                      "readOnly": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "token",
+                    "token_uuid",
+                    "status",
+                    "label",
+                    "created",
+                    "updated",
+                    "expiry",
+                    "valid_for_sharegroup_uuid",
+                    "sharegroup_uuid",
+                    "sharegroup_label"
+                  ],
+                  "type": "object",
+                  "x-akamai": {
+                    "file-path": "schemas/post-sharegroup-token-200.yaml"
+                  }
+                },
+                "x-example": {
+                  "x-ref": "../examples/post-sharegroup-tokens-200.json"
+                }
+              }
+            },
+            "description": "Token generated successfully."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "errors": {
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "An object for describing a single error that occurred during the processing of a request.",
+                        "properties": {
+                          "field": {
+                            "description": "The field in the request that caused this error. This may be a path, separated by periods in the case of nested fields. In some cases this may come back as `null` if the error is not specific to any single element of the request.",
+                            "example": "fieldname",
+                            "type": "string"
+                          },
+                          "reason": {
+                            "description": "What happened to cause this error. In most cases, this can be fixed immediately by changing the data you sent in the request, but in some cases you will be instructed to [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) or perform some other action before you can complete the request successfully.",
+                            "example": "fieldname must be a valid value",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-akamai": {
+                          "file-path": "schemas/error-object.yaml"
+                        }
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "See [Errors](https://techdocs.akamai.com/linode-api/reference/errors) for the range of possible error response codes."
+          }
+        },
+        "security": [
+          {
+            "personalAccessToken": []
+          },
+          {
+            "oauth": [
+              "images:read_write"
+            ]
+          }
+        ],
+        "summary": "Create a token",
+        "tags": [
+          "Private image sharing"
+        ],
+        "x-akamai": {
+          "tabs": [
+            {
+              "syntax": "images:read_write",
+              "title": "OAuth scopes",
+              "url": "https://techdocs.akamai.com/linode-api/reference/get-started#oauth"
+            }
+          ]
+        },
+        "x-linode-redoc-load-ids": true
+      },
+      "get": {
+        "description": "Get details about the tokens.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    images:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "externalDocs": {
+          "description": "See documentation for this operation in Akamai's Linode API",
+          "url": "https://techdocs.akamai.com/linode-api/reference/get-user-tokens"
+        },
+        "operationId": "get-user-tokens",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "ImageShareGroupMemberTokens object.",
+                        "properties": {
+                          "created": {
+                            "description": "__Read-only__ The creation time of this token.",
+                            "example": "2025-08-04T10:09:09",
+                            "format": "date-time",
+                            "readOnly": true,
+                            "type": "string"
+                          },
+                          "expiry": {
+                            "description": "__Read-only__ The time when this token expires.",
+                            "example": null,
+                            "format": "date-time",
+                            "nullable": true,
+                            "readOnly": true,
+                            "type": "string"
+                          },
+                          "label": {
+                            "description": "__Filterable__ A short description of the token.",
+                            "example": "Backend Services - Engineering",
+                            "type": "string",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ]
+                            },
+                            "x-linode-filterable": true
+                          },
+                          "sharegroup_label": {
+                            "description": "__Filterable__, __Read-only__ Associated share group label.",
+                            "example": "DevOps Base Images",
+                            "readOnly": true,
+                            "type": "string",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ]
+                            },
+                            "x-linode-filterable": true
+                          },
+                          "sharegroup_uuid": {
+                            "description": "__Filterable__, __Read-only__ UUID identifying the associated share group.",
+                            "example": "e1d0e58b-f89f-4237-84ab-b82077342359",
+                            "readOnly": true,
+                            "type": "string",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ]
+                            },
+                            "x-linode-filterable": true
+                          },
+                          "status": {
+                            "description": "__Filterable__, __Read-only__ Represents the current token status.\n\n- `pending`: The token has been created but is not yet active.\n- `active`: The token is currently active and usable.\n- `revoked`: The token has been deleted and is no longer valid.\n- `expired`: The token has passed its validity period and is no longer usable.",
+                            "enum": [
+                              "pending",
+                              "active",
+                              "revoked",
+                              "expired"
+                            ],
+                            "example": "active",
+                            "readOnly": true,
+                            "type": "string",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ]
+                            },
+                            "x-linode-filterable": true
+                          },
+                          "token_uuid": {
+                            "description": "__Read-only__ A unique identifier representing the token.",
+                            "example": "13428362-5458-4dad-b14b-8d0d4d648f8c",
+                            "readOnly": true,
+                            "type": "string"
+                          },
+                          "updated": {
+                            "description": "__Read-only__ The time when this token was last updated.",
+                            "example": null,
+                            "format": "date-time",
+                            "nullable": true,
+                            "readOnly": true,
+                            "type": "string"
+                          },
+                          "valid_for_sharegroup_uuid": {
+                            "description": "__Filterable__, __Read-only__ UUID identifying the associated share group.",
+                            "example": "e1d0e58b-f89f-4237-84ab-b82077342359",
+                            "readOnly": true,
+                            "type": "string",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ]
+                            },
+                            "x-linode-filterable": true
+                          }
+                        },
+                        "required": [
+                          "token_uuid",
+                          "status",
+                          "label",
+                          "created",
+                          "updated",
+                          "expiry",
+                          "valid_for_sharegroup_uuid",
+                          "sharegroup_uuid",
+                          "sharegroup_label"
+                        ],
+                        "type": "object",
+                        "x-akamai": {
+                          "file-path": "schemas/tokens.yaml"
+                        }
+                      },
+                      "type": "array"
+                    },
+                    "page": {
+                      "description": "__Read-only__ The current [page](https://techdocs.akamai.com/linode-api/reference/pagination).",
+                      "example": 1,
+                      "readOnly": true,
+                      "type": "integer"
+                    },
+                    "pages": {
+                      "description": "__Read-only__ The total number of [pages](https://techdocs.akamai.com/linode-api/reference/pagination).",
+                      "example": 1,
+                      "readOnly": true,
+                      "type": "integer"
+                    },
+                    "results": {
+                      "description": "__Read-only__ The total number of results.",
+                      "example": 1,
+                      "readOnly": true,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "page",
+                    "pages",
+                    "results"
+                  ],
+                  "type": "object",
+                  "x-akamai": {
+                    "file-path": "schemas/get-sharegroup-tokens-200.yaml"
+                  }
+                },
+                "x-example": {
+                  "x-ref": "../examples/get-sharegroup-tokens-200.json"
+                }
+              }
+            },
+            "description": "Returns a paginated list of the tokens."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "errors": {
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "An object for describing a single error that occurred during the processing of a request.",
+                        "properties": {
+                          "field": {
+                            "description": "The field in the request that caused this error. This may be a path, separated by periods in the case of nested fields. In some cases this may come back as `null` if the error is not specific to any single element of the request.",
+                            "example": "fieldname",
+                            "type": "string"
+                          },
+                          "reason": {
+                            "description": "What happened to cause this error. In most cases, this can be fixed immediately by changing the data you sent in the request, but in some cases you will be instructed to [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) or perform some other action before you can complete the request successfully.",
+                            "example": "fieldname must be a valid value",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-akamai": {
+                          "file-path": "schemas/error-object.yaml"
+                        }
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "See [Errors](https://techdocs.akamai.com/linode-api/reference/errors) for the range of possible error response codes."
+          }
+        },
+        "security": [
+          {
+            "personalAccessToken": []
+          },
+          {
+            "oauth": [
+              "images:read_only"
+            ]
+          }
+        ],
+        "summary": "List tokens",
+        "tags": [
+          "Private image sharing"
+        ],
+        "x-akamai": {
+          "tabs": [
+            {
+              "syntax": "images:read_only",
+              "title": "OAuth scopes",
+              "url": "https://techdocs.akamai.com/linode-api/reference/get-started#oauth"
+            }
+          ]
+        },
+        "x-linode-redoc-load-ids": true
+      },
+      "parameters": [
+        {
+          "description": "__Enum__ Call either the `v4` URL, or `v4beta` for operations still in Beta.",
+          "example": "{{apiVersion}}",
+          "in": "path",
+          "name": "apiVersion",
+          "required": true,
+          "schema": {
+            "enum": [
+              "v4",
+              "v4beta"
+            ],
+            "type": "string"
+          },
+          "x-akamai": {
+            "file-path": "parameters/api-version-path.yaml"
+          }
+        }
+      ],
+      "x-akamai": {
+        "file-path": "paths/images-sharegroup-tokens.yaml",
+        "path-info": "/{apiVersion}/images/sharegroups/tokens"
+      }
+    },
+    "/{apiVersion}/images/sharegroups/tokens/{tokenUuid}": {
+      "get": {
+        "description": "Get details about the selected token.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    images:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "externalDocs": {
+          "description": "See documentation for this operation in Akamai's Linode API",
+          "url": "https://techdocs.akamai.com/linode-api/reference/get-sharegroup-token"
+        },
+        "operationId": "get-sharegroup-token",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "description": "ImageShareGroupMemberTokens object.",
+                  "properties": {
+                    "created": {
+                      "description": "__Read-only__ The creation time of this token.",
+                      "example": "2025-08-04T10:09:09",
+                      "format": "date-time",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "expiry": {
+                      "description": "__Read-only__ The time when this token expires.",
+                      "example": null,
+                      "format": "date-time",
+                      "nullable": true,
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "label": {
+                      "description": "A short description of the token.",
+                      "example": "Backend Services - Engineering",
+                      "type": "string"
+                    },
+                    "sharegroup_label": {
+                      "description": "__Read-only__ Associated share group label.",
+                      "example": "DevOps Base Images",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "sharegroup_uuid": {
+                      "description": "__Read-only__ UUID identifying the associated share group.",
+                      "example": "e1d0e58b-f89f-4237-84ab-b82077342359",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "status": {
+                      "description": "__Read-only__ Represents the current token status.\n\n- `pending`: The token has been created but is not yet active.\n- `active`: The token is currently active and usable.\n- `revoked`: The token has been deleted and is no longer valid.\n- `expired`: The token has passed its validity period and is no longer usable.",
+                      "enum": [
+                        "pending",
+                        "active",
+                        "revoked",
+                        "expired"
+                      ],
+                      "example": "active",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "token_uuid": {
+                      "description": "__Read-only__ A unique identifier representing the token.",
+                      "example": "13428362-5458-4dad-b14b-8d0d4d648f8c",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "updated": {
+                      "description": "__Read-only__ The time when this token was last updated.",
+                      "example": null,
+                      "format": "date-time",
+                      "nullable": true,
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "valid_for_sharegroup_uuid": {
+                      "description": "__Read-only__ UUID identifying the associated share group.",
+                      "example": "e1d0e58b-f89f-4237-84ab-b82077342359",
+                      "readOnly": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "token_uuid",
+                    "status",
+                    "label",
+                    "created",
+                    "updated",
+                    "expiry",
+                    "valid_for_sharegroup_uuid",
+                    "sharegroup_uuid",
+                    "sharegroup_label"
+                  ],
+                  "type": "object",
+                  "x-akamai": {
+                    "file-path": "schemas/token.yaml"
+                  }
+                },
+                "x-example": {
+                  "x-ref": "../examples/get-sharegroup-token-200.json"
+                }
+              }
+            },
+            "description": "Returns the selected token."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "errors": {
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "An object for describing a single error that occurred during the processing of a request.",
+                        "properties": {
+                          "field": {
+                            "description": "The field in the request that caused this error. This may be a path, separated by periods in the case of nested fields. In some cases this may come back as `null` if the error is not specific to any single element of the request.",
+                            "example": "fieldname",
+                            "type": "string"
+                          },
+                          "reason": {
+                            "description": "What happened to cause this error. In most cases, this can be fixed immediately by changing the data you sent in the request, but in some cases you will be instructed to [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) or perform some other action before you can complete the request successfully.",
+                            "example": "fieldname must be a valid value",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-akamai": {
+                          "file-path": "schemas/error-object.yaml"
+                        }
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "See [Errors](https://techdocs.akamai.com/linode-api/reference/errors) for the range of possible error response codes."
+          }
+        },
+        "security": [
+          {
+            "personalAccessToken": []
+          },
+          {
+            "oauth": [
+              "images:read_only"
+            ]
+          }
+        ],
+        "summary": "Get a token",
+        "tags": [
+          "Private image sharing"
+        ],
+        "x-akamai": {
+          "tabs": [
+            {
+              "syntax": "images:read_only",
+              "title": "OAuth scopes",
+              "url": "https://techdocs.akamai.com/linode-api/reference/get-started#oauth"
+            }
+          ]
+        },
+        "x-linode-redoc-load-ids": true
+      },
+      "put": {
+        "description": "Updates a token that you have permission to `read_write`.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    images:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "externalDocs": {
+          "description": "See documentation for this operation in Akamai's Linode API",
+          "url": "https://techdocs.akamai.com/linode-api/reference/put-sharegroup-token"
+        },
+        "operationId": "put-sharegroup-token",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "ImageShareGroupMemberTokens object.",
+                "properties": {
+                  "label": {
+                    "description": "Label for the token.",
+                    "example": "{{label}}",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "label"
+                ],
+                "type": "object",
+                "x-akamai": {
+                  "file-path": "schemas/put-sharegroup-token.yaml"
+                }
+              },
+              "x-example": {
+                "x-ref": "../examples/put-sharegroup-token.json"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "description": "ImageShareGroupMemberTokens object.",
+                  "properties": {
+                    "created": {
+                      "description": "__Read-only__ The creation time of this token.",
+                      "example": "2025-08-04T10:09:09",
+                      "format": "date-time",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "expiry": {
+                      "description": "__Read-only__ The time when this token expires.",
+                      "example": null,
+                      "format": "date-time",
+                      "nullable": true,
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "label": {
+                      "description": "A short description of the token.",
+                      "example": "Backend Services - Engineering",
+                      "type": "string"
+                    },
+                    "sharegroup_label": {
+                      "description": "__Read-only__ Associated share group label.",
+                      "example": "DevOps Base Images",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "sharegroup_uuid": {
+                      "description": "__Read-only__ UUID identifying the associated share group.",
+                      "example": "e1d0e58b-f89f-4237-84ab-b82077342359",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "status": {
+                      "description": "__Read-only__ Represents the current token status.\n\n- `pending`: The token has been created but is not yet active.\n- `active`: The token is currently active and usable.\n- `revoked`: The token has been deleted and is no longer valid.\n- `expired`: The token has passed its validity period and is no longer usable.",
+                      "enum": [
+                        "pending",
+                        "active",
+                        "revoked",
+                        "expired"
+                      ],
+                      "example": "active",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "token_uuid": {
+                      "description": "__Read-only__ A unique identifier representing the token.",
+                      "example": "13428362-5458-4dad-b14b-8d0d4d648f8c",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "updated": {
+                      "description": "__Read-only__ The time when this token was last updated.",
+                      "example": null,
+                      "format": "date-time",
+                      "nullable": true,
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "valid_for_sharegroup_uuid": {
+                      "description": "__Read-only__ UUID identifying the associated share group.",
+                      "example": "e1d0e58b-f89f-4237-84ab-b82077342359",
+                      "readOnly": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "token_uuid",
+                    "status",
+                    "label",
+                    "created",
+                    "updated",
+                    "expiry",
+                    "valid_for_sharegroup_uuid",
+                    "sharegroup_uuid",
+                    "sharegroup_label"
+                  ],
+                  "type": "object",
+                  "x-akamai": {
+                    "file-path": "schemas/token.yaml"
+                  }
+                },
+                "x-example": {
+                  "x-ref": "../examples/put-sharegroup-token-200.json"
+                }
+              }
+            },
+            "description": "Token updated successfully."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "errors": {
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "An object for describing a single error that occurred during the processing of a request.",
+                        "properties": {
+                          "field": {
+                            "description": "The field in the request that caused this error. This may be a path, separated by periods in the case of nested fields. In some cases this may come back as `null` if the error is not specific to any single element of the request.",
+                            "example": "fieldname",
+                            "type": "string"
+                          },
+                          "reason": {
+                            "description": "What happened to cause this error. In most cases, this can be fixed immediately by changing the data you sent in the request, but in some cases you will be instructed to [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) or perform some other action before you can complete the request successfully.",
+                            "example": "fieldname must be a valid value",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-akamai": {
+                          "file-path": "schemas/error-object.yaml"
+                        }
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "See [Errors](https://techdocs.akamai.com/linode-api/reference/errors) for the range of possible error response codes."
+          }
+        },
+        "security": [
+          {
+            "personalAccessToken": []
+          },
+          {
+            "oauth": [
+              "images:read_write"
+            ]
+          }
+        ],
+        "summary": "Update a token",
+        "tags": [
+          "Private image sharing"
+        ],
+        "x-akamai": {
+          "tabs": [
+            {
+              "syntax": "images:read_write",
+              "title": "OAuth scopes",
+              "url": "https://techdocs.akamai.com/linode-api/reference/get-started#oauth"
+            }
+          ]
+        },
+        "x-linode-redoc-load-ids": true
+      },
+      "delete": {
+        "description": "Deletes a token that you have permission to `read_write`.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    images:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "externalDocs": {
+          "description": "See documentation for this operation in Akamai's Linode API",
+          "url": "https://techdocs.akamai.com/linode-api/reference/delete-sharegroup-token"
+        },
+        "operationId": "delete-sharegroup-token",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "The API responds with an empty object.",
+                  "maxProperties": 0,
+                  "type": "object",
+                  "x-akamai": {
+                    "file-path": "schemas/added-empty-obj.yaml"
+                  }
+                },
+                "x-example": {
+                  "x-ref": "../examples/delete-sharegroup-token-200.json"
+                }
+              }
+            },
+            "description": "Token deleted successfully."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "errors": {
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "An object for describing a single error that occurred during the processing of a request.",
+                        "properties": {
+                          "field": {
+                            "description": "The field in the request that caused this error. This may be a path, separated by periods in the case of nested fields. In some cases this may come back as `null` if the error is not specific to any single element of the request.",
+                            "example": "fieldname",
+                            "type": "string"
+                          },
+                          "reason": {
+                            "description": "What happened to cause this error. In most cases, this can be fixed immediately by changing the data you sent in the request, but in some cases you will be instructed to [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) or perform some other action before you can complete the request successfully.",
+                            "example": "fieldname must be a valid value",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-akamai": {
+                          "file-path": "schemas/error-object.yaml"
+                        }
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "See [Errors](https://techdocs.akamai.com/linode-api/reference/errors) for the range of possible error response codes."
+          }
+        },
+        "security": [
+          {
+            "personalAccessToken": []
+          },
+          {
+            "oauth": [
+              "images:read_write"
+            ]
+          }
+        ],
+        "summary": "Delete a token",
+        "tags": [
+          "Private image sharing"
+        ],
+        "x-akamai": {
+          "tabs": [
+            {
+              "syntax": "images:read_write",
+              "title": "OAuth scopes",
+              "url": "https://techdocs.akamai.com/linode-api/reference/get-started#oauth"
+            }
+          ]
+        },
+        "x-linode-grant": "read_write"
+      },
+      "parameters": [
+        {
+          "description": "__Enum__ Call either the `v4` URL, or `v4beta` for operations still in Beta.",
+          "example": "{{apiVersion}}",
+          "in": "path",
+          "name": "apiVersion",
+          "required": true,
+          "schema": {
+            "enum": [
+              "v4",
+              "v4beta"
+            ],
+            "type": "string"
+          },
+          "x-akamai": {
+            "file-path": "parameters/api-version-path.yaml"
+          }
+        },
+        {
+          "description": "A unique identifier for the token, used to reference it after creation.",
+          "example": "{{tokenUuid}}",
+          "in": "path",
+          "name": "tokenUuid",
+          "required": true,
+          "schema": {
+            "example": "13428362-5458-4dad-b14b-8d0d4d648f8c",
+            "format": "uuid",
+            "type": "string"
+          },
+          "x-akamai": {
+            "file-path": "parameters/token-uuid-path.yaml"
+          }
+        }
+      ],
+      "x-akamai": {
+        "file-path": "paths/images-sharegroups-tokens-id.yaml",
+        "path-info": "/{apiVersion}/images/sharegroups/tokens/{tokenUuid}"
+      }
+    },
+    "/{apiVersion}/images/sharegroups/tokens/{tokenUuid}/sharegroup": {
+      "get": {
+        "description": "Retrieves information about the share group linked to a specific token.\nThe token is expected to have been previously generated and accepted into a sharegroup.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    images:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "externalDocs": {
+          "description": "See documentation for this operation in Akamai's Linode API",
+          "url": "https://techdocs.akamai.com/linode-api/reference/get-sharegroup-by-token"
+        },
+        "operationId": "get-sharegroup-by-token",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "description": "ShareGroup object.",
+                  "properties": {
+                    "created": {
+                      "description": "__Read-only__ The time when this share group was created.",
+                      "example": "2025-04-14T22:44:02",
+                      "format": "date-time",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "description": {
+                      "description": "A detailed description of this share group.",
+                      "example": "Group of base operating system images and engineers used for CI/CD pipelines and infrastructure automation",
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "id": {
+                      "description": "__Read-only__ A numeric identifier for the share group. This is primarily used within the system for database operations and is read-only.",
+                      "example": 1,
+                      "readOnly": true,
+                      "type": "integer"
+                    },
+                    "is_suspended": {
+                      "description": "__Read-only__ Indicates whether the share group is currently suspended.",
+                      "example": false,
+                      "readOnly": true,
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "description": "Label for the share group.",
+                      "example": "DevOps Base Images",
+                      "type": "string"
+                    },
+                    "updated": {
+                      "description": "__Read-only__ The time when this share group was last updated.",
+                      "example": null,
+                      "format": "date-time",
+                      "nullable": true,
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "uuid": {
+                      "description": "__Read-only__ A universally unique identifier for the share group. Used by clients to reference a specific share group when creating a single-use token.",
+                      "example": "1533863e-16a4-47b5-b829-ac0f35c13278",
+                      "format": "uuid",
+                      "readOnly": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "uuid",
+                    "label",
+                    "description",
+                    "is_suspended",
+                    "created",
+                    "updated"
+                  ],
+                  "type": "object",
+                  "x-akamai": {
+                    "file-path": "schemas/get-sharegroup.yaml"
+                  }
+                },
+                "x-example": {
+                  "x-ref": "../examples/get-sharegroup-200.json"
+                }
+              }
+            },
+            "description": "A single share group object."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "errors": {
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "An object for describing a single error that occurred during the processing of a request.",
+                        "properties": {
+                          "field": {
+                            "description": "The field in the request that caused this error. This may be a path, separated by periods in the case of nested fields. In some cases this may come back as `null` if the error is not specific to any single element of the request.",
+                            "example": "fieldname",
+                            "type": "string"
+                          },
+                          "reason": {
+                            "description": "What happened to cause this error. In most cases, this can be fixed immediately by changing the data you sent in the request, but in some cases you will be instructed to [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) or perform some other action before you can complete the request successfully.",
+                            "example": "fieldname must be a valid value",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-akamai": {
+                          "file-path": "schemas/error-object.yaml"
+                        }
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "See [Errors](https://techdocs.akamai.com/linode-api/reference/errors) for the range of possible error response codes."
+          }
+        },
+        "security": [
+          {
+            "personalAccessToken": []
+          },
+          {
+            "oauth": [
+              "images:read_only"
+            ]
+          }
+        ],
+        "summary": "Get a token's share group",
+        "tags": [
+          "Private image sharing"
+        ],
+        "x-akamai": {
+          "tabs": [
+            {
+              "syntax": "images:read_only",
+              "title": "OAuth scopes",
+              "url": "https://techdocs.akamai.com/linode-api/reference/get-started#oauth"
+            }
+          ]
+        },
+        "x-linode-redoc-load-ids": true
+      },
+      "parameters": [
+        {
+          "description": "__Enum__ Call either the `v4` URL, or `v4beta` for operations still in Beta.",
+          "example": "{{apiVersion}}",
+          "in": "path",
+          "name": "apiVersion",
+          "required": true,
+          "schema": {
+            "enum": [
+              "v4",
+              "v4beta"
+            ],
+            "type": "string"
+          },
+          "x-akamai": {
+            "file-path": "parameters/api-version-path.yaml"
+          }
+        },
+        {
+          "description": "A unique identifier for the token, used to reference it after creation.",
+          "example": "{{tokenUuid}}",
+          "in": "path",
+          "name": "tokenUuid",
+          "required": true,
+          "schema": {
+            "example": "13428362-5458-4dad-b14b-8d0d4d648f8c",
+            "format": "uuid",
+            "type": "string"
+          },
+          "x-akamai": {
+            "file-path": "parameters/token-uuid-path.yaml"
+          }
+        }
+      ],
+      "x-akamai": {
+        "file-path": "paths/images-sharegroups-tokens-id-sharegroup.yaml",
+        "path-info": "/{apiVersion}/images/sharegroups/tokens/{tokenUuid}/sharegroup"
+      }
+    },
+    "/{apiVersion}/images/sharegroups/tokens/{tokenUuid}/sharegroup/images": {
+      "get": {
+        "description": "Returns the images a user has access to through a valid share group token.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    images:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "externalDocs": {
+          "description": "See documentation for this operation in Akamai's Linode API",
+          "url": "https://techdocs.akamai.com/linode-api/reference/get-sharegroup-images-by-token"
+        },
+        "operationId": "get-sharegroup-images-by-token",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "ImageShare object.",
+                        "properties": {
+                          "capabilities": {
+                            "description": "__Read-only__ A list of the possible capabilities of this image.",
+                            "example": [
+                              "cloud-init",
+                              "distributed-sites"
+                            ],
+                            "items": {
+                              "type": "string"
+                            },
+                            "readOnly": true,
+                            "type": "array"
+                          },
+                          "created": {
+                            "description": "__Read-only__ When this image share was created.",
+                            "example": "2025-08-04T10:07:59",
+                            "format": "date-time",
+                            "readOnly": true,
+                            "type": "string"
+                          },
+                          "created_by": {
+                            "description": "__Read-only__ The name of the user who created this image share.",
+                            "example": null,
+                            "nullable": true,
+                            "readOnly": true,
+                            "type": "string"
+                          },
+                          "deprecated": {
+                            "description": "Whether this image is deprecated. Only public images can be deprecated.",
+                            "type": "boolean"
+                          },
+                          "description": {
+                            "description": "A detailed description of this image share.",
+                            "example": "Official Debian Linux image for server deployment",
+                            "type": "string"
+                          },
+                          "eol": {
+                            "description": "__Read-only__ The date of the public image's planned removal from service. This is `null` for private images.",
+                            "format": "date-time",
+                            "nullable": true,
+                            "readOnly": true,
+                            "type": "string"
+                          },
+                          "expiry": {
+                            "description": "__Read-only__ Only images created automatically from a deleted compute instance (type=automatic) expire. This is `null` for private images.",
+                            "format": "date-time",
+                            "nullable": true,
+                            "readOnly": true,
+                            "type": "string"
+                          },
+                          "id": {
+                            "description": "__Read-only__ The unique identifier for each image share.",
+                            "example": "shared/1",
+                            "readOnly": true,
+                            "type": "string"
+                          },
+                          "image_sharing": {
+                            "additionalProperties": false,
+                            "description": "__Read-only__ Sharing information for the image, including who it was shared by and with.",
+                            "properties": {
+                              "shared_by": {
+                                "properties": {
+                                  "sharegroup_id": {
+                                    "description": "__Read-only__ A numeric identifier for the share group. This is primarily used within the system for database operations and is read-only.",
+                                    "example": 3,
+                                    "readOnly": true,
+                                    "type": "integer"
+                                  },
+                                  "sharegroup_label": {
+                                    "description": "Descriptive label of the share group.",
+                                    "example": "DevOps Base Images",
+                                    "type": "string"
+                                  },
+                                  "sharegroup_uuid": {
+                                    "description": "__Read-only__ A universally unique identifier for the share group. Used by clients to reference a specific share group when creating a single-use token.",
+                                    "example": "8d64b99e-92f7-4c7b-a616-8f622fffb94c",
+                                    "format": "uuid",
+                                    "readOnly": true,
+                                    "type": "string"
+                                  },
+                                  "source_image_id": {
+                                    "description": "__Read-only__ Slug identifier of the source image.",
+                                    "example": "private/15",
+                                    "readOnly": true,
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "sharegroup_id",
+                                  "sharegroup_uuid",
+                                  "sharegroup_label",
+                                  "source_image_id"
+                                ],
+                                "type": "object"
+                              },
+                              "shared_with": {
+                                "description": "Details about who this image was shared with.",
+                                "example": null,
+                                "nullable": true,
+                                "type": "object"
+                              }
+                            },
+                            "readOnly": true,
+                            "type": "object"
+                          },
+                          "is_public": {
+                            "description": "__Read-only__ Indicates whether this image is shared with others.",
+                            "example": true,
+                            "readOnly": true,
+                            "type": "boolean"
+                          },
+                          "is_shared": {
+                            "description": "__Read-only__ Indicates if the image is a private image shared with other users.",
+                            "example": null,
+                            "nullable": true,
+                            "readOnly": true,
+                            "type": "boolean"
+                          },
+                          "label": {
+                            "description": "__Filterable__ A short description of the image share.",
+                            "example": "Linux Debian",
+                            "type": "string",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ]
+                            },
+                            "x-linode-filterable": true
+                          },
+                          "regions": {
+                            "description": "__Filterable__, __Read-only__ Details on the regions where this image is stored. See [Regions and images](https://techdocs.akamai.com/cloud-computing/docs/images#regions-and-images) for full details on support for `regions`.",
+                            "items": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "region": {
+                                  "description": "The unique identifier for the core compute region where this image is stored.",
+                                  "example": "us-iad",
+                                  "type": "string"
+                                },
+                                "status": {
+                                  "description": "The status of the image in this `region`. Possible values are `available`, `creating`, `pending`, `pending deletion`, `pending replication`, or `replicating`.",
+                                  "enum": [
+                                    "available",
+                                    "creating",
+                                    "pending",
+                                    "pending deletion",
+                                    "pending replication",
+                                    "replicating"
+                                  ],
+                                  "example": "available",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "readOnly": true,
+                            "type": "array",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ]
+                            },
+                            "x-linode-filterable": true
+                          },
+                          "size": {
+                            "description": "__Read-only__ The minimum size in MB this image needs to deploy.",
+                            "example": 256,
+                            "readOnly": true,
+                            "type": "integer"
+                          },
+                          "status": {
+                            "description": "__Read-only__ The current status of the image. Possible values are `available`, `creating`, and `pending_upload`.",
+                            "enum": [
+                              "creating",
+                              "pending_upload",
+                              "available"
+                            ],
+                            "example": "available",
+                            "readOnly": true,
+                            "type": "string"
+                          },
+                          "tags": {
+                            "description": "__Filterable__, __Read-only__ Tags used for organizational purposes. A tag can be from 3 to 100 characters long, and an image can have a maximum of 500 total tags.",
+                            "example": [
+                              "repair-image",
+                              "fix-1"
+                            ],
+                            "items": {
+                              "maxLength": 100,
+                              "minLength": 3,
+                              "type": "string"
+                            },
+                            "maxItems": 500,
+                            "minItems": 0,
+                            "readOnly": true,
+                            "type": "array",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ]
+                            },
+                            "x-linode-filterable": true
+                          },
+                          "total_size": {
+                            "description": "__Read-only__ The total size in bytes of all instances of this image, in all `regions`.",
+                            "example": 256,
+                            "readOnly": true,
+                            "type": "integer"
+                          },
+                          "type": {
+                            "description": "__Filterable__, __Read-only__ How the image was created. Create a `manual` image at any time. An `automatic` image is created automatically from a deleted compute instance. A `shared` image is made accessible to others.",
+                            "enum": [
+                              "manual",
+                              "automatic",
+                              "shared"
+                            ],
+                            "example": "shared",
+                            "readOnly": true,
+                            "type": "string",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ]
+                            },
+                            "x-linode-filterable": true
+                          },
+                          "updated": {
+                            "description": "__Read-only__ When this image share was last updated.",
+                            "example": null,
+                            "format": "date-time",
+                            "nullable": true,
+                            "readOnly": true,
+                            "type": "string"
+                          },
+                          "vendor": {
+                            "description": "__Read-only__ The upstream distribution vendor. This is `null` for private and shared images.",
+                            "nullable": true,
+                            "readOnly": true,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "tags",
+                          "type",
+                          "description",
+                          "label",
+                          "created",
+                          "updated",
+                          "size",
+                          "status",
+                          "capabilities",
+                          "is_public",
+                          "is_shared",
+                          "deprecated",
+                          "regions",
+                          "total_size",
+                          "image_sharing",
+                          "created_by",
+                          "expiry",
+                          "eol",
+                          "vendor"
+                        ],
+                        "type": "object",
+                        "x-akamai": {
+                          "file-path": "schemas/imageshares.yaml"
+                        }
+                      },
+                      "type": "array"
+                    },
+                    "page": {
+                      "description": "__Read-only__ The current [page](https://techdocs.akamai.com/linode-api/reference/pagination).",
+                      "example": 1,
+                      "readOnly": true,
+                      "type": "integer"
+                    },
+                    "pages": {
+                      "description": "__Read-only__ The total number of [pages](https://techdocs.akamai.com/linode-api/reference/pagination).",
+                      "example": 1,
+                      "readOnly": true,
+                      "type": "integer"
+                    },
+                    "results": {
+                      "description": "__Read-only__ The total number of results.",
+                      "example": 1,
+                      "readOnly": true,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "page",
+                    "pages",
+                    "results"
+                  ],
+                  "type": "object",
+                  "x-akamai": {
+                    "file-path": "schemas/get-sharegroup-token-images-200.yaml"
+                  }
+                },
+                "x-example": {
+                  "x-ref": "../examples/get-sharegroup-token-images-200.json"
+                }
+              }
+            },
+            "description": "A paginated list of images."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "errors": {
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "An object for describing a single error that occurred during the processing of a request.",
+                        "properties": {
+                          "field": {
+                            "description": "The field in the request that caused this error. This may be a path, separated by periods in the case of nested fields. In some cases this may come back as `null` if the error is not specific to any single element of the request.",
+                            "example": "fieldname",
+                            "type": "string"
+                          },
+                          "reason": {
+                            "description": "What happened to cause this error. In most cases, this can be fixed immediately by changing the data you sent in the request, but in some cases you will be instructed to [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) or perform some other action before you can complete the request successfully.",
+                            "example": "fieldname must be a valid value",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-akamai": {
+                          "file-path": "schemas/error-object.yaml"
+                        }
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "See [Errors](https://techdocs.akamai.com/linode-api/reference/errors) for the range of possible error response codes."
+          }
+        },
+        "security": [
+          {
+            "personalAccessToken": []
+          },
+          {
+            "oauth": [
+              "images:read_only"
+            ]
+          }
+        ],
+        "summary": "List images by token",
+        "tags": [
+          "Private image sharing"
+        ],
+        "x-akamai": {
+          "tabs": [
+            {
+              "syntax": "images:read_only",
+              "title": "OAuth scopes",
+              "url": "https://techdocs.akamai.com/linode-api/reference/get-started#oauth"
+            }
+          ]
+        },
+        "x-linode-redoc-load-ids": true
+      },
+      "parameters": [
+        {
+          "description": "__Enum__ Call either the `v4` URL, or `v4beta` for operations still in Beta.",
+          "example": "{{apiVersion}}",
+          "in": "path",
+          "name": "apiVersion",
+          "required": true,
+          "schema": {
+            "enum": [
+              "v4",
+              "v4beta"
+            ],
+            "type": "string"
+          },
+          "x-akamai": {
+            "file-path": "parameters/api-version-path.yaml"
+          }
+        },
+        {
+          "description": "A unique identifier for the token, used to reference it after creation.",
+          "example": "{{tokenUuid}}",
+          "in": "path",
+          "name": "tokenUuid",
+          "required": true,
+          "schema": {
+            "example": "13428362-5458-4dad-b14b-8d0d4d648f8c",
+            "format": "uuid",
+            "type": "string"
+          },
+          "x-akamai": {
+            "file-path": "parameters/token-uuid-path.yaml"
+          }
+        }
+      ],
+      "x-akamai": {
+        "file-path": "paths/images-sharegroups-tokens-id-sharegroup-images.yaml",
+        "path-info": "/{apiVersion}/images/sharegroups/tokens/{tokenUuid}/sharegroup/images"
+      }
+    },
+    "/{apiVersion}/images/sharegroups/{sharegroupId}": {
+      "get": {
+        "description": "Get information about a single share group.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    images:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "externalDocs": {
+          "description": "See documentation for this operation in Akamai's Linode API",
+          "url": "https://techdocs.akamai.com/linode-api/reference/get-sharegroup"
+        },
+        "operationId": "get-sharegroup",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "description": "ShareGroup object.",
+                  "properties": {
+                    "created": {
+                      "description": "__Read-only__ The time when this share group was created.",
+                      "example": "2025-04-14T22:44:02",
+                      "format": "date-time",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "description": {
+                      "description": "A detailed description of this share group.",
+                      "example": "Group of base operating system images and engineers used for CI/CD pipelines and infrastructure automation",
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "expiry": {
+                      "description": "__Read-only__ The time when the share group expires.",
+                      "example": null,
+                      "format": "date-time",
+                      "nullable": true,
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "id": {
+                      "description": "A numeric identifier for the share group. This is primarily used within the system for database operations and is read-only.",
+                      "example": 1,
+                      "type": "integer"
+                    },
+                    "images_count": {
+                      "description": "__Read-only__ The total number of images currently belonging to the share group.",
+                      "readOnly": true,
+                      "type": "integer"
+                    },
+                    "is_suspended": {
+                      "description": "__Read-only__ Indicates whether the share group is currently suspended.",
+                      "example": false,
+                      "readOnly": true,
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "description": "Label for the share group.",
+                      "example": "DevOps Base Images",
+                      "type": "string"
+                    },
+                    "members_count": {
+                      "description": "__Read-only__ The number of members who have access to the share group.",
+                      "readOnly": true,
+                      "type": "integer"
+                    },
+                    "updated": {
+                      "description": "__Read-only__ The time when this share group was last updated.",
+                      "example": null,
+                      "format": "date-time",
+                      "nullable": true,
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "uuid": {
+                      "description": "__Read-only__ A universally unique identifier for the share group. Used by clients to reference a specific share group when creating a single-use token.",
+                      "example": "1533863e-16a4-47b5-b829-ac0f35c13278",
+                      "format": "uuid",
+                      "readOnly": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "uuid",
+                    "label",
+                    "description",
+                    "is_suspended",
+                    "created",
+                    "updated",
+                    "expiry",
+                    "images_count",
+                    "members_count"
+                  ],
+                  "type": "object",
+                  "x-akamai": {
+                    "file-path": "schemas/sharegroup.yaml"
+                  }
+                },
+                "x-example": {
+                  "x-ref": "../examples/get-sharegroup-200.json"
+                }
+              }
+            },
+            "description": "A single share group object."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "errors": {
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "An object for describing a single error that occurred during the processing of a request.",
+                        "properties": {
+                          "field": {
+                            "description": "The field in the request that caused this error. This may be a path, separated by periods in the case of nested fields. In some cases this may come back as `null` if the error is not specific to any single element of the request.",
+                            "example": "fieldname",
+                            "type": "string"
+                          },
+                          "reason": {
+                            "description": "What happened to cause this error. In most cases, this can be fixed immediately by changing the data you sent in the request, but in some cases you will be instructed to [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) or perform some other action before you can complete the request successfully.",
+                            "example": "fieldname must be a valid value",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-akamai": {
+                          "file-path": "schemas/error-object.yaml"
+                        }
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "See [Errors](https://techdocs.akamai.com/linode-api/reference/errors) for the range of possible error response codes."
+          }
+        },
+        "security": [
+          {
+            "personalAccessToken": []
+          },
+          {
+            "oauth": [
+              "images:read_only"
+            ]
+          }
+        ],
+        "summary": "Get a share group",
+        "tags": [
+          "Private image sharing"
+        ],
+        "x-akamai": {
+          "tabs": [
+            {
+              "syntax": "images:read_only",
+              "title": "OAuth scopes",
+              "url": "https://techdocs.akamai.com/linode-api/reference/get-started#oauth"
+            }
+          ]
+        },
+        "x-linode-redoc-load-ids": true
+      },
+      "put": {
+        "description": "Updates a share group that you have permission to `read_write`.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    images:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "externalDocs": {
+          "description": "See documentation for this operation in Akamai's Linode API",
+          "url": "https://techdocs.akamai.com/linode-api/reference/put-sharegroup"
+        },
+        "operationId": "put-sharegroup",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "description": "ShareGroup object.",
+                "properties": {
+                  "description": {
+                    "description": "A detailed description of this share group.",
+                    "example": "{{description}}",
+                    "type": "string"
+                  },
+                  "label": {
+                    "description": "Label for the share group.",
+                    "example": "{{label}}",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "x-akamai": {
+                  "file-path": "schemas/put-sharegroup.yaml"
+                }
+              },
+              "x-example": {
+                "x-ref": "../examples/put-sharegroup-200.json"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "description": "ShareGroup object.",
+                  "properties": {
+                    "created": {
+                      "description": "__Read-only__ The time when this share group was created.",
+                      "example": "2025-04-14T22:44:02",
+                      "format": "date-time",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "description": {
+                      "description": "A detailed description of this share group.",
+                      "example": "Group of base operating system images and engineers used for CI/CD pipelines and infrastructure automation",
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "expiry": {
+                      "description": "__Read-only__ The time when the share group expires.",
+                      "example": null,
+                      "format": "date-time",
+                      "nullable": true,
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "id": {
+                      "description": "A numeric identifier for the share group. This is primarily used within the system for database operations and is read-only.",
+                      "example": 1,
+                      "type": "integer"
+                    },
+                    "images_count": {
+                      "description": "__Read-only__ The total number of images currently belonging to the share group.",
+                      "readOnly": true,
+                      "type": "integer"
+                    },
+                    "is_suspended": {
+                      "description": "__Read-only__ Indicates whether the share group is currently suspended.",
+                      "example": false,
+                      "readOnly": true,
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "description": "Label for the share group.",
+                      "example": "DevOps Base Images",
+                      "type": "string"
+                    },
+                    "members_count": {
+                      "description": "__Read-only__ The number of members who have access to the share group.",
+                      "readOnly": true,
+                      "type": "integer"
+                    },
+                    "updated": {
+                      "description": "__Read-only__ The time when this share group was last updated.",
+                      "example": null,
+                      "format": "date-time",
+                      "nullable": true,
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "uuid": {
+                      "description": "__Read-only__ A universally unique identifier for the share group. Used by clients to reference a specific share group when creating a single-use token.",
+                      "example": "1533863e-16a4-47b5-b829-ac0f35c13278",
+                      "format": "uuid",
+                      "readOnly": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "uuid",
+                    "label",
+                    "description",
+                    "is_suspended",
+                    "created",
+                    "updated",
+                    "expiry",
+                    "images_count",
+                    "members_count"
+                  ],
+                  "type": "object",
+                  "x-akamai": {
+                    "file-path": "schemas/sharegroup.yaml"
+                  }
+                },
+                "x-example": {
+                  "x-ref": "../examples/put-sharegroup-200.json"
+                },
+                "x-linode-cli-subtables": [
+                  "regions"
+                ]
+              }
+            },
+            "description": "The updated share group."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "errors": {
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "An object for describing a single error that occurred during the processing of a request.",
+                        "properties": {
+                          "field": {
+                            "description": "The field in the request that caused this error. This may be a path, separated by periods in the case of nested fields. In some cases this may come back as `null` if the error is not specific to any single element of the request.",
+                            "example": "fieldname",
+                            "type": "string"
+                          },
+                          "reason": {
+                            "description": "What happened to cause this error. In most cases, this can be fixed immediately by changing the data you sent in the request, but in some cases you will be instructed to [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) or perform some other action before you can complete the request successfully.",
+                            "example": "fieldname must be a valid value",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-akamai": {
+                          "file-path": "schemas/error-object.yaml"
+                        }
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "See [Errors](https://techdocs.akamai.com/linode-api/reference/errors) for the range of possible error response codes."
+          }
+        },
+        "security": [
+          {
+            "personalAccessToken": []
+          },
+          {
+            "oauth": [
+              "images:read_write"
+            ]
+          }
+        ],
+        "summary": "Update a share group",
+        "tags": [
+          "Private image sharing"
+        ],
+        "x-akamai": {
+          "tabs": [
+            {
+              "syntax": "images:read_write",
+              "title": "OAuth scopes",
+              "url": "https://techdocs.akamai.com/linode-api/reference/get-started#oauth"
+            }
+          ]
+        },
+        "x-linode-grant": "read_write"
+      },
+      "delete": {
+        "description": "Deletes a share group that you have permission to `read_write`.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    images:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "externalDocs": {
+          "description": "See documentation for this operation in Akamai's Linode API",
+          "url": "https://techdocs.akamai.com/linode-api/reference/delete-sharegroup"
+        },
+        "operationId": "delete-sharegroup",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "The API responds with an empty object.",
+                  "maxProperties": 0,
+                  "type": "object",
+                  "x-akamai": {
+                    "file-path": "schemas/added-empty-obj.yaml"
+                  }
+                },
+                "x-example": {
+                  "x-ref": "../examples/delete-sharegroup-200.json"
+                }
+              }
+            },
+            "description": "Share group delete successfully."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "errors": {
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "An object for describing a single error that occurred during the processing of a request.",
+                        "properties": {
+                          "field": {
+                            "description": "The field in the request that caused this error. This may be a path, separated by periods in the case of nested fields. In some cases this may come back as `null` if the error is not specific to any single element of the request.",
+                            "example": "fieldname",
+                            "type": "string"
+                          },
+                          "reason": {
+                            "description": "What happened to cause this error. In most cases, this can be fixed immediately by changing the data you sent in the request, but in some cases you will be instructed to [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) or perform some other action before you can complete the request successfully.",
+                            "example": "fieldname must be a valid value",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-akamai": {
+                          "file-path": "schemas/error-object.yaml"
+                        }
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "See [Errors](https://techdocs.akamai.com/linode-api/reference/errors) for the range of possible error response codes."
+          }
+        },
+        "security": [
+          {
+            "personalAccessToken": []
+          },
+          {
+            "oauth": [
+              "images:read_write"
+            ]
+          }
+        ],
+        "summary": "Delete a share group",
+        "tags": [
+          "Private image sharing"
+        ],
+        "x-akamai": {
+          "tabs": [
+            {
+              "syntax": "images:read_write",
+              "title": "OAuth scopes",
+              "url": "https://techdocs.akamai.com/linode-api/reference/get-started#oauth"
+            }
+          ]
+        },
+        "x-linode-grant": "read_write"
+      },
+      "parameters": [
+        {
+          "description": "__Enum__ Call either the `v4` URL, or `v4beta` for operations still in Beta.",
+          "example": "{{apiVersion}}",
+          "in": "path",
+          "name": "apiVersion",
+          "required": true,
+          "schema": {
+            "enum": [
+              "v4",
+              "v4beta"
+            ],
+            "type": "string"
+          },
+          "x-akamai": {
+            "file-path": "parameters/api-version-path.yaml"
+          }
+        },
+        {
+          "description": "The unique identifier assigned to the share group after creation.",
+          "example": "{{sharegroupId}}",
+          "in": "path",
+          "name": "sharegroupId",
+          "required": true,
+          "schema": {
+            "example": 54321,
+            "type": "integer"
+          },
+          "x-akamai": {
+            "file-path": "parameters/sharegroup-id-path.yaml"
+          }
+        }
+      ],
+      "x-akamai": {
+        "file-path": "paths/images-sharegroup-id.yaml",
+        "path-info": "/{apiVersion}/images/sharegroups/{sharegroupId}"
+      }
+    },
+    "/{apiVersion}/images/sharegroups/{sharegroupId}/images": {
+      "post": {
+        "description": "Allows to add images to a specific share group.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    images:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "externalDocs": {
+          "description": "See documentation for this operation in Akamai's Linode API",
+          "url": "https://techdocs.akamai.com/linode-api/reference/post-sharegroup-images"
+        },
+        "operationId": "post-sharegroup-images",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "images": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "description": {
+                          "description": "Image share description.",
+                          "example": "Official Debian Linux image for server deployment",
+                          "type": "string"
+                        },
+                        "id": {
+                          "allowReserved": true,
+                          "description": "The ID of the private image, formatted as a slug.",
+                          "example": "private/15",
+                          "type": "string"
+                        },
+                        "label": {
+                          "description": "Image share label.",
+                          "example": "Linux Debian",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "images"
+                ],
+                "type": "object",
+                "x-akamai": {
+                  "file-path": "schemas/post-sharegroup-images.yaml"
+                }
+              },
+              "x-example": {
+                "x-ref": "../examples/post-sharegroup-images.json"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "description": "ImageShare object.",
+                  "properties": {
+                    "capabilities": {
+                      "description": "__Read-only__ A list of the possible capabilities of this image.",
+                      "example": [
+                        "cloud-init",
+                        "distributed-sites"
+                      ],
+                      "items": {
+                        "type": "string"
+                      },
+                      "readOnly": true,
+                      "type": "array"
+                    },
+                    "created": {
+                      "description": "__Read-only__ When this image share was created.",
+                      "example": "2025-08-04T10:07:59",
+                      "format": "date-time",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "created_by": {
+                      "description": "__Read-only__ The name of the user who created this image share.",
+                      "example": null,
+                      "nullable": true,
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "deprecated": {
+                      "description": "Whether this image is deprecated. Only public images can be deprecated.",
+                      "type": "boolean"
+                    },
+                    "description": {
+                      "description": "A detailed description of this image share.",
+                      "example": "Official Debian Linux image for server deployment",
+                      "type": "string"
+                    },
+                    "eol": {
+                      "description": "__Read-only__ The date of the public image's planned removal from service. This is `null` for private images.",
+                      "format": "date-time",
+                      "nullable": true,
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "expiry": {
+                      "description": "__Read-only__ Only images created automatically from a deleted compute instance (type=automatic) expire. This is `null` for private images.",
+                      "format": "date-time",
+                      "nullable": true,
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "id": {
+                      "description": "__Read-only__ The unique identifier for each image share.",
+                      "example": "shared/1",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "image_sharing": {
+                      "additionalProperties": false,
+                      "description": "__Read-only__ Sharing information for the image, including who it was shared by and with.",
+                      "properties": {
+                        "shared_by": {
+                          "properties": {
+                            "sharegroup_id": {
+                              "description": "__Read-only__ A numeric identifier for the share group. This is primarily used within the system for database operations and is read-only.",
+                              "example": 3,
+                              "readOnly": true,
+                              "type": "integer"
+                            },
+                            "sharegroup_label": {
+                              "description": "Descriptive label of the share group.",
+                              "example": "DevOps Base Images",
+                              "type": "string"
+                            },
+                            "sharegroup_uuid": {
+                              "description": "__Read-only__ A universally unique identifier for the share group. Used by clients to reference a specific share group when creating a single-use token.",
+                              "example": "8d64b99e-92f7-4c7b-a616-8f622fffb94c",
+                              "format": "uuid",
+                              "readOnly": true,
+                              "type": "string"
+                            },
+                            "source_image_id": {
+                              "description": "__Read-only__ Slug identifier of the source image.",
+                              "example": "private/15",
+                              "readOnly": true,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "sharegroup_id",
+                            "sharegroup_uuid",
+                            "sharegroup_label",
+                            "source_image_id"
+                          ],
+                          "type": "object"
+                        },
+                        "shared_with": {
+                          "description": "Details about who this image was shared with.",
+                          "example": null,
+                          "nullable": true,
+                          "type": "object"
+                        }
+                      },
+                      "readOnly": true,
+                      "type": "object"
+                    },
+                    "is_public": {
+                      "description": "__Read-only__ Indicates whether this image is shared with others.",
+                      "example": true,
+                      "readOnly": true,
+                      "type": "boolean"
+                    },
+                    "is_shared": {
+                      "description": "__Read-only__ Indicates if the image is a private image shared with other users.",
+                      "example": null,
+                      "nullable": true,
+                      "readOnly": true,
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "description": "A short description of the image share.",
+                      "example": "Linux Debian",
+                      "type": "string"
+                    },
+                    "regions": {
+                      "description": "__Read-only__ Details on the regions where this image is stored. See [Regions and images](https://techdocs.akamai.com/cloud-computing/docs/images#regions-and-images) for full details on support for `regions`.",
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "region": {
+                            "description": "The unique identifier for the core compute region where this image is stored.",
+                            "example": "us-iad",
+                            "type": "string"
+                          },
+                          "status": {
+                            "description": "The status of the image in this `region`. Possible values are `available`, `creating`, `pending`, `pending deletion`, `pending replication`, or `replicating`.",
+                            "enum": [
+                              "available",
+                              "creating",
+                              "pending",
+                              "pending deletion",
+                              "pending replication",
+                              "replicating"
+                            ],
+                            "example": "available",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "readOnly": true,
+                      "type": "array"
+                    },
+                    "size": {
+                      "description": "__Read-only__ The minimum size in MB this image needs to deploy.",
+                      "example": 256,
+                      "readOnly": true,
+                      "type": "integer"
+                    },
+                    "status": {
+                      "description": "__Read-only__ The current status of the image. Possible values are `available`, `creating`, and `pending_upload`.",
+                      "enum": [
+                        "creating",
+                        "pending_upload",
+                        "available"
+                      ],
+                      "example": "available",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "tags": {
+                      "description": "__Read-only__ Tags used for organizational purposes. A tag can be from 3 to 100 characters long, and an image can have a maximum of 500 total tags.",
+                      "example": [
+                        "repair-image",
+                        "fix-1"
+                      ],
+                      "items": {
+                        "maxLength": 100,
+                        "minLength": 3,
+                        "type": "string"
+                      },
+                      "maxItems": 500,
+                      "minItems": 0,
+                      "readOnly": true,
+                      "type": "array"
+                    },
+                    "total_size": {
+                      "description": "__Read-only__ The total size in bytes of all instances of this image, in all `regions`.",
+                      "example": 256,
+                      "readOnly": true,
+                      "type": "integer"
+                    },
+                    "type": {
+                      "description": "__Read-only__ How the image was created. Create a `manual` image at any time. An `automatic` image is created automatically from a deleted compute instance. A `shared` image is made accessible to others.",
+                      "enum": [
+                        "manual",
+                        "automatic",
+                        "shared"
+                      ],
+                      "example": "shared",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "updated": {
+                      "description": "__Read-only__ When this image share was last updated.",
+                      "example": null,
+                      "format": "date-time",
+                      "nullable": true,
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "vendor": {
+                      "description": "__Read-only__ The upstream distribution vendor. This is `null` for private and shared images.",
+                      "nullable": true,
+                      "readOnly": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "tags",
+                    "type",
+                    "description",
+                    "label",
+                    "created",
+                    "updated",
+                    "size",
+                    "status",
+                    "capabilities",
+                    "is_public",
+                    "is_shared",
+                    "deprecated",
+                    "regions",
+                    "total_size",
+                    "image_sharing",
+                    "created_by",
+                    "expiry",
+                    "eol",
+                    "vendor"
+                  ],
+                  "type": "object",
+                  "x-akamai": {
+                    "file-path": "schemas/imageshare.yaml"
+                  }
+                },
+                "x-example": {
+                  "x-ref": "../examples/post-sharegroup-images-200.json"
+                }
+              }
+            },
+            "description": "Image added successfully."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "errors": {
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "An object for describing a single error that occurred during the processing of a request.",
+                        "properties": {
+                          "field": {
+                            "description": "The field in the request that caused this error. This may be a path, separated by periods in the case of nested fields. In some cases this may come back as `null` if the error is not specific to any single element of the request.",
+                            "example": "fieldname",
+                            "type": "string"
+                          },
+                          "reason": {
+                            "description": "What happened to cause this error. In most cases, this can be fixed immediately by changing the data you sent in the request, but in some cases you will be instructed to [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) or perform some other action before you can complete the request successfully.",
+                            "example": "fieldname must be a valid value",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-akamai": {
+                          "file-path": "schemas/error-object.yaml"
+                        }
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "See [Errors](https://techdocs.akamai.com/linode-api/reference/errors) for the range of possible error response codes."
+          }
+        },
+        "security": [
+          {
+            "personalAccessToken": []
+          },
+          {
+            "oauth": [
+              "images:read_write"
+            ]
+          }
+        ],
+        "summary": "Add images to a share group",
+        "tags": [
+          "Private image sharing"
+        ],
+        "x-akamai": {
+          "tabs": [
+            {
+              "syntax": "images:read_write",
+              "title": "OAuth scopes",
+              "url": "https://techdocs.akamai.com/linode-api/reference/get-started#oauth"
+            }
+          ]
+        },
+        "x-linode-redoc-load-ids": true
+      },
+      "get": {
+        "description": "Get details about shared images linked to the share group.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    images:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "externalDocs": {
+          "description": "See documentation for this operation in Akamai's Linode API",
+          "url": "https://techdocs.akamai.com/linode-api/reference/get-sharegroup-images"
+        },
+        "operationId": "get-sharegroup-images",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "ImageShare object.",
+                        "properties": {
+                          "capabilities": {
+                            "description": "__Read-only__ A list of the possible capabilities of this image.",
+                            "example": [
+                              "cloud-init",
+                              "distributed-sites"
+                            ],
+                            "items": {
+                              "type": "string"
+                            },
+                            "readOnly": true,
+                            "type": "array"
+                          },
+                          "created": {
+                            "description": "__Read-only__ When this image share was created.",
+                            "example": "2025-08-04T10:07:59",
+                            "format": "date-time",
+                            "readOnly": true,
+                            "type": "string"
+                          },
+                          "created_by": {
+                            "description": "__Read-only__ The name of the user who created this image share.",
+                            "example": null,
+                            "nullable": true,
+                            "readOnly": true,
+                            "type": "string"
+                          },
+                          "deprecated": {
+                            "description": "Whether this image is deprecated. Only public images can be deprecated.",
+                            "type": "boolean"
+                          },
+                          "description": {
+                            "description": "A detailed description of this image share.",
+                            "example": "Official Debian Linux image for server deployment",
+                            "type": "string"
+                          },
+                          "eol": {
+                            "description": "__Read-only__ The date of the public image's planned removal from service. This is `null` for private images.",
+                            "format": "date-time",
+                            "nullable": true,
+                            "readOnly": true,
+                            "type": "string"
+                          },
+                          "expiry": {
+                            "description": "__Read-only__ Only images created automatically from a deleted compute instance (type=automatic) expire. This is `null` for private images.",
+                            "format": "date-time",
+                            "nullable": true,
+                            "readOnly": true,
+                            "type": "string"
+                          },
+                          "id": {
+                            "description": "__Read-only__ The unique identifier for each image share.",
+                            "example": "shared/1",
+                            "readOnly": true,
+                            "type": "string"
+                          },
+                          "image_sharing": {
+                            "additionalProperties": false,
+                            "description": "__Read-only__ Sharing information for the image, including who it was shared by and with.",
+                            "properties": {
+                              "shared_by": {
+                                "properties": {
+                                  "sharegroup_id": {
+                                    "description": "__Read-only__ A numeric identifier for the share group. This is primarily used within the system for database operations and is read-only.",
+                                    "example": 3,
+                                    "readOnly": true,
+                                    "type": "integer"
+                                  },
+                                  "sharegroup_label": {
+                                    "description": "Descriptive label of the share group.",
+                                    "example": "DevOps Base Images",
+                                    "type": "string"
+                                  },
+                                  "sharegroup_uuid": {
+                                    "description": "__Read-only__ A universally unique identifier for the share group. Used by clients to reference a specific share group when creating a single-use token.",
+                                    "example": "8d64b99e-92f7-4c7b-a616-8f622fffb94c",
+                                    "format": "uuid",
+                                    "readOnly": true,
+                                    "type": "string"
+                                  },
+                                  "source_image_id": {
+                                    "description": "__Read-only__ Slug identifier of the source image.",
+                                    "example": "private/15",
+                                    "readOnly": true,
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "sharegroup_id",
+                                  "sharegroup_uuid",
+                                  "sharegroup_label",
+                                  "source_image_id"
+                                ],
+                                "type": "object"
+                              },
+                              "shared_with": {
+                                "description": "Details about who this image was shared with.",
+                                "example": null,
+                                "nullable": true,
+                                "type": "object"
+                              }
+                            },
+                            "readOnly": true,
+                            "type": "object"
+                          },
+                          "is_public": {
+                            "description": "__Read-only__ Indicates whether this image is shared with others.",
+                            "example": true,
+                            "readOnly": true,
+                            "type": "boolean"
+                          },
+                          "is_shared": {
+                            "description": "__Read-only__ Indicates if the image is a private image shared with other users.",
+                            "example": null,
+                            "nullable": true,
+                            "readOnly": true,
+                            "type": "boolean"
+                          },
+                          "label": {
+                            "description": "__Filterable__ A short description of the image share.",
+                            "example": "Linux Debian",
+                            "type": "string",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ]
+                            },
+                            "x-linode-filterable": true
+                          },
+                          "regions": {
+                            "description": "__Filterable__, __Read-only__ Details on the regions where this image is stored. See [Regions and images](https://techdocs.akamai.com/cloud-computing/docs/images#regions-and-images) for full details on support for `regions`.",
+                            "items": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "region": {
+                                  "description": "The unique identifier for the core compute region where this image is stored.",
+                                  "example": "us-iad",
+                                  "type": "string"
+                                },
+                                "status": {
+                                  "description": "The status of the image in this `region`. Possible values are `available`, `creating`, `pending`, `pending deletion`, `pending replication`, or `replicating`.",
+                                  "enum": [
+                                    "available",
+                                    "creating",
+                                    "pending",
+                                    "pending deletion",
+                                    "pending replication",
+                                    "replicating"
+                                  ],
+                                  "example": "available",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "readOnly": true,
+                            "type": "array",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ]
+                            },
+                            "x-linode-filterable": true
+                          },
+                          "size": {
+                            "description": "__Read-only__ The minimum size in MB this image needs to deploy.",
+                            "example": 256,
+                            "readOnly": true,
+                            "type": "integer"
+                          },
+                          "status": {
+                            "description": "__Read-only__ The current status of the image. Possible values are `available`, `creating`, and `pending_upload`.",
+                            "enum": [
+                              "creating",
+                              "pending_upload",
+                              "available"
+                            ],
+                            "example": "available",
+                            "readOnly": true,
+                            "type": "string"
+                          },
+                          "tags": {
+                            "description": "__Filterable__, __Read-only__ Tags used for organizational purposes. A tag can be from 3 to 100 characters long, and an image can have a maximum of 500 total tags.",
+                            "example": [
+                              "repair-image",
+                              "fix-1"
+                            ],
+                            "items": {
+                              "maxLength": 100,
+                              "minLength": 3,
+                              "type": "string"
+                            },
+                            "maxItems": 500,
+                            "minItems": 0,
+                            "readOnly": true,
+                            "type": "array",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ]
+                            },
+                            "x-linode-filterable": true
+                          },
+                          "total_size": {
+                            "description": "__Read-only__ The total size in bytes of all instances of this image, in all `regions`.",
+                            "example": 256,
+                            "readOnly": true,
+                            "type": "integer"
+                          },
+                          "type": {
+                            "description": "__Filterable__, __Read-only__ How the image was created. Create a `manual` image at any time. An `automatic` image is created automatically from a deleted compute instance. A `shared` image is made accessible to others.",
+                            "enum": [
+                              "manual",
+                              "automatic",
+                              "shared"
+                            ],
+                            "example": "shared",
+                            "readOnly": true,
+                            "type": "string",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ]
+                            },
+                            "x-linode-filterable": true
+                          },
+                          "updated": {
+                            "description": "__Read-only__ When this image share was last updated.",
+                            "example": null,
+                            "format": "date-time",
+                            "nullable": true,
+                            "readOnly": true,
+                            "type": "string"
+                          },
+                          "vendor": {
+                            "description": "__Read-only__ The upstream distribution vendor. This is `null` for private and shared images.",
+                            "nullable": true,
+                            "readOnly": true,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "tags",
+                          "type",
+                          "description",
+                          "label",
+                          "created",
+                          "updated",
+                          "size",
+                          "status",
+                          "capabilities",
+                          "is_public",
+                          "is_shared",
+                          "deprecated",
+                          "regions",
+                          "total_size",
+                          "image_sharing",
+                          "created_by",
+                          "expiry",
+                          "eol",
+                          "vendor"
+                        ],
+                        "type": "object",
+                        "x-akamai": {
+                          "file-path": "schemas/imageshares.yaml"
+                        }
+                      },
+                      "type": "array"
+                    },
+                    "page": {
+                      "description": "__Read-only__ The current [page](https://techdocs.akamai.com/linode-api/reference/pagination).",
+                      "example": 1,
+                      "readOnly": true,
+                      "type": "integer"
+                    },
+                    "pages": {
+                      "description": "__Read-only__ The total number of [pages](https://techdocs.akamai.com/linode-api/reference/pagination).",
+                      "example": 1,
+                      "readOnly": true,
+                      "type": "integer"
+                    },
+                    "results": {
+                      "description": "__Read-only__ The total number of results.",
+                      "example": 1,
+                      "readOnly": true,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "page",
+                    "pages",
+                    "results"
+                  ],
+                  "type": "object",
+                  "x-akamai": {
+                    "file-path": "schemas/get-sharegroups-images-200.yaml"
+                  }
+                },
+                "x-example": {
+                  "x-ref": "../examples/get-sharegroup-images-200.json"
+                }
+              }
+            },
+            "description": "Returns a paginated list of shared images linked to the share group."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "errors": {
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "An object for describing a single error that occurred during the processing of a request.",
+                        "properties": {
+                          "field": {
+                            "description": "The field in the request that caused this error. This may be a path, separated by periods in the case of nested fields. In some cases this may come back as `null` if the error is not specific to any single element of the request.",
+                            "example": "fieldname",
+                            "type": "string"
+                          },
+                          "reason": {
+                            "description": "What happened to cause this error. In most cases, this can be fixed immediately by changing the data you sent in the request, but in some cases you will be instructed to [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) or perform some other action before you can complete the request successfully.",
+                            "example": "fieldname must be a valid value",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-akamai": {
+                          "file-path": "schemas/error-object.yaml"
+                        }
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "See [Errors](https://techdocs.akamai.com/linode-api/reference/errors) for the range of possible error response codes."
+          }
+        },
+        "security": [
+          {
+            "personalAccessToken": []
+          },
+          {
+            "oauth": [
+              "images:read_only"
+            ]
+          }
+        ],
+        "summary": "List targeted share group images",
+        "tags": [
+          "Private image sharing"
+        ],
+        "x-akamai": {
+          "tabs": [
+            {
+              "syntax": "images:read_only",
+              "title": "OAuth scopes",
+              "url": "https://techdocs.akamai.com/linode-api/reference/get-started#oauth"
+            }
+          ]
+        },
+        "x-linode-redoc-load-ids": true
+      },
+      "parameters": [
+        {
+          "description": "__Enum__ Call either the `v4` URL, or `v4beta` for operations still in Beta.",
+          "example": "{{apiVersion}}",
+          "in": "path",
+          "name": "apiVersion",
+          "required": true,
+          "schema": {
+            "enum": [
+              "v4",
+              "v4beta"
+            ],
+            "type": "string"
+          },
+          "x-akamai": {
+            "file-path": "parameters/api-version-path.yaml"
+          }
+        },
+        {
+          "description": "The unique identifier assigned to the share group after creation.",
+          "example": "{{sharegroupId}}",
+          "in": "path",
+          "name": "sharegroupId",
+          "required": true,
+          "schema": {
+            "example": 54321,
+            "type": "integer"
+          },
+          "x-akamai": {
+            "file-path": "parameters/sharegroup-id-path.yaml"
+          }
+        }
+      ],
+      "x-akamai": {
+        "file-path": "paths/images-sharegroup-id-images.yaml",
+        "path-info": "/{apiVersion}/images/sharegroups/{sharegroupId}/images"
+      }
+    },
+    "/{apiVersion}/images/sharegroups/{sharegroupId}/images/{imageId}": {
+      "put": {
+        "description": "Updates the image share.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    images:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "externalDocs": {
+          "description": "See documentation for this operation in Akamai's Linode API",
+          "url": "https://techdocs.akamai.com/linode-api/reference/put-sharegroup-imageshare"
+        },
+        "operationId": "put-sharegroup-imageshare",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "description": "ImageShareGroupMemberTokens object.",
+                "properties": {
+                  "description": {
+                    "description": "A detailed description of this image share.",
+                    "example": "{{description}}",
+                    "type": "string"
+                  },
+                  "label": {
+                    "description": "A short description of the image share.",
+                    "example": "{{label}}",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "label"
+                ],
+                "type": "object",
+                "x-akamai": {
+                  "file-path": "schemas/put-sharegroup-imageshare.yaml"
+                }
+              },
+              "x-example": {
+                "x-ref": "../examples/put-sharegroup-imageshare-200.json"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "description": "ImageShare object.",
+                  "properties": {
+                    "capabilities": {
+                      "description": "__Read-only__ A list of the possible capabilities of this image.",
+                      "example": [
+                        "cloud-init",
+                        "distributed-sites"
+                      ],
+                      "items": {
+                        "type": "string"
+                      },
+                      "readOnly": true,
+                      "type": "array"
+                    },
+                    "created": {
+                      "description": "__Read-only__ When this image share was created.",
+                      "example": "2025-08-04T10:07:59",
+                      "format": "date-time",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "created_by": {
+                      "description": "__Read-only__ The name of the user who created this image share.",
+                      "example": null,
+                      "nullable": true,
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "deprecated": {
+                      "description": "Whether this image is deprecated. Only public images can be deprecated.",
+                      "type": "boolean"
+                    },
+                    "description": {
+                      "description": "A detailed description of this image share.",
+                      "example": "Official Debian Linux image for server deployment",
+                      "type": "string"
+                    },
+                    "eol": {
+                      "description": "__Read-only__ The date of the public image's planned removal from service. This is `null` for private images.",
+                      "format": "date-time",
+                      "nullable": true,
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "expiry": {
+                      "description": "__Read-only__ Only images created automatically from a deleted compute instance (type=automatic) expire. This is `null` for private images.",
+                      "format": "date-time",
+                      "nullable": true,
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "id": {
+                      "description": "__Read-only__ The unique identifier for each image share.",
+                      "example": "shared/1",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "image_sharing": {
+                      "additionalProperties": false,
+                      "description": "__Read-only__ Sharing information for the image, including who it was shared by and with.",
+                      "properties": {
+                        "shared_by": {
+                          "properties": {
+                            "sharegroup_id": {
+                              "description": "__Read-only__ A numeric identifier for the share group. This is primarily used within the system for database operations and is read-only.",
+                              "example": 3,
+                              "readOnly": true,
+                              "type": "integer"
+                            },
+                            "sharegroup_label": {
+                              "description": "Descriptive label of the share group.",
+                              "example": "DevOps Base Images",
+                              "type": "string"
+                            },
+                            "sharegroup_uuid": {
+                              "description": "__Read-only__ A universally unique identifier for the share group. Used by clients to reference a specific share group when creating a single-use token.",
+                              "example": "8d64b99e-92f7-4c7b-a616-8f622fffb94c",
+                              "format": "uuid",
+                              "readOnly": true,
+                              "type": "string"
+                            },
+                            "source_image_id": {
+                              "description": "__Read-only__ Slug identifier of the source image.",
+                              "example": "private/15",
+                              "readOnly": true,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "sharegroup_id",
+                            "sharegroup_uuid",
+                            "sharegroup_label",
+                            "source_image_id"
+                          ],
+                          "type": "object"
+                        },
+                        "shared_with": {
+                          "description": "Details about who this image was shared with.",
+                          "example": null,
+                          "nullable": true,
+                          "type": "object"
+                        }
+                      },
+                      "readOnly": true,
+                      "type": "object"
+                    },
+                    "is_public": {
+                      "description": "__Read-only__ Indicates whether this image is shared with others.",
+                      "example": true,
+                      "readOnly": true,
+                      "type": "boolean"
+                    },
+                    "is_shared": {
+                      "description": "__Read-only__ Indicates if the image is a private image shared with other users.",
+                      "example": null,
+                      "nullable": true,
+                      "readOnly": true,
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "description": "A short description of the image share.",
+                      "example": "Linux Debian",
+                      "type": "string"
+                    },
+                    "regions": {
+                      "description": "__Read-only__ Details on the regions where this image is stored. See [Regions and images](https://techdocs.akamai.com/cloud-computing/docs/images#regions-and-images) for full details on support for `regions`.",
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "region": {
+                            "description": "The unique identifier for the core compute region where this image is stored.",
+                            "example": "us-iad",
+                            "type": "string"
+                          },
+                          "status": {
+                            "description": "The status of the image in this `region`. Possible values are `available`, `creating`, `pending`, `pending deletion`, `pending replication`, or `replicating`.",
+                            "enum": [
+                              "available",
+                              "creating",
+                              "pending",
+                              "pending deletion",
+                              "pending replication",
+                              "replicating"
+                            ],
+                            "example": "available",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "readOnly": true,
+                      "type": "array"
+                    },
+                    "size": {
+                      "description": "__Read-only__ The minimum size in MB this image needs to deploy.",
+                      "example": 256,
+                      "readOnly": true,
+                      "type": "integer"
+                    },
+                    "status": {
+                      "description": "__Read-only__ The current status of the image. Possible values are `available`, `creating`, and `pending_upload`.",
+                      "enum": [
+                        "creating",
+                        "pending_upload",
+                        "available"
+                      ],
+                      "example": "available",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "tags": {
+                      "description": "__Read-only__ Tags used for organizational purposes. A tag can be from 3 to 100 characters long, and an image can have a maximum of 500 total tags.",
+                      "example": [
+                        "repair-image",
+                        "fix-1"
+                      ],
+                      "items": {
+                        "maxLength": 100,
+                        "minLength": 3,
+                        "type": "string"
+                      },
+                      "maxItems": 500,
+                      "minItems": 0,
+                      "readOnly": true,
+                      "type": "array"
+                    },
+                    "total_size": {
+                      "description": "__Read-only__ The total size in bytes of all instances of this image, in all `regions`.",
+                      "example": 256,
+                      "readOnly": true,
+                      "type": "integer"
+                    },
+                    "type": {
+                      "description": "__Read-only__ How the image was created. Create a `manual` image at any time. An `automatic` image is created automatically from a deleted compute instance. A `shared` image is made accessible to others.",
+                      "enum": [
+                        "manual",
+                        "automatic",
+                        "shared"
+                      ],
+                      "example": "shared",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "updated": {
+                      "description": "__Read-only__ When this image share was last updated.",
+                      "example": null,
+                      "format": "date-time",
+                      "nullable": true,
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "vendor": {
+                      "description": "__Read-only__ The upstream distribution vendor. This is `null` for private and shared images.",
+                      "nullable": true,
+                      "readOnly": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "tags",
+                    "type",
+                    "description",
+                    "label",
+                    "created",
+                    "updated",
+                    "size",
+                    "status",
+                    "capabilities",
+                    "is_public",
+                    "is_shared",
+                    "deprecated",
+                    "regions",
+                    "total_size",
+                    "image_sharing",
+                    "created_by",
+                    "expiry",
+                    "eol",
+                    "vendor"
+                  ],
+                  "type": "object",
+                  "x-akamai": {
+                    "file-path": "schemas/imageshare.yaml"
+                  }
+                },
+                "x-example": {
+                  "x-ref": "../examples/put-sharegroup-imageshare-200.json"
+                },
+                "x-linode-cli-subtables": [
+                  "regions"
+                ]
+              }
+            },
+            "description": "The updated image share."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "errors": {
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "An object for describing a single error that occurred during the processing of a request.",
+                        "properties": {
+                          "field": {
+                            "description": "The field in the request that caused this error. This may be a path, separated by periods in the case of nested fields. In some cases this may come back as `null` if the error is not specific to any single element of the request.",
+                            "example": "fieldname",
+                            "type": "string"
+                          },
+                          "reason": {
+                            "description": "What happened to cause this error. In most cases, this can be fixed immediately by changing the data you sent in the request, but in some cases you will be instructed to [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) or perform some other action before you can complete the request successfully.",
+                            "example": "fieldname must be a valid value",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-akamai": {
+                          "file-path": "schemas/error-object.yaml"
+                        }
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "See [Errors](https://techdocs.akamai.com/linode-api/reference/errors) for the range of possible error response codes."
+          }
+        },
+        "security": [
+          {
+            "personalAccessToken": []
+          },
+          {
+            "oauth": [
+              "images:read_write"
+            ]
+          }
+        ],
+        "summary": "Update image share",
+        "tags": [
+          "Private image sharing"
+        ],
+        "x-akamai": {
+          "tabs": [
+            {
+              "syntax": "images:read_write",
+              "title": "OAuth scopes",
+              "url": "https://techdocs.akamai.com/linode-api/reference/get-started#oauth"
+            }
+          ]
+        },
+        "x-linode-grant": "read_write"
+      },
+      "delete": {
+        "description": "Deletes image access from a share group.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    images:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "externalDocs": {
+          "description": "See documentation for this operation in Akamai's Linode API",
+          "url": "https://techdocs.akamai.com/linode-api/reference/delete-sharegroup-imageshare"
+        },
+        "operationId": "delete-sharegroup-imageshare",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "The API responds with an empty object.",
+                  "maxProperties": 0,
+                  "type": "object",
+                  "x-akamai": {
+                    "file-path": "schemas/added-empty-obj.yaml"
+                  }
+                },
+                "x-example": {
+                  "x-ref": "../examples/delete-sharegroup-imageshare-200.json"
+                }
+              }
+            },
+            "description": "Image access deleted successfully from share group."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "errors": {
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "An object for describing a single error that occurred during the processing of a request.",
+                        "properties": {
+                          "field": {
+                            "description": "The field in the request that caused this error. This may be a path, separated by periods in the case of nested fields. In some cases this may come back as `null` if the error is not specific to any single element of the request.",
+                            "example": "fieldname",
+                            "type": "string"
+                          },
+                          "reason": {
+                            "description": "What happened to cause this error. In most cases, this can be fixed immediately by changing the data you sent in the request, but in some cases you will be instructed to [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) or perform some other action before you can complete the request successfully.",
+                            "example": "fieldname must be a valid value",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-akamai": {
+                          "file-path": "schemas/error-object.yaml"
+                        }
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "See [Errors](https://techdocs.akamai.com/linode-api/reference/errors) for the range of possible error response codes."
+          }
+        },
+        "security": [
+          {
+            "personalAccessToken": []
+          },
+          {
+            "oauth": [
+              "images:read_write"
+            ]
+          }
+        ],
+        "summary": "Delete access to an image in a share group",
+        "tags": [
+          "Private image sharing"
+        ],
+        "x-akamai": {
+          "tabs": [
+            {
+              "syntax": "images:read_write",
+              "title": "OAuth scopes",
+              "url": "https://techdocs.akamai.com/linode-api/reference/get-started#oauth"
+            }
+          ]
+        },
+        "x-linode-grant": "read_write"
+      },
+      "parameters": [
+        {
+          "description": "__Enum__ Call either the `v4` URL, or `v4beta` for operations still in Beta.",
+          "example": "{{apiVersion}}",
+          "in": "path",
+          "name": "apiVersion",
+          "required": true,
+          "schema": {
+            "enum": [
+              "v4",
+              "v4beta"
+            ],
+            "type": "string"
+          },
+          "x-akamai": {
+            "file-path": "parameters/api-version-path.yaml"
+          }
+        },
+        {
+          "description": "The unique identifier assigned to the share group after creation.",
+          "example": "{{sharegroupId}}",
+          "in": "path",
+          "name": "sharegroupId",
+          "required": true,
+          "schema": {
+            "example": 54321,
+            "type": "integer"
+          },
+          "x-akamai": {
+            "file-path": "parameters/sharegroup-id-path.yaml"
+          }
+        },
+        {
+          "description": "Slug identifier assigned to the shared image upon sharing.",
+          "example": "{{imageId}}",
+          "in": "path",
+          "name": "imageId",
+          "required": true,
+          "schema": {
+            "example": "shared/7",
+            "type": "string"
+          },
+          "x-akamai": {
+            "file-path": "parameters/image-id-path-w-shared-slug.yaml"
+          }
+        }
+      ],
+      "x-akamai": {
+        "file-path": "paths/images-sharegroups-id-images-id.yaml",
+        "path-info": "/{apiVersion}/images/sharegroups/{sharegroupId}/images/{imageId}"
+      }
+    },
+    "/{apiVersion}/images/sharegroups/{sharegroupId}/members": {
+      "post": {
+        "description": "Allows to add members to a specific share group.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    images:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "externalDocs": {
+          "description": "See documentation for this operation in Akamai's Linode API",
+          "url": "https://techdocs.akamai.com/linode-api/reference/post-sharegroup-members"
+        },
+        "operationId": "post-sharegroup-members",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "label": {
+                    "description": "Membership label.",
+                    "example": "{{label}}",
+                    "type": "string"
+                  },
+                  "token": {
+                    "description": "Image share group membership token.",
+                    "example": "{{token}}",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "token",
+                  "label"
+                ],
+                "type": "object",
+                "x-akamai": {
+                  "file-path": "schemas/post-sharegroup-members.yaml"
+                }
+              },
+              "x-example": {
+                "x-ref": "../examples/post-sharegroup-members.json"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "description": "ImageShareGroupMembership object.",
+                  "properties": {
+                    "created": {
+                      "description": "__Read-only__ The creation time of this share group membership.",
+                      "example": "2025-08-04T10:07:59",
+                      "format": "date-time",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "expiry": {
+                      "description": "__Read-only__ The expiration time of this share group membership.",
+                      "example": null,
+                      "format": "date-time",
+                      "nullable": true,
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "label": {
+                      "description": "A short description of the share group membership.",
+                      "example": "Engineering - Backend",
+                      "type": "string"
+                    },
+                    "status": {
+                      "description": "__Read-only__ Represents the current membership `status`. Possible values are `active` or `revoked`.",
+                      "enum": [
+                        "active",
+                        "revoked"
+                      ],
+                      "example": "active",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "token_uuid": {
+                      "description": "__Read-only__ A unique identifier representing the membership token.",
+                      "example": "4591075e-4ba8-43c9-a521-928c3d4a135d",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "updated": {
+                      "description": "__Read-only__ The timestamp of the last update to this share group membership.",
+                      "example": null,
+                      "format": "date-time",
+                      "nullable": true,
+                      "readOnly": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "token_uuid",
+                    "status",
+                    "label",
+                    "created",
+                    "updated",
+                    "expiry"
+                  ],
+                  "type": "object",
+                  "x-akamai": {
+                    "file-path": "schemas/membership.yaml"
+                  }
+                },
+                "x-example": {
+                  "x-ref": "../examples/post-sharegroup-members-200.json"
+                }
+              }
+            },
+            "description": "Member added successfully."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "errors": {
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "An object for describing a single error that occurred during the processing of a request.",
+                        "properties": {
+                          "field": {
+                            "description": "The field in the request that caused this error. This may be a path, separated by periods in the case of nested fields. In some cases this may come back as `null` if the error is not specific to any single element of the request.",
+                            "example": "fieldname",
+                            "type": "string"
+                          },
+                          "reason": {
+                            "description": "What happened to cause this error. In most cases, this can be fixed immediately by changing the data you sent in the request, but in some cases you will be instructed to [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) or perform some other action before you can complete the request successfully.",
+                            "example": "fieldname must be a valid value",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-akamai": {
+                          "file-path": "schemas/error-object.yaml"
+                        }
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "See [Errors](https://techdocs.akamai.com/linode-api/reference/errors) for the range of possible error response codes."
+          }
+        },
+        "security": [
+          {
+            "personalAccessToken": []
+          },
+          {
+            "oauth": [
+              "images:read_write"
+            ]
+          }
+        ],
+        "summary": "Add members to a share group",
+        "tags": [
+          "Private image sharing"
+        ],
+        "x-akamai": {
+          "tabs": [
+            {
+              "syntax": "images:read_write",
+              "title": "OAuth scopes",
+              "url": "https://techdocs.akamai.com/linode-api/reference/get-started#oauth"
+            }
+          ]
+        },
+        "x-linode-redoc-load-ids": true
+      },
+      "get": {
+        "description": "Get details about the current members of the targeted share group.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    images:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "externalDocs": {
+          "description": "See documentation for this operation in Akamai's Linode API",
+          "url": "https://techdocs.akamai.com/linode-api/reference/get-sharegroup-members"
+        },
+        "operationId": "get-sharegroup-members",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "ImageShareGroupMembership object.",
+                        "properties": {
+                          "created": {
+                            "description": "__Read-only__ The creation time of this share group membership.",
+                            "example": "2025-08-04T10:07:59",
+                            "format": "date-time",
+                            "readOnly": true,
+                            "type": "string"
+                          },
+                          "expiry": {
+                            "description": "__Read-only__ The expiration time of this share group membership.",
+                            "example": null,
+                            "format": "date-time",
+                            "nullable": true,
+                            "readOnly": true,
+                            "type": "string"
+                          },
+                          "label": {
+                            "description": "__Filterable__ A short description of the share group membership.",
+                            "example": "Engineering - Backend",
+                            "type": "string",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ]
+                            },
+                            "x-linode-filterable": true
+                          },
+                          "status": {
+                            "description": "__Filterable__, __Read-only__ Represents the current membership `status`. Possible values are `active` or `revoked`.",
+                            "enum": [
+                              "active",
+                              "revoked"
+                            ],
+                            "example": "active",
+                            "readOnly": true,
+                            "type": "string",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ]
+                            },
+                            "x-linode-filterable": true
+                          },
+                          "token_uuid": {
+                            "description": "__Filterable__, __Read-only__ A unique identifier representing the membership token.",
+                            "example": "4591075e-4ba8-43c9-a521-928c3d4a135d",
+                            "readOnly": true,
+                            "type": "string",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ]
+                            },
+                            "x-linode-filterable": true
+                          },
+                          "updated": {
+                            "description": "__Read-only__ The timestamp of the last update to this share group membership.",
+                            "example": null,
+                            "format": "date-time",
+                            "nullable": true,
+                            "readOnly": true,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "token_uuid",
+                          "status",
+                          "label",
+                          "created",
+                          "updated",
+                          "expiry"
+                        ],
+                        "type": "object",
+                        "x-akamai": {
+                          "file-path": "schemas/memberships.yaml"
+                        }
+                      },
+                      "type": "array"
+                    },
+                    "page": {
+                      "description": "__Read-only__ The current [page](https://techdocs.akamai.com/linode-api/reference/pagination).",
+                      "example": 1,
+                      "readOnly": true,
+                      "type": "integer"
+                    },
+                    "pages": {
+                      "description": "__Read-only__ The total number of [pages](https://techdocs.akamai.com/linode-api/reference/pagination).",
+                      "example": 1,
+                      "readOnly": true,
+                      "type": "integer"
+                    },
+                    "results": {
+                      "description": "__Read-only__ The total number of results.",
+                      "example": 1,
+                      "readOnly": true,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "page",
+                    "pages",
+                    "results"
+                  ],
+                  "type": "object",
+                  "x-akamai": {
+                    "file-path": "schemas/get-sharegroups-members-200.yaml"
+                  }
+                },
+                "x-example": {
+                  "x-ref": "../examples/get-sharegroup-members-200.json"
+                }
+              }
+            },
+            "description": "Returns a paginated list of the current members linked to the targeted share group."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "errors": {
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "An object for describing a single error that occurred during the processing of a request.",
+                        "properties": {
+                          "field": {
+                            "description": "The field in the request that caused this error. This may be a path, separated by periods in the case of nested fields. In some cases this may come back as `null` if the error is not specific to any single element of the request.",
+                            "example": "fieldname",
+                            "type": "string"
+                          },
+                          "reason": {
+                            "description": "What happened to cause this error. In most cases, this can be fixed immediately by changing the data you sent in the request, but in some cases you will be instructed to [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) or perform some other action before you can complete the request successfully.",
+                            "example": "fieldname must be a valid value",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-akamai": {
+                          "file-path": "schemas/error-object.yaml"
+                        }
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "See [Errors](https://techdocs.akamai.com/linode-api/reference/errors) for the range of possible error response codes."
+          }
+        },
+        "security": [
+          {
+            "personalAccessToken": []
+          },
+          {
+            "oauth": [
+              "images:read_only"
+            ]
+          }
+        ],
+        "summary": "List targeted share group members",
+        "tags": [
+          "Private image sharing"
+        ],
+        "x-akamai": {
+          "tabs": [
+            {
+              "syntax": "images:read_only",
+              "title": "OAuth scopes",
+              "url": "https://techdocs.akamai.com/linode-api/reference/get-started#oauth"
+            }
+          ]
+        },
+        "x-linode-redoc-load-ids": true
+      },
+      "parameters": [
+        {
+          "description": "__Enum__ Call either the `v4` URL, or `v4beta` for operations still in Beta.",
+          "example": "{{apiVersion}}",
+          "in": "path",
+          "name": "apiVersion",
+          "required": true,
+          "schema": {
+            "enum": [
+              "v4",
+              "v4beta"
+            ],
+            "type": "string"
+          },
+          "x-akamai": {
+            "file-path": "parameters/api-version-path.yaml"
+          }
+        },
+        {
+          "description": "The unique identifier assigned to the share group after creation.",
+          "example": "{{sharegroupId}}",
+          "in": "path",
+          "name": "sharegroupId",
+          "required": true,
+          "schema": {
+            "example": 54321,
+            "type": "integer"
+          },
+          "x-akamai": {
+            "file-path": "parameters/sharegroup-id-path.yaml"
+          }
+        }
+      ],
+      "x-akamai": {
+        "file-path": "paths/images-sharegroup-id-members.yaml",
+        "path-info": "/{apiVersion}/images/sharegroups/{sharegroupId}/members"
+      }
+    },
+    "/{apiVersion}/images/sharegroups/{sharegroupId}/members/{tokenUuid}": {
+      "get": {
+        "description": "Get details about the targeted membership token status.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    images:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "externalDocs": {
+          "description": "See documentation for this operation in Akamai's Linode API",
+          "url": "https://techdocs.akamai.com/linode-api/reference/get-sharegroup-member-token"
+        },
+        "operationId": "get-sharegroup-member-token",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "description": "ImageShareGroupMembership object.",
+                  "properties": {
+                    "created": {
+                      "description": "__Read-only__ The creation time of this share group membership.",
+                      "example": "2025-08-04T10:07:59",
+                      "format": "date-time",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "expiry": {
+                      "description": "__Read-only__ The expiration time of this share group membership.",
+                      "example": null,
+                      "format": "date-time",
+                      "nullable": true,
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "label": {
+                      "description": "A short description of the share group membership.",
+                      "example": "Engineering - Backend",
+                      "type": "string"
+                    },
+                    "status": {
+                      "description": "__Read-only__ Represents the current membership `status`. Possible values are `active` or `revoked`.",
+                      "enum": [
+                        "active",
+                        "revoked"
+                      ],
+                      "example": "active",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "token_uuid": {
+                      "description": "__Read-only__ A unique identifier representing the membership token.",
+                      "example": "4591075e-4ba8-43c9-a521-928c3d4a135d",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "updated": {
+                      "description": "__Read-only__ The timestamp of the last update to this share group membership.",
+                      "example": null,
+                      "format": "date-time",
+                      "nullable": true,
+                      "readOnly": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "token_uuid",
+                    "status",
+                    "label",
+                    "created",
+                    "updated",
+                    "expiry"
+                  ],
+                  "type": "object",
+                  "x-akamai": {
+                    "file-path": "schemas/membership.yaml"
+                  }
+                },
+                "x-example": {
+                  "x-ref": "../examples/get-sharegroup-member-token-200.json"
+                }
+              }
+            },
+            "description": "A single token object."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "errors": {
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "An object for describing a single error that occurred during the processing of a request.",
+                        "properties": {
+                          "field": {
+                            "description": "The field in the request that caused this error. This may be a path, separated by periods in the case of nested fields. In some cases this may come back as `null` if the error is not specific to any single element of the request.",
+                            "example": "fieldname",
+                            "type": "string"
+                          },
+                          "reason": {
+                            "description": "What happened to cause this error. In most cases, this can be fixed immediately by changing the data you sent in the request, but in some cases you will be instructed to [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) or perform some other action before you can complete the request successfully.",
+                            "example": "fieldname must be a valid value",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-akamai": {
+                          "file-path": "schemas/error-object.yaml"
+                        }
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "See [Errors](https://techdocs.akamai.com/linode-api/reference/errors) for the range of possible error response codes."
+          }
+        },
+        "security": [
+          {
+            "personalAccessToken": []
+          },
+          {
+            "oauth": [
+              "images:read_only"
+            ]
+          }
+        ],
+        "summary": "Get a membership token",
+        "tags": [
+          "Private image sharing"
+        ],
+        "x-akamai": {
+          "tabs": [
+            {
+              "syntax": "images:read_only",
+              "title": "OAuth scopes",
+              "url": "https://techdocs.akamai.com/linode-api/reference/get-started#oauth"
+            }
+          ]
+        },
+        "x-linode-redoc-load-ids": true
+      },
+      "put": {
+        "description": "Updates the specified membership token.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    images:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "externalDocs": {
+          "description": "See documentation for this operation in Akamai's Linode API",
+          "url": "https://techdocs.akamai.com/linode-api/reference/put-sharegroup-member-token"
+        },
+        "operationId": "put-sharegroup-member-token",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "description": "ImageShareGroupMembership object.",
+                "properties": {
+                  "label": {
+                    "description": "Label for the membership.",
+                    "example": "{{label}}",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "label"
+                ],
+                "type": "object",
+                "x-akamai": {
+                  "file-path": "schemas/put-sharegroup-member-token.yaml"
+                }
+              },
+              "x-example": {
+                "x-ref": "../examples/put-sharegroup-member-token-200.json"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "description": "ImageShareGroupMembership object.",
+                  "properties": {
+                    "created": {
+                      "description": "__Read-only__ The creation time of this share group membership.",
+                      "example": "2025-08-04T10:07:59",
+                      "format": "date-time",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "expiry": {
+                      "description": "__Read-only__ The expiration time of this share group membership.",
+                      "example": null,
+                      "format": "date-time",
+                      "nullable": true,
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "label": {
+                      "description": "A short description of the share group membership.",
+                      "example": "Engineering - Backend",
+                      "type": "string"
+                    },
+                    "status": {
+                      "description": "__Read-only__ Represents the current membership `status`. Possible values are `active` or `revoked`.",
+                      "enum": [
+                        "active",
+                        "revoked"
+                      ],
+                      "example": "active",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "token_uuid": {
+                      "description": "__Read-only__ A unique identifier representing the membership token.",
+                      "example": "4591075e-4ba8-43c9-a521-928c3d4a135d",
+                      "readOnly": true,
+                      "type": "string"
+                    },
+                    "updated": {
+                      "description": "__Read-only__ The timestamp of the last update to this share group membership.",
+                      "example": null,
+                      "format": "date-time",
+                      "nullable": true,
+                      "readOnly": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "token_uuid",
+                    "status",
+                    "label",
+                    "created",
+                    "updated",
+                    "expiry"
+                  ],
+                  "type": "object",
+                  "x-akamai": {
+                    "file-path": "schemas/membership.yaml"
+                  }
+                },
+                "x-example": {
+                  "x-ref": "../examples/put-sharegroup-member-token-200.json"
+                }
+              }
+            },
+            "description": "The updated token."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "errors": {
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "An object for describing a single error that occurred during the processing of a request.",
+                        "properties": {
+                          "field": {
+                            "description": "The field in the request that caused this error. This may be a path, separated by periods in the case of nested fields. In some cases this may come back as `null` if the error is not specific to any single element of the request.",
+                            "example": "fieldname",
+                            "type": "string"
+                          },
+                          "reason": {
+                            "description": "What happened to cause this error. In most cases, this can be fixed immediately by changing the data you sent in the request, but in some cases you will be instructed to [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) or perform some other action before you can complete the request successfully.",
+                            "example": "fieldname must be a valid value",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-akamai": {
+                          "file-path": "schemas/error-object.yaml"
+                        }
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "See [Errors](https://techdocs.akamai.com/linode-api/reference/errors) for the range of possible error response codes."
+          }
+        },
+        "security": [
+          {
+            "personalAccessToken": []
+          },
+          {
+            "oauth": [
+              "images:read_write"
+            ]
+          }
+        ],
+        "summary": "Update a membership token",
+        "tags": [
+          "Private image sharing"
+        ],
+        "x-akamai": {
+          "tabs": [
+            {
+              "syntax": "images:read_write",
+              "title": "OAuth scopes",
+              "url": "https://techdocs.akamai.com/linode-api/reference/get-started#oauth"
+            }
+          ]
+        },
+        "x-linode-grant": "read_write"
+      },
+      "delete": {
+        "description": "Deletes a membership token accepted into a share group and marks it as `revoked`.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    images:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "externalDocs": {
+          "description": "See documentation for this operation in Akamai's Linode API",
+          "url": "https://techdocs.akamai.com/linode-api/reference/delete-sharegroup-member-token"
+        },
+        "operationId": "delete-sharegroup-member-token",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "The API responds with an empty object.",
+                  "maxProperties": 0,
+                  "type": "object",
+                  "x-akamai": {
+                    "file-path": "schemas/added-empty-obj.yaml"
+                  }
+                },
+                "x-example": {
+                  "x-ref": "../examples/delete-sharegroup-member-token-200.json"
+                }
+              }
+            },
+            "description": "Token revoked successfully."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "errors": {
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "An object for describing a single error that occurred during the processing of a request.",
+                        "properties": {
+                          "field": {
+                            "description": "The field in the request that caused this error. This may be a path, separated by periods in the case of nested fields. In some cases this may come back as `null` if the error is not specific to any single element of the request.",
+                            "example": "fieldname",
+                            "type": "string"
+                          },
+                          "reason": {
+                            "description": "What happened to cause this error. In most cases, this can be fixed immediately by changing the data you sent in the request, but in some cases you will be instructed to [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) or perform some other action before you can complete the request successfully.",
+                            "example": "fieldname must be a valid value",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-akamai": {
+                          "file-path": "schemas/error-object.yaml"
+                        }
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "See [Errors](https://techdocs.akamai.com/linode-api/reference/errors) for the range of possible error response codes."
+          }
+        },
+        "security": [
+          {
+            "personalAccessToken": []
+          },
+          {
+            "oauth": [
+              "images:read_write"
+            ]
+          }
+        ],
+        "summary": "Delete a membership token",
+        "tags": [
+          "Private image sharing"
+        ],
+        "x-akamai": {
+          "tabs": [
+            {
+              "syntax": "images:read_write",
+              "title": "OAuth scopes",
+              "url": "https://techdocs.akamai.com/linode-api/reference/get-started#oauth"
+            }
+          ]
+        },
+        "x-linode-grant": "read_write"
+      },
+      "parameters": [
+        {
+          "description": "__Enum__ Call either the `v4` URL, or `v4beta` for operations still in Beta.",
+          "example": "{{apiVersion}}",
+          "in": "path",
+          "name": "apiVersion",
+          "required": true,
+          "schema": {
+            "enum": [
+              "v4",
+              "v4beta"
+            ],
+            "type": "string"
+          },
+          "x-akamai": {
+            "file-path": "parameters/api-version-path.yaml"
+          }
+        },
+        {
+          "description": "The unique identifier assigned to the share group after creation.",
+          "example": "{{sharegroupId}}",
+          "in": "path",
+          "name": "sharegroupId",
+          "required": true,
+          "schema": {
+            "example": 54321,
+            "type": "integer"
+          },
+          "x-akamai": {
+            "file-path": "parameters/sharegroup-id-path.yaml"
+          }
+        },
+        {
+          "description": "A unique identifier for the token, used to reference it after creation.",
+          "example": "{{tokenUuid}}",
+          "in": "path",
+          "name": "tokenUuid",
+          "required": true,
+          "schema": {
+            "example": "13428362-5458-4dad-b14b-8d0d4d648f8c",
+            "format": "uuid",
+            "type": "string"
+          },
+          "x-akamai": {
+            "file-path": "parameters/token-uuid-path.yaml"
+          }
+        }
+      ],
+      "x-akamai": {
+        "file-path": "paths/images-sharegroups-id-members-id.yaml",
+        "path-info": "/{apiVersion}/images/sharegroups/{sharegroupId}/members/{tokenUuid}"
+      }
     },
     "/{apiVersion}/images/upload": {
       "post": {
@@ -42355,14 +47936,117 @@
                         },
                         "id": {
                           "description": "__Read-only__ The unique identifier for each image.",
-                          "example": "linode/debian11",
+                          "example": "private/15",
                           "readOnly": true,
                           "type": "string",
                           "x-linode-cli-display": 1
                         },
+                        "image_sharing": {
+                          "description": "This object represents the sharing status of an image.",
+                          "oneOf": [
+                            {
+                              "additionalProperties": false,
+                              "example": {
+                                "shared_by": null,
+                                "shared_with": {
+                                  "image_sharegroup_list_url": "/images/private/15/sharegroups",
+                                  "sharegroup_count": 0
+                                }
+                              },
+                              "properties": {
+                                "shared_by": {
+                                  "description": "This field is `null` in this case, meaning the image is not shared by any group. The `shared_with` field provides details on the image's share group.",
+                                  "nullable": true,
+                                  "type": "object"
+                                },
+                                "shared_with": {
+                                  "additionalProperties": false,
+                                  "description": "Specifies the group that the image is shared with, including the count of share groups and a URL to view the share groups.",
+                                  "properties": {
+                                    "image_sharegroup_list_url": {
+                                      "description": "A URL to view the list of share groups the image is shared with.",
+                                      "type": "string"
+                                    },
+                                    "sharegroup_count": {
+                                      "description": "The number of share groups the image is shared with.",
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "sharegroup_count",
+                                    "image_sharegroup_list_url"
+                                  ],
+                                  "type": "object"
+                                }
+                              },
+                              "required": [
+                                "shared_with",
+                                "shared_by"
+                              ],
+                              "title": "shared_with",
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "example": {
+                                "shared_by": {
+                                  "sharegroup_id": 3,
+                                  "sharegroup_label": "label",
+                                  "sharegroup_uuid": "8003abfe-6b03-41a1-9e4c-a234ae3060c8",
+                                  "source_image_id": null
+                                },
+                                "shared_with": null
+                              },
+                              "properties": {
+                                "shared_by": {
+                                  "additionalProperties": false,
+                                  "description": "This object contains the details of the share group that is sharing the image. The share group details are specified in this object.",
+                                  "properties": {
+                                    "sharegroup_id": {
+                                      "description": "The ID of the share group.",
+                                      "type": "integer"
+                                    },
+                                    "sharegroup_label": {
+                                      "description": "A label linked to the share group.",
+                                      "type": "string"
+                                    },
+                                    "sharegroup_uuid": {
+                                      "description": "The unique identifier of the share group.",
+                                      "format": "uuid",
+                                      "type": "string"
+                                    },
+                                    "source_image_id": {
+                                      "description": "The ID of the source image being shared. This can be null if no specific source image is being referenced.",
+                                      "nullable": true,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "sharegroup_id",
+                                    "sharegroup_uuid",
+                                    "sharegroup_label",
+                                    "source_image_id"
+                                  ],
+                                  "type": "object"
+                                },
+                                "shared_with": {
+                                  "description": "This field is null in this case, meaning the image is not shared with anyone. The details of sharing are contained in the `shared_by` field.",
+                                  "nullable": true,
+                                  "type": "object"
+                                }
+                              },
+                              "required": [
+                                "shared_with",
+                                "shared_by"
+                              ],
+                              "title": "shared_by",
+                              "type": "object"
+                            }
+                          ]
+                        },
                         "is_public": {
                           "description": "__Filterable__, __Read-only__ Revealed as `true` if the image is a public distribution image. Private, account-specific images are listed as `false`.",
-                          "example": true,
+                          "example": false,
                           "readOnly": true,
                           "type": "boolean",
                           "x-akamai": {
@@ -42371,6 +48055,18 @@
                             ]
                           },
                           "x-linode-cli-display": 5,
+                          "x-linode-filterable": true
+                        },
+                        "is_shared": {
+                          "description": "__Filterable__, __Read-only__ Indicates if the image is a private image shared with other users.",
+                          "example": false,
+                          "readOnly": true,
+                          "type": "boolean",
+                          "x-akamai": {
+                            "labels": [
+                              "Filterable"
+                            ]
+                          },
                           "x-linode-filterable": true
                         },
                         "label": {
@@ -42517,6 +48213,28 @@
                           "x-linode-filterable": true
                         }
                       },
+                      "required": [
+                        "id",
+                        "tags",
+                        "type",
+                        "description",
+                        "label",
+                        "created",
+                        "updated",
+                        "size",
+                        "status",
+                        "capabilities",
+                        "is_public",
+                        "is_shared",
+                        "deprecated",
+                        "regions",
+                        "total_size",
+                        "image_sharing",
+                        "created_by",
+                        "expiry",
+                        "eol",
+                        "vendor"
+                      ],
                       "type": "object",
                       "x-akamai": {
                         "file-path": "schemas/image.yaml"
@@ -42635,7 +48353,7 @@
     },
     "/{apiVersion}/images/{imageId}": {
       "get": {
-        "description": "Get information about a single image. An image can be one of two types:\n\n- **Public image**. The `id` for these images begins with `linode/`. These images are generally available to all users. To limit the response to public images, don't include [authentication](https://techdocs.akamai.com/linode-api/reference/get-started#authentication) when calling this operation.\n\n- **Private image**. The `id` for these images begins with `private/`. These images are account-specific and only accessible to users with appropriate [grants](https://techdocs.akamai.com/linode-api/reference/get-user-grants). To view private images, you need to include authentication when calling this operation. The response will also include public images.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli images view linode/debian9\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    images:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Get information about a single image. An image can be one of two types:\n\n- **Public image**. The `id` for these images begins with `linode/`. These images are generally available to all users. To limit the response to public images, don't include [authentication](https://techdocs.akamai.com/linode-api/reference/get-started#authentication) when calling this operation.\n\n- **Private image**. The `id` for these images begins with `private/`. These images are account-specific and only accessible to users with appropriate [grants](https://techdocs.akamai.com/linode-api/reference/get-user-grants). To view private images, you need to include authentication when calling this operation. The response will also include public images.\n\n- **Shared image**. The `id` for these images begins with `shared/`. These are the images that are shared with the user.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli images view linode/debian9\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    images:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-image"
@@ -42718,14 +48436,117 @@
                     },
                     "id": {
                       "description": "__Read-only__ The unique identifier for each image.",
-                      "example": "linode/debian11",
+                      "example": "private/15",
                       "readOnly": true,
                       "type": "string",
                       "x-linode-cli-display": 1
                     },
+                    "image_sharing": {
+                      "description": "This object represents the sharing status of an image.",
+                      "oneOf": [
+                        {
+                          "additionalProperties": false,
+                          "example": {
+                            "shared_by": null,
+                            "shared_with": {
+                              "image_sharegroup_list_url": "/images/private/15/sharegroups",
+                              "sharegroup_count": 0
+                            }
+                          },
+                          "properties": {
+                            "shared_by": {
+                              "description": "This field is `null` in this case, meaning the image is not shared by any group. The `shared_with` field provides details on the image's share group.",
+                              "nullable": true,
+                              "type": "object"
+                            },
+                            "shared_with": {
+                              "additionalProperties": false,
+                              "description": "Specifies the group that the image is shared with, including the count of share groups and a URL to view the share groups.",
+                              "properties": {
+                                "image_sharegroup_list_url": {
+                                  "description": "A URL to view the list of share groups the image is shared with.",
+                                  "type": "string"
+                                },
+                                "sharegroup_count": {
+                                  "description": "The number of share groups the image is shared with.",
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "sharegroup_count",
+                                "image_sharegroup_list_url"
+                              ],
+                              "type": "object"
+                            }
+                          },
+                          "required": [
+                            "shared_with",
+                            "shared_by"
+                          ],
+                          "title": "shared_with",
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "example": {
+                            "shared_by": {
+                              "sharegroup_id": 3,
+                              "sharegroup_label": "label",
+                              "sharegroup_uuid": "8003abfe-6b03-41a1-9e4c-a234ae3060c8",
+                              "source_image_id": null
+                            },
+                            "shared_with": null
+                          },
+                          "properties": {
+                            "shared_by": {
+                              "additionalProperties": false,
+                              "description": "This object contains the details of the share group that is sharing the image. The share group details are specified in this object.",
+                              "properties": {
+                                "sharegroup_id": {
+                                  "description": "The ID of the share group.",
+                                  "type": "integer"
+                                },
+                                "sharegroup_label": {
+                                  "description": "A label linked to the share group.",
+                                  "type": "string"
+                                },
+                                "sharegroup_uuid": {
+                                  "description": "The unique identifier of the share group.",
+                                  "format": "uuid",
+                                  "type": "string"
+                                },
+                                "source_image_id": {
+                                  "description": "The ID of the source image being shared. This can be null if no specific source image is being referenced.",
+                                  "nullable": true,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "sharegroup_id",
+                                "sharegroup_uuid",
+                                "sharegroup_label",
+                                "source_image_id"
+                              ],
+                              "type": "object"
+                            },
+                            "shared_with": {
+                              "description": "This field is null in this case, meaning the image is not shared with anyone. The details of sharing are contained in the `shared_by` field.",
+                              "nullable": true,
+                              "type": "object"
+                            }
+                          },
+                          "required": [
+                            "shared_with",
+                            "shared_by"
+                          ],
+                          "title": "shared_by",
+                          "type": "object"
+                        }
+                      ]
+                    },
                     "is_public": {
                       "description": "__Filterable__, __Read-only__ Revealed as `true` if the image is a public distribution image. Private, account-specific images are listed as `false`.",
-                      "example": true,
+                      "example": false,
                       "readOnly": true,
                       "type": "boolean",
                       "x-akamai": {
@@ -42734,6 +48555,18 @@
                         ]
                       },
                       "x-linode-cli-display": 5,
+                      "x-linode-filterable": true
+                    },
+                    "is_shared": {
+                      "description": "__Filterable__, __Read-only__ Indicates if the image is a private image shared with other users.",
+                      "example": false,
+                      "readOnly": true,
+                      "type": "boolean",
+                      "x-akamai": {
+                        "labels": [
+                          "Filterable"
+                        ]
+                      },
                       "x-linode-filterable": true
                     },
                     "label": {
@@ -42880,6 +48713,28 @@
                       "x-linode-filterable": true
                     }
                   },
+                  "required": [
+                    "id",
+                    "tags",
+                    "type",
+                    "description",
+                    "label",
+                    "created",
+                    "updated",
+                    "size",
+                    "status",
+                    "capabilities",
+                    "is_public",
+                    "is_shared",
+                    "deprecated",
+                    "regions",
+                    "total_size",
+                    "image_sharing",
+                    "created_by",
+                    "expiry",
+                    "eol",
+                    "vendor"
+                  ],
                   "type": "object",
                   "x-akamai": {
                     "file-path": "schemas/image.yaml"
@@ -42974,7 +48829,6 @@
             "application/json": {
               "schema": {
                 "additionalProperties": false,
-                "description": "Image object.",
                 "properties": {
                   "capabilities": {
                     "description": "__Read-only__ A list of the possible capabilities of this image.\n\n- `cloud-init`. The image supports the cloud-init multi-distribution method with our [Metadata service](https://www.linode.com/docs/products/compute/compute-instances/guides/metadata/#troubleshoot-metadata-and-cloud-init). This only applies to public images.\n\n- `distributed-sites`. Whether the image can be used in distributed compute regions. Compared to a core compute region, distributed compute regions offer limited functionality, but they're globally distributed. Your image can be geographically closer to you, potentially letting you deploy it quicker. See [Regions and images](https://techdocs.akamai.com/cloud-computing/docs/images#regions-and-images) for complete details.",
@@ -43061,6 +48915,18 @@
                       ]
                     },
                     "x-linode-cli-display": 5,
+                    "x-linode-filterable": true
+                  },
+                  "is_shared": {
+                    "description": "__Filterable__, __Read-only__ Indicates if the image is a private image shared with other users.",
+                    "example": "{{is_shared}}",
+                    "readOnly": true,
+                    "type": "boolean",
+                    "x-akamai": {
+                      "labels": [
+                        "Filterable"
+                      ]
+                    },
                     "x-linode-filterable": true
                   },
                   "label": {
@@ -43209,7 +49075,7 @@
                 },
                 "type": "object",
                 "x-akamai": {
-                  "file-path": "schemas/image.yaml"
+                  "file-path": "schemas/put-image.yaml"
                 }
               },
               "x-example": {
@@ -43296,14 +49162,117 @@
                     },
                     "id": {
                       "description": "__Read-only__ The unique identifier for each image.",
-                      "example": "linode/debian11",
+                      "example": "private/15",
                       "readOnly": true,
                       "type": "string",
                       "x-linode-cli-display": 1
                     },
+                    "image_sharing": {
+                      "description": "This object represents the sharing status of an image.",
+                      "oneOf": [
+                        {
+                          "additionalProperties": false,
+                          "example": {
+                            "shared_by": null,
+                            "shared_with": {
+                              "image_sharegroup_list_url": "/images/private/15/sharegroups",
+                              "sharegroup_count": 0
+                            }
+                          },
+                          "properties": {
+                            "shared_by": {
+                              "description": "This field is `null` in this case, meaning the image is not shared by any group. The `shared_with` field provides details on the image's share group.",
+                              "nullable": true,
+                              "type": "object"
+                            },
+                            "shared_with": {
+                              "additionalProperties": false,
+                              "description": "Specifies the group that the image is shared with, including the count of share groups and a URL to view the share groups.",
+                              "properties": {
+                                "image_sharegroup_list_url": {
+                                  "description": "A URL to view the list of share groups the image is shared with.",
+                                  "type": "string"
+                                },
+                                "sharegroup_count": {
+                                  "description": "The number of share groups the image is shared with.",
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "sharegroup_count",
+                                "image_sharegroup_list_url"
+                              ],
+                              "type": "object"
+                            }
+                          },
+                          "required": [
+                            "shared_with",
+                            "shared_by"
+                          ],
+                          "title": "shared_with",
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "example": {
+                            "shared_by": {
+                              "sharegroup_id": 3,
+                              "sharegroup_label": "label",
+                              "sharegroup_uuid": "8003abfe-6b03-41a1-9e4c-a234ae3060c8",
+                              "source_image_id": null
+                            },
+                            "shared_with": null
+                          },
+                          "properties": {
+                            "shared_by": {
+                              "additionalProperties": false,
+                              "description": "This object contains the details of the share group that is sharing the image. The share group details are specified in this object.",
+                              "properties": {
+                                "sharegroup_id": {
+                                  "description": "The ID of the share group.",
+                                  "type": "integer"
+                                },
+                                "sharegroup_label": {
+                                  "description": "A label linked to the share group.",
+                                  "type": "string"
+                                },
+                                "sharegroup_uuid": {
+                                  "description": "The unique identifier of the share group.",
+                                  "format": "uuid",
+                                  "type": "string"
+                                },
+                                "source_image_id": {
+                                  "description": "The ID of the source image being shared. This can be null if no specific source image is being referenced.",
+                                  "nullable": true,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "sharegroup_id",
+                                "sharegroup_uuid",
+                                "sharegroup_label",
+                                "source_image_id"
+                              ],
+                              "type": "object"
+                            },
+                            "shared_with": {
+                              "description": "This field is null in this case, meaning the image is not shared with anyone. The details of sharing are contained in the `shared_by` field.",
+                              "nullable": true,
+                              "type": "object"
+                            }
+                          },
+                          "required": [
+                            "shared_with",
+                            "shared_by"
+                          ],
+                          "title": "shared_by",
+                          "type": "object"
+                        }
+                      ]
+                    },
                     "is_public": {
                       "description": "__Filterable__, __Read-only__ Revealed as `true` if the image is a public distribution image. Private, account-specific images are listed as `false`.",
-                      "example": true,
+                      "example": false,
                       "readOnly": true,
                       "type": "boolean",
                       "x-akamai": {
@@ -43312,6 +49281,18 @@
                         ]
                       },
                       "x-linode-cli-display": 5,
+                      "x-linode-filterable": true
+                    },
+                    "is_shared": {
+                      "description": "__Filterable__, __Read-only__ Indicates if the image is a private image shared with other users.",
+                      "example": false,
+                      "readOnly": true,
+                      "type": "boolean",
+                      "x-akamai": {
+                        "labels": [
+                          "Filterable"
+                        ]
+                      },
                       "x-linode-filterable": true
                     },
                     "label": {
@@ -43458,13 +49439,35 @@
                       "x-linode-filterable": true
                     }
                   },
+                  "required": [
+                    "id",
+                    "tags",
+                    "type",
+                    "description",
+                    "label",
+                    "created",
+                    "updated",
+                    "size",
+                    "status",
+                    "capabilities",
+                    "is_public",
+                    "is_shared",
+                    "deprecated",
+                    "regions",
+                    "total_size",
+                    "image_sharing",
+                    "created_by",
+                    "expiry",
+                    "eol",
+                    "vendor"
+                  ],
                   "type": "object",
                   "x-akamai": {
                     "file-path": "schemas/image.yaml"
                   }
                 },
                 "x-example": {
-                  "x-ref": "../examples/get-image-200.json"
+                  "x-ref": "../examples/put-image-200.json"
                 },
                 "x-linode-cli-subtables": [
                   "regions"
@@ -43793,14 +49796,117 @@
                     },
                     "id": {
                       "description": "__Read-only__ The unique identifier for each image.",
-                      "example": "linode/debian11",
+                      "example": "private/15",
                       "readOnly": true,
                       "type": "string",
                       "x-linode-cli-display": 1
                     },
+                    "image_sharing": {
+                      "description": "This object represents the sharing status of an image.",
+                      "oneOf": [
+                        {
+                          "additionalProperties": false,
+                          "example": {
+                            "shared_by": null,
+                            "shared_with": {
+                              "image_sharegroup_list_url": "/images/private/15/sharegroups",
+                              "sharegroup_count": 0
+                            }
+                          },
+                          "properties": {
+                            "shared_by": {
+                              "description": "This field is `null` in this case, meaning the image is not shared by any group. The `shared_with` field provides details on the image's share group.",
+                              "nullable": true,
+                              "type": "object"
+                            },
+                            "shared_with": {
+                              "additionalProperties": false,
+                              "description": "Specifies the group that the image is shared with, including the count of share groups and a URL to view the share groups.",
+                              "properties": {
+                                "image_sharegroup_list_url": {
+                                  "description": "A URL to view the list of share groups the image is shared with.",
+                                  "type": "string"
+                                },
+                                "sharegroup_count": {
+                                  "description": "The number of share groups the image is shared with.",
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "sharegroup_count",
+                                "image_sharegroup_list_url"
+                              ],
+                              "type": "object"
+                            }
+                          },
+                          "required": [
+                            "shared_with",
+                            "shared_by"
+                          ],
+                          "title": "shared_with",
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "example": {
+                            "shared_by": {
+                              "sharegroup_id": 3,
+                              "sharegroup_label": "label",
+                              "sharegroup_uuid": "8003abfe-6b03-41a1-9e4c-a234ae3060c8",
+                              "source_image_id": null
+                            },
+                            "shared_with": null
+                          },
+                          "properties": {
+                            "shared_by": {
+                              "additionalProperties": false,
+                              "description": "This object contains the details of the share group that is sharing the image. The share group details are specified in this object.",
+                              "properties": {
+                                "sharegroup_id": {
+                                  "description": "The ID of the share group.",
+                                  "type": "integer"
+                                },
+                                "sharegroup_label": {
+                                  "description": "A label linked to the share group.",
+                                  "type": "string"
+                                },
+                                "sharegroup_uuid": {
+                                  "description": "The unique identifier of the share group.",
+                                  "format": "uuid",
+                                  "type": "string"
+                                },
+                                "source_image_id": {
+                                  "description": "The ID of the source image being shared. This can be null if no specific source image is being referenced.",
+                                  "nullable": true,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "sharegroup_id",
+                                "sharegroup_uuid",
+                                "sharegroup_label",
+                                "source_image_id"
+                              ],
+                              "type": "object"
+                            },
+                            "shared_with": {
+                              "description": "This field is null in this case, meaning the image is not shared with anyone. The details of sharing are contained in the `shared_by` field.",
+                              "nullable": true,
+                              "type": "object"
+                            }
+                          },
+                          "required": [
+                            "shared_with",
+                            "shared_by"
+                          ],
+                          "title": "shared_by",
+                          "type": "object"
+                        }
+                      ]
+                    },
                     "is_public": {
                       "description": "__Filterable__, __Read-only__ Revealed as `true` if the image is a public distribution image. Private, account-specific images are listed as `false`.",
-                      "example": true,
+                      "example": false,
                       "readOnly": true,
                       "type": "boolean",
                       "x-akamai": {
@@ -43809,6 +49915,18 @@
                         ]
                       },
                       "x-linode-cli-display": 5,
+                      "x-linode-filterable": true
+                    },
+                    "is_shared": {
+                      "description": "__Filterable__, __Read-only__ Indicates if the image is a private image shared with other users.",
+                      "example": false,
+                      "readOnly": true,
+                      "type": "boolean",
+                      "x-akamai": {
+                        "labels": [
+                          "Filterable"
+                        ]
+                      },
                       "x-linode-filterable": true
                     },
                     "label": {
@@ -43955,6 +50073,28 @@
                       "x-linode-filterable": true
                     }
                   },
+                  "required": [
+                    "id",
+                    "tags",
+                    "type",
+                    "description",
+                    "label",
+                    "created",
+                    "updated",
+                    "size",
+                    "status",
+                    "capabilities",
+                    "is_public",
+                    "is_shared",
+                    "deprecated",
+                    "regions",
+                    "total_size",
+                    "image_sharing",
+                    "created_by",
+                    "expiry",
+                    "eol",
+                    "vendor"
+                  ],
                   "type": "object",
                   "x-akamai": {
                     "file-path": "schemas/image.yaml"
@@ -44074,6 +50214,251 @@
       },
       "x-linode-cli-command": "images"
     },
+    "/{apiVersion}/images/{imageId}/sharegroups": {
+      "get": {
+        "description": "Get all share groups where the given `private` image is present.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    images:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "externalDocs": {
+          "description": "See documentation for this operation in Akamai's Linode API",
+          "url": "https://techdocs.akamai.com/linode-api/reference/get-images-sharegroups-image"
+        },
+        "operationId": "get-images-sharegroups-image",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "ShareGroup object.",
+                        "properties": {
+                          "created": {
+                            "description": "__Read-only__ The time when this share group was created.",
+                            "example": "2025-04-14T22:44:02",
+                            "format": "date-time",
+                            "readOnly": true,
+                            "type": "string"
+                          },
+                          "description": {
+                            "description": "A detailed description of this share group.",
+                            "example": "Group of base operating system images and engineers used for CI/CD pipelines and infrastructure automation",
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "expiry": {
+                            "description": "__Read-only__ The time when the share group expires.",
+                            "example": null,
+                            "format": "date-time",
+                            "nullable": true,
+                            "readOnly": true,
+                            "type": "string"
+                          },
+                          "id": {
+                            "description": "A numeric identifier for the share group. This is primarily used within the system for database operations and is read-only.",
+                            "example": 1,
+                            "type": "integer"
+                          },
+                          "images_count": {
+                            "description": "__Read-only__ The total number of images currently belonging to the share group.",
+                            "readOnly": true,
+                            "type": "integer"
+                          },
+                          "is_suspended": {
+                            "description": "__Read-only__ Indicates whether the share group is currently suspended.",
+                            "example": false,
+                            "readOnly": true,
+                            "type": "boolean"
+                          },
+                          "label": {
+                            "description": "__Filterable__ Label for the share group.",
+                            "example": "DevOps Base Images",
+                            "type": "string",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ]
+                            },
+                            "x-linode-filterable": true
+                          },
+                          "members_count": {
+                            "description": "__Read-only__ The number of members who have access to the share group.",
+                            "readOnly": true,
+                            "type": "integer"
+                          },
+                          "updated": {
+                            "description": "__Read-only__ The time when this share group was last updated.",
+                            "example": null,
+                            "format": "date-time",
+                            "nullable": true,
+                            "readOnly": true,
+                            "type": "string"
+                          },
+                          "uuid": {
+                            "description": "A universally unique identifier for the share group. Used by clients to reference a specific share group when creating a single-use token.",
+                            "example": "1533863e-16a4-47b5-b829-ac0f35c13278",
+                            "format": "uuid",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "uuid",
+                          "label",
+                          "description",
+                          "is_suspended",
+                          "created",
+                          "updated",
+                          "expiry",
+                          "images_count",
+                          "members_count"
+                        ],
+                        "type": "object",
+                        "x-akamai": {
+                          "file-path": "schemas/sharegroups.yaml"
+                        }
+                      },
+                      "type": "array"
+                    },
+                    "page": {
+                      "description": "__Read-only__ The current [page](https://techdocs.akamai.com/linode-api/reference/pagination).",
+                      "example": 1,
+                      "readOnly": true,
+                      "type": "integer"
+                    },
+                    "pages": {
+                      "description": "__Read-only__ The total number of [pages](https://techdocs.akamai.com/linode-api/reference/pagination).",
+                      "example": 1,
+                      "readOnly": true,
+                      "type": "integer"
+                    },
+                    "results": {
+                      "description": "__Read-only__ The total number of results.",
+                      "example": 1,
+                      "readOnly": true,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "page",
+                    "pages",
+                    "results"
+                  ],
+                  "type": "object",
+                  "x-akamai": {
+                    "file-path": "schemas/get-images-sharegroups-200.yaml"
+                  }
+                },
+                "x-example": {
+                  "x-ref": "../examples/get-images-sharegroups-image-200.json"
+                }
+              }
+            },
+            "description": "Returns a paginated list of share groups."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "errors": {
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "An object for describing a single error that occurred during the processing of a request.",
+                        "properties": {
+                          "field": {
+                            "description": "The field in the request that caused this error. This may be a path, separated by periods in the case of nested fields. In some cases this may come back as `null` if the error is not specific to any single element of the request.",
+                            "example": "fieldname",
+                            "type": "string"
+                          },
+                          "reason": {
+                            "description": "What happened to cause this error. In most cases, this can be fixed immediately by changing the data you sent in the request, but in some cases you will be instructed to [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) or perform some other action before you can complete the request successfully.",
+                            "example": "fieldname must be a valid value",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-akamai": {
+                          "file-path": "schemas/error-object.yaml"
+                        }
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "See [Errors](https://techdocs.akamai.com/linode-api/reference/errors) for the range of possible error response codes."
+          }
+        },
+        "security": [
+          {
+            "personalAccessToken": []
+          },
+          {
+            "oauth": [
+              "images:read_only"
+            ]
+          }
+        ],
+        "summary": "List share groups by image",
+        "tags": [
+          "Private image sharing"
+        ],
+        "x-akamai": {
+          "tabs": [
+            {
+              "syntax": "images:read_only",
+              "title": "OAuth scopes",
+              "url": "https://techdocs.akamai.com/linode-api/reference/get-started#oauth"
+            }
+          ]
+        },
+        "x-linode-redoc-load-ids": true
+      },
+      "parameters": [
+        {
+          "description": "__Enum__ Call either the `v4` URL, or `v4beta` for operations still in Beta.",
+          "example": "{{apiVersion}}",
+          "in": "path",
+          "name": "apiVersion",
+          "required": true,
+          "schema": {
+            "enum": [
+              "v4",
+              "v4beta"
+            ],
+            "type": "string"
+          },
+          "x-akamai": {
+            "file-path": "parameters/api-version-path.yaml"
+          }
+        },
+        {
+          "description": "Slug identifier assigned to the private image upon creation.\nThis identifier includes a slash (/), which must be URL-encoded in requests to prevent breaking the URL structure.",
+          "example": "{{imageId}}",
+          "in": "path",
+          "name": "imageId",
+          "required": true,
+          "schema": {
+            "allowReserved": true,
+            "example": "private/7",
+            "type": "string"
+          },
+          "x-akamai": {
+            "file-path": "parameters/image-id-path-w-private-slug.yaml"
+          }
+        }
+      ],
+      "x-akamai": {
+        "file-path": "paths/images-id-sharegroups.yaml",
+        "path-info": "/{apiVersion}/images/{imageId}/sharegroups"
+      }
+    },
     "/{apiVersion}/linode/instances": {
       "post": {
         "description": "Creates a Linode Instance on your Account. In order for this request to complete successfully, your User must have the `add_linodes` grant. Creating a new Linode will incur a charge on your Account.\n\nLinodes can be created using one of the available Types. Run [List Linode types](https://techdocs.akamai.com/linode-api/reference/get-linode-types) to get more information about each Type's specs and cost.\n\nLinodes can be created in any one of our available Regions, which are accessible from the [List regions](https://techdocs.akamai.com/linode-api/reference/get-regions) operation.\n\nIn an effort to fight spam, Linode restricts outbound connections on ports 25, 465, and 587 on all Linodes for new accounts created after November 5th, 2019. For more information, see our guide on [Running a Mail Server](https://www.linode.com/docs/guides/running-a-mail-server/).\n\n__Important__. You must be an unrestricted User in order to add or modify tags on Linodes.\n\nLinodes can be created in a number of ways:\n\n- Using a Linode Public Image distribution or a Private Image you created based on another Linode.\n\n  - Run the [List images](https://techdocs.akamai.com/linode-api/reference/get-images) operation with authentication to view all available Images.\n\n  - The Linode will be `running` after it completes `provisioning`.\n  - A default config with two Disks, one being a 512 swap disk, is created.\n    - `swap_size` can be used to customize the swap disk size.\n  - Requires a `root_pass` be supplied to use for the root User's Account.\n  - It is recommended to supply SSH keys for the root User using the `authorized_keys` field.\n  - You may also supply a list of usernames via the `authorized_users` field.\n    - These users must have an SSH Key associated with your Profile first. See the [Add an SSH key](https://techdocs.akamai.com/linode-api/reference/post-add-ssh-key)) operation for more information.\n\n- Using cloud-init with [Metadata](https://www.linode.com/docs/products/compute/compute-instances/guides/metadata/).\n  - Automate system configuration and software installation by providing a base-64 encoded [cloud-config](https://www.linode.com/docs/products/compute/compute-instances/guides/metadata-cloud-config/) file.\n  - Requires a compatible Image. You can determine compatible Images by checking for `cloud-init` under `capabilities` when running [List images](https://techdocs.akamai.com/linode-api/reference/get-images).\n  - Requires a compatible Region.  You can determine compatible Regions by checking for `Metadata` under `capabilities` when running [List regions](https://techdocs.akamai.com/linode-api/reference/get-regions).\n\n- Using a StackScript.\n\n  - Run [List StackScripts](https://techdocs.akamai.com/linode-api/reference/get-stack-scripts) for a list of available StackScripts.\n  - The Linode will be `running` after it completes `provisioning`.\n  - Requires a compatible Image to be supplied.\n    - Run [Get a StackScript](https://techdocs.akamai.com/linode-api/reference/get-stack-script) for compatible Images.\n  - Requires a `root_pass` be supplied to use for the root User's Account.\n  - It is recommended to supply SSH keys for the root User using the `authorized_keys` field.\n  - You may also supply a list of usernames via the `authorized_users` field.\n    - These users must have an SSH Key associated with your Profile first. See [Add an SSH key](https://techdocs.akamai.com/linode-api/reference/post-add-ssh-key) for more information.\n\n- Using one of your other Linode's backups.\n  - You must create a Linode large enough to accommodate the Backup's size.\n  - The Disks and Config will match that of the Linode that was backed up.\n  - The `root_pass` will match that of the Linode that was backed up.\n\n- Attached to a private VLAN.\n  - Review the `interfaces` property of the [Request Body Schema](https://techdocs.akamai.com/linode-api/reference/post-linode-instance) for details.\n  - For more information, see our guide on [Getting Started with VLANs](https://www.linode.com/docs/products/networking/vlans/get-started/).\n\n- Create an empty Linode.\n  - The Linode will remain `offline` and must be manually started.\n    - Run [Boot a Linode](https://techdocs.akamai.com/linode-api/reference/post-boot-linode-instance).\n  - Disks and Configs must be created manually.\n  - This is only recommended for advanced use cases.\n\nDepending on your [account settings](https://techdocs.akamai.com/linode-api/reference/get-account-settings), you can choose between legacy configuration interfaces or Linode interfaces when creating a Linode. Only one type of interface is allowed per Linode. The `interface_generation` field lets you select one interface type for new Linodes when both legacy and Linode interfaces options are available on your account. If a Linode is configured with a Linode interface, legacy configuration interfaces can no longer be used on that Linode.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli linodes create \\\n  --label linode123 \\\n  --root_pass aComplex@Password \\\n  --booted true \\\n  --stackscript_id 10079 \\\n  --stackscript_data '{\"gh_username\": \"linode\"}' \\\n  --region us-east \\\n  --disk_encryption enabled\\\n  --placement_group.id 528 \\\n  --type g6-standard-2 \\\n  --authorized_keys \"ssh-rsa AAAA_valid_public_ssh_key_123456785== user@their-computer\" \\\n  --authorized_users \"myUser\" \\\n  --authorized_users \"secondaryUser\" \\\n  --metadata.user_data \"I2Nsb3VkLWNvbmZpZw==\" \\\n  --firewall_id 9000\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    linodes:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
@@ -44133,6 +50518,18 @@
                         "description": "An Image ID to deploy the Linode Disk from.\n\nRun the [List images](https://techdocs.akamai.com/linode-api/reference/get-images) operation with authentication to view all available Images. Official Linode Images start with `linode/`, while your Account's Images start with `private/`. Creating a disk from a Private Image requires `read_only` or `read_write` permissions for that Image. Run the [Update a user's grants](https://techdocs.akamai.com/linode-api/reference/put-user-grants) operation to adjust permissions for an Account Image.",
                         "example": "linode/debian9",
                         "type": "string"
+                      },
+                      "maintenance_policy": {
+                        "description": "__Beta__ Defines the maintenance policy for this Linode. Choose from the following policies:\n\n- `linode/migrate`: Migrates the Linode to a new host while it remains fully operational (with some performance degradation). Recommended for maximizing availability.\n- `linode/power_off_on`: Powers off the Linode at the start of the maintenance event and reboots it once the maintenance finishes. Recommended for maximizing performance.\n\nReview [maintenance policy](https://techdocs.akamai.com/cloud-computing/docs/host-maintenance-policy) documentation for more details.",
+                        "enum": [
+                          "linode/migrate",
+                          "linode/power_off_on"
+                        ],
+                        "example": "linode/migrate",
+                        "type": "string",
+                        "x-akamai": {
+                          "status": "BETA"
+                        }
                       },
                       "metadata": {
                         "additionalProperties": false,
@@ -44321,12 +50718,8 @@
                                               "items": {
                                                 "properties": {
                                                   "range": {
-                                                    "default": null,
                                                     "description": "Your assigned IPv6 range in CIDR notation (`2001:0db8::1/64`) or prefix (`/64`).\n- The prefix of `/64` or `/56` block of IPv6 addresses.\n- If provided in CIDR notation, the prefix must be within the assigned ranges for the Linode.",
-                                                    "example": [
-                                                      "2001:0a0a::1/64",
-                                                      "/64"
-                                                    ],
+                                                    "example": "2001:0a0a::1/64",
                                                     "type": "string"
                                                   }
                                                 },
@@ -44486,7 +50879,6 @@
                                                 "additionalProperties": false,
                                                 "properties": {
                                                   "range": {
-                                                    "default": null,
                                                     "description": "CIDR notation of a range (`1.2.3.4/24`) or prefix only (`/24`).\n- When only the prefix is provided, then an available range of that size within the VPC's subnet is automatically selected.\n- If specified as CIDR notation, it must belong to the VPC subnet. All addresses in the range must not be taken by any other Linode or interfaces in the VPC subnet and must not include any of the first two or last two addresses of the VPC subnet.",
                                                     "example": [
                                                       "192.168.100.100/28",
@@ -44495,12 +50887,11 @@
                                                       "10.11.12.0/24",
                                                       "auto"
                                                     ],
-                                                    "nullable": true,
                                                     "type": "string"
                                                   }
                                                 },
                                                 "required": [
-                                                  "address"
+                                                  "range"
                                                 ],
                                                 "type": "object"
                                               },
@@ -45047,6 +51438,18 @@
                       "nullable": true,
                       "readOnly": true,
                       "type": "integer"
+                    },
+                    "maintenance_policy": {
+                      "description": "__Beta__ The maintenance policy configured by the user for this Linode. Review [maintenance policy](https://techdocs.akamai.com/cloud-computing/docs/host-maintenance-policy) documentation for more details.",
+                      "enum": [
+                        "linode/migrate",
+                        "linode/power_off_on"
+                      ],
+                      "example": "linode/migrate",
+                      "type": "string",
+                      "x-akamai": {
+                        "status": "BETA"
+                      }
                     },
                     "placement_group": {
                       "additionalProperties": false,
@@ -45711,6 +52114,19 @@
                             "readOnly": true,
                             "type": "integer"
                           },
+                          "maintenance_policy": {
+                            "description": "__Beta__, __Read-only__ The maintenance policy configured by the user for this Linode. Review [maintenance policy](https://techdocs.akamai.com/cloud-computing/docs/host-maintenance-policy) documentation for more details.",
+                            "enum": [
+                              "linode/migrate",
+                              "linode/power_off_on"
+                            ],
+                            "example": "linode/migrate",
+                            "readOnly": true,
+                            "type": "string",
+                            "x-akamai": {
+                              "status": "BETA"
+                            }
+                          },
                           "placement_group": {
                             "additionalProperties": false,
                             "description": "__Read-only__ Details on the [placement group](https://www.linode.com/docs/products/compute/compute-instances/guides/placement-groups/) that this Linode belongs to. Empty if the Linode isn't in a placement group.",
@@ -46302,6 +52718,19 @@
                       "nullable": true,
                       "readOnly": true,
                       "type": "integer"
+                    },
+                    "maintenance_policy": {
+                      "description": "__Beta__, __Read-only__ The maintenance policy configured by the user for this Linode. Review [maintenance policy](https://techdocs.akamai.com/cloud-computing/docs/host-maintenance-policy) documentation for more details.",
+                      "enum": [
+                        "linode/migrate",
+                        "linode/power_off_on"
+                      ],
+                      "example": "linode/migrate",
+                      "readOnly": true,
+                      "type": "string",
+                      "x-akamai": {
+                        "status": "BETA"
+                      }
                     },
                     "placement_group": {
                       "additionalProperties": false,
@@ -46902,6 +53331,18 @@
                     "readOnly": true,
                     "type": "integer"
                   },
+                  "maintenance_policy": {
+                    "description": "__Beta__ The maintenance policy configured by the user for this Linode. Review [maintenance policy](https://techdocs.akamai.com/cloud-computing/docs/host-maintenance-policy) documentation for more details.",
+                    "enum": [
+                      "linode/migrate",
+                      "linode/power_off_on"
+                    ],
+                    "example": "{{maintenance_policy}}",
+                    "type": "string",
+                    "x-akamai": {
+                      "status": "BETA"
+                    }
+                  },
                   "placement_group": {
                     "additionalProperties": false,
                     "description": "__Read-only__ Details on the [placement group](https://www.linode.com/docs/products/compute/compute-instances/guides/placement-groups/) that this Linode belongs to. Empty if the Linode isn't in a placement group.",
@@ -47358,6 +53799,18 @@
                       "nullable": true,
                       "readOnly": true,
                       "type": "integer"
+                    },
+                    "maintenance_policy": {
+                      "description": "__Beta__ The maintenance policy configured by the user for this Linode. Review [maintenance policy](https://techdocs.akamai.com/cloud-computing/docs/host-maintenance-policy) documentation for more details.",
+                      "enum": [
+                        "linode/migrate",
+                        "linode/power_off_on"
+                      ],
+                      "example": "linode/migrate",
+                      "type": "string",
+                      "x-akamai": {
+                        "status": "BETA"
+                      }
                     },
                     "placement_group": {
                       "additionalProperties": false,
@@ -49588,6 +56041,18 @@
                     "example": "{{linode_id}}",
                     "type": "integer"
                   },
+                  "maintenance_policy": {
+                    "description": "__Beta__ Defines the maintenance policy for the new Linode. If you don't provide it, the new Linode inherits the maintenance policy from the original Linode. Review [maintenance policy](https://techdocs.akamai.com/cloud-computing/docs/host-maintenance-policy) documentation for more details.",
+                    "enum": [
+                      "linode/migrate",
+                      "linode/power_off_on"
+                    ],
+                    "example": "{{maintenance_policy}}",
+                    "type": "string",
+                    "x-akamai": {
+                      "status": "BETA"
+                    }
+                  },
                   "metadata": {
                     "additionalProperties": false,
                     "description": "__Write-only__ An object containing user-defined data relevant to the creation of Linodes.",
@@ -49922,6 +56387,18 @@
                       "nullable": true,
                       "readOnly": true,
                       "type": "integer"
+                    },
+                    "maintenance_policy": {
+                      "description": "__Beta__ The maintenance policy configured by the user for this Linode. Review [maintenance policy](https://techdocs.akamai.com/cloud-computing/docs/host-maintenance-policy) documentation for more details.",
+                      "enum": [
+                        "linode/migrate",
+                        "linode/power_off_on"
+                      ],
+                      "example": "linode/migrate",
+                      "type": "string",
+                      "x-akamai": {
+                        "status": "BETA"
+                      }
                     },
                     "placement_group": {
                       "additionalProperties": false,
@@ -53910,7 +60387,7 @@
         ],
         "summary": "Add a configuration profile interface",
         "tags": [
-          "Interfaces"
+          "Configuration profile interfaces"
         ],
         "x-akamai": {
           "tabs": [
@@ -54171,7 +60648,7 @@
         ],
         "summary": "List configuration profile interfaces",
         "tags": [
-          "Interfaces"
+          "Configuration profile interfaces"
         ],
         "x-akamai": {
           "tabs": [
@@ -54357,7 +60834,7 @@
         ],
         "summary": "Reorder configuration profile interfaces",
         "tags": [
-          "Interfaces"
+          "Configuration profile interfaces"
         ],
         "x-akamai": {
           "tabs": [
@@ -54624,7 +61101,7 @@
         ],
         "summary": "Get a configuration profile interface",
         "tags": [
-          "Interfaces"
+          "Configuration profile interfaces"
         ],
         "x-akamai": {
           "tabs": [
@@ -54897,7 +61374,7 @@
         ],
         "summary": "Update a configuration profile interface",
         "tags": [
-          "Interfaces"
+          "Configuration profile interfaces"
         ],
         "x-akamai": {
           "tabs": [
@@ -54991,7 +61468,7 @@
         ],
         "summary": "Delete a configuration profile interface",
         "tags": [
-          "Interfaces"
+          "Configuration profile interfaces"
         ],
         "x-akamai": {
           "tabs": [
@@ -57293,7 +63770,10 @@
                 "properties": {
                   "firewall_ids": {
                     "description": "A complete list of firewall IDs to assign to this Linode or NodeBalancer. This operation replaces any existing assignments. To remove all firewalls, pass an empty list, `[]`.",
-                    "example": 1234,
+                    "example": [
+                      1,
+                      2
+                    ],
                     "items": {
                       "type": "integer"
                     },
@@ -58005,12 +64485,8 @@
                                 "items": {
                                   "properties": {
                                     "range": {
-                                      "default": null,
                                       "description": "Your assigned IPv6 range in CIDR notation (`2001:0db8::1/64`) or prefix (`/64`).\n- The prefix of `/64` or `/56` block of IPv6 addresses.\n- If provided in CIDR notation, the prefix must be within the assigned ranges for the Linode.",
-                                      "example": [
-                                        "2001:0a0a::1/64",
-                                        "/64"
-                                      ],
+                                      "example": "2001:0a0a::1/64",
                                       "type": "string"
                                     }
                                   },
@@ -58170,7 +64646,6 @@
                                   "additionalProperties": false,
                                   "properties": {
                                     "range": {
-                                      "default": null,
                                       "description": "CIDR notation of a range (`1.2.3.4/24`) or prefix only (`/24`).\n- When only the prefix is provided, then an available range of that size within the VPC's subnet is automatically selected.\n- If specified as CIDR notation, it must belong to the VPC subnet. All addresses in the range must not be taken by any other Linode or interfaces in the VPC subnet and must not include any of the first two or last two addresses of the VPC subnet.",
                                       "example": [
                                         "192.168.100.100/28",
@@ -58179,12 +64654,11 @@
                                         "10.11.12.0/24",
                                         "auto"
                                       ],
-                                      "nullable": true,
                                       "type": "string"
                                     }
                                   },
                                   "required": [
-                                    "address"
+                                    "range"
                                   ],
                                   "type": "object"
                                 },
@@ -58884,558 +65358,583 @@
                   "ex-public": {
                     "summary": "Public interface",
                     "value": {
-                      "created": "2025-01-01T00:01:01",
-                      "default_route": {
-                        "ipv4": true,
-                        "ipv6": true
-                      },
-                      "id": 1234,
-                      "mac_address": "22:00:AB:CD:EF:01",
-                      "public": {
-                        "ipv4": {
-                          "addresses": [
-                            {
-                              "address": "172.30.0.50",
-                              "primary": true
-                            }
-                          ],
-                          "shared": [
-                            {
-                              "address": "172.30.0.51",
-                              "linode_id": 12345
-                            }
-                          ]
-                        },
-                        "ipv6": {
-                          "ranges": [
-                            {
-                              "range": "2600:3c09:e001:59::/64",
-                              "route_target": "2600:3c09::ff:feab:cdef"
+                      "interfaces": [
+                        {
+                          "created": "2025-01-01T00:01:01",
+                          "default_route": {
+                            "ipv4": true,
+                            "ipv6": true
+                          },
+                          "id": 1234,
+                          "mac_address": "22:00:AB:CD:EF:01",
+                          "public": {
+                            "ipv4": {
+                              "addresses": [
+                                {
+                                  "address": "172.30.0.50",
+                                  "primary": true
+                                }
+                              ],
+                              "shared": [
+                                {
+                                  "address": "172.30.0.51",
+                                  "linode_id": 12345
+                                }
+                              ]
                             },
-                            {
-                              "range": "2600:3c09:e001:5a::/64",
-                              "route_target": "2600:3c09::ff:feab:cdef"
+                            "ipv6": {
+                              "ranges": [
+                                {
+                                  "range": "2001:DB8::/64",
+                                  "route_target": "2600:3c09::ff:feab:cdef"
+                                },
+                                {
+                                  "range": "2001:DB8::/64",
+                                  "route_target": "2600:3c09::ff:feab:cdef"
+                                }
+                              ],
+                              "shared": [
+                                {
+                                  "range": "2001:DB8::/64",
+                                  "route_target": null
+                                }
+                              ],
+                              "slaac": [
+                                {
+                                  "address": "2600:3c09::ff:feab:cdef",
+                                  "prefix": 64
+                                }
+                              ]
                             }
-                          ],
-                          "shared": [
-                            {
-                              "range": "2600:3c09:e001:2a::/64",
-                              "route_target": null
-                            }
-                          ],
-                          "slaac": [
-                            {
-                              "address": "2600:3c09::ff:feab:cdef",
-                              "prefix": 64
-                            }
-                          ]
+                          },
+                          "updated": "2025-01-01T00:01:01",
+                          "version": 1,
+                          "vlan": null,
+                          "vpc": null
                         }
-                      },
-                      "updated": "2025-01-01T00:01:01",
-                      "version": 1,
-                      "vlan": null,
-                      "vpc": null
+                      ]
                     }
                   },
                   "ex-vlan": {
                     "summary": "VLAN interface",
                     "value": {
-                      "created": "2025-01-01T00:01:01",
-                      "default_route": {},
-                      "id": 1234,
-                      "mac_address": "22:00:AB:CD:EF:01",
-                      "public": null,
-                      "updated": "2025-01-01T00:01:01",
-                      "version": 1,
-                      "vlan": {
-                        "ipam_address": "10.0.0.1/24",
-                        "vlan_label": "my-vlan"
-                      },
-                      "vpc": null
+                      "interfaces": [
+                        {
+                          "created": "2025-01-01T00:01:01",
+                          "default_route": {},
+                          "id": 1234,
+                          "mac_address": "22:00:AB:CD:EF:01",
+                          "public": null,
+                          "updated": "2025-01-01T00:01:01",
+                          "version": 1,
+                          "vlan": {
+                            "ipam_address": "10.0.0.1/24",
+                            "vlan_label": "my-vlan"
+                          },
+                          "vpc": null
+                        }
+                      ]
                     }
                   },
                   "ex-vpc": {
                     "summary": "VPC interface",
                     "value": {
-                      "created": "2025-01-01T00:01:01",
-                      "default_route": {
-                        "ipv4": true
-                      },
-                      "id": 1234,
-                      "mac_address": "22:00:AB:CD:EF:01",
-                      "public": null,
-                      "updated": "2025-01-01T00:02:01",
-                      "version": 1,
-                      "vlan": null,
-                      "vpc": {
-                        "ipv4": {
-                          "addresses": [
-                            {
-                              "address": "192.168.22.3",
-                              "primary": true
-                            }
-                          ],
-                          "ranges": [
-                            {
-                              "range": "192.168.22.16/28"
+                      "interfaces": [
+                        {
+                          "created": "2025-01-01T00:01:01",
+                          "default_route": {
+                            "ipv4": true
+                          },
+                          "id": 1234,
+                          "mac_address": "22:00:AB:CD:EF:01",
+                          "public": null,
+                          "updated": "2025-01-01T00:02:01",
+                          "version": 1,
+                          "vlan": null,
+                          "vpc": {
+                            "ipv4": {
+                              "addresses": [
+                                {
+                                  "address": "192.168.22.3",
+                                  "primary": true
+                                }
+                              ],
+                              "ranges": [
+                                {
+                                  "range": "192.168.22.16/28"
+                                },
+                                {
+                                  "range": "192.168.22.32/28"
+                                }
+                              ]
                             },
-                            {
-                              "range": "192.168.22.32/28"
-                            }
-                          ]
-                        },
-                        "subnet_id": 1234,
-                        "vpc_id": 1234
-                      }
+                            "subnet_id": 1234,
+                            "vpc_id": 1234
+                          }
+                        }
+                      ]
                     }
                   }
                 },
                 "schema": {
-                  "description": "One of the following interface types: VPC, public, or VLAN.",
-                  "oneOf": [
-                    {
-                      "additionalProperties": false,
-                      "description": "A public interface configuration defines the properties and settings for a specific public interface in the Linode network.",
-                      "properties": {
-                        "created": {
-                          "description": "When the interface was created.",
-                          "example": "2024-01-01T00:01:01",
-                          "format": "date-time",
-                          "type": "string",
-                          "x-linode-cli-display": 3
-                        },
-                        "default_route": {
-                          "additionalProperties": false,
-                          "description": "Indicates if the interface is used as a default route.",
-                          "nullable": true,
-                          "properties": {
-                            "ipv4": {
-                              "default": false,
-                              "description": "Indicates if the interface is used for the IPv4 default route. Only one interface per Linode can have the IPv4 default route.",
-                              "example": true,
-                              "type": "boolean",
-                              "x-linode-cli-display": 5
-                            },
-                            "ipv6": {
-                              "default": false,
-                              "description": "Indicates if the interface is used for the IPv6 default route. Only one interface per Linode can have the IPv6 default route.",
-                              "example": true,
-                              "type": "boolean",
-                              "x-linode-cli-display": 6
-                            }
-                          },
-                          "type": "object"
-                        },
-                        "id": {
-                          "description": "__Read-only__ The unique ID for this interface. For `dry_run` [upgrades](https://techdocs.akamai.com/linode-api/reference/post-upgrade-linode-interfaces), a unique `id` is not generated for the interface and its value is set to 0.",
-                          "example": 1234,
-                          "readOnly": true,
-                          "type": "integer",
-                          "x-linode-cli-display": 1
-                        },
-                        "mac_address": {
-                          "description": "A 48-bit MAC address used to identify the Linode\u2019s interface. A public interface's `mac_address` does not change, even if the public interface is deleted and then recreated.",
-                          "example": "22:00:AB:CD:EF:01",
-                          "maxLength": 64,
-                          "minLength": 1,
-                          "pattern": "[a-zA-Z0-9-]+",
-                          "type": "string",
-                          "x-linode-cli-display": 2
-                        },
-                        "public": {
-                          "additionalProperties": false,
-                          "description": "Public interface type.",
-                          "properties": {
-                            "ipv4": {
-                              "additionalProperties": false,
-                              "description": "The interface's public IPv4 `addresses`.",
-                              "properties": {
-                                "addresses": {
-                                  "description": "The public IPv4 addresses and primary settings for this public interface.",
-                                  "items": {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "address": {
-                                        "description": "The public IPv4 address assigned to this interface.",
-                                        "example": "172.232.100.100",
-                                        "type": "string",
-                                        "x-linode-cli-display": 8
-                                      },
-                                      "primary": {
-                                        "description": "Indicates if the public IPv4 address serves as the source address for traffic routing within the Linode and other corresponding network interfaces and services.",
-                                        "example": true,
-                                        "type": "boolean",
-                                        "x-linode-cli-display": 9
-                                      }
-                                    },
-                                    "type": "object"
-                                  },
-                                  "type": "array"
-                                },
-                                "shared": {
-                                  "description": "The IPv4 address assigned to this Linode interface, which is also shared with another Linode.",
-                                  "items": {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "address": {
-                                        "description": "Shared IPv4 address.",
-                                        "example": "172.222.33.4",
-                                        "type": "string",
-                                        "x-linode-cli-display": 10
-                                      },
-                                      "linode_id": {
-                                        "description": "The ID of the Linode this address currently belongs to. For IPv4 addresses, by default this is the Linode this address was assigned when created.",
-                                        "example": 12345,
-                                        "type": "string",
-                                        "x-linode-cli-display": 11
-                                      }
-                                    },
-                                    "type": "object"
-                                  },
-                                  "type": "array"
-                                }
+                  "additionalProperties": false,
+                  "properties": {
+                    "interfaces": {
+                      "description": "Any of the following interface types: VPC, public, or VLAN.",
+                      "items": {
+                        "additionalProperties": false,
+                        "anyOf": [
+                          {
+                            "additionalProperties": false,
+                            "description": "A public interface configuration defines the properties and settings for a specific public interface in the Linode network.",
+                            "properties": {
+                              "created": {
+                                "description": "When the interface was created.",
+                                "example": "2024-01-01T00:01:01",
+                                "format": "date-time",
+                                "type": "string",
+                                "x-linode-cli-display": 3
                               },
-                              "type": "object"
-                            },
-                            "ipv6": {
-                              "additionalProperties": false,
-                              "description": "The interface's public IPv6 configuration.",
-                              "properties": {
-                                "ranges": {
-                                  "description": "List of IPv6 ranges assigned to this interface.",
-                                  "items": {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "range": {
-                                        "description": "IPv6 range in CIDR notation (`2600:0db8::1/64`) or prefix-only (`/64`).",
-                                        "example": "2600:3c09:e001:59::/64",
-                                        "type": "string",
-                                        "x-linode-cli-display": 16
-                                      },
-                                      "route_target": {
-                                        "description": "The public IPv6 address that the `range` is routed to.",
-                                        "example": "2600:3c09::ff:feab:cdef",
-                                        "type": "string",
-                                        "x-linode-cli-display": 17
-                                      }
-                                    },
-                                    "type": "object"
+                              "default_route": {
+                                "additionalProperties": false,
+                                "description": "Indicates if the interface is used as a default route.",
+                                "nullable": true,
+                                "properties": {
+                                  "ipv4": {
+                                    "default": false,
+                                    "description": "Indicates if the interface is used for the IPv4 default route. Only one interface per Linode can have the IPv4 default route.",
+                                    "example": true,
+                                    "type": "boolean",
+                                    "x-linode-cli-display": 5
                                   },
-                                  "type": "array"
+                                  "ipv6": {
+                                    "default": false,
+                                    "description": "Indicates if the interface is used for the IPv6 default route. Only one interface per Linode can have the IPv6 default route.",
+                                    "example": true,
+                                    "type": "boolean",
+                                    "x-linode-cli-display": 6
+                                  }
                                 },
-                                "shared": {
-                                  "description": "The IPv6 address assigned to this Linode interface, which is also shared with another Linode.",
-                                  "items": {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "range": {
-                                        "description": "The IPv6 address range.",
-                                        "example": "2600:3c09:e001:2a::/64",
-                                        "type": "string",
-                                        "x-linode-cli-display": 14
-                                      },
-                                      "route_target": {
-                                        "description": "The public IPv6 address that the `range` is routed to.",
-                                        "example": null,
-                                        "type": "string",
-                                        "x-linode-cli-display": 15
-                                      }
-                                    },
-                                    "type": "object"
-                                  },
-                                  "type": "array"
-                                },
-                                "slaac": {
-                                  "description": "The public `slaac` and subnet prefix settings for this public interface that is used to communicate over the public internet, and with other services in the same data center.",
-                                  "items": {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "address": {
-                                        "description": "Public IPv6 addresses assigned to this interface.",
-                                        "example": "2600:3c09::ff:feab:cdef",
-                                        "type": "string",
-                                        "x-linode-cli-display": 12
-                                      },
-                                      "prefix": {
-                                        "description": "The prefix length advertised for SLAAC to use. Only the specific (`/128`) EUI-64 address derived from the interface's MAC address is supported. To ensure the MAC-based EUI-64 address is used, privacy addressing needs to be disabled. Network Helper automatically configures the MAC-derived EUI-64 address. If you disable Network Helper or use an unsupported operating system, follow the specific instructions for your OS.",
-                                        "example": 64,
-                                        "type": "integer",
-                                        "x-linode-cli-display": 13
-                                      }
-                                    },
-                                    "type": "object"
-                                  },
-                                  "type": "array"
-                                }
+                                "type": "object"
                               },
-                              "type": "object"
-                            }
-                          },
-                          "type": "object"
-                        },
-                        "updated": {
-                          "description": "When the interface was last updated.",
-                          "example": "2024-01-01T00:01:01",
-                          "format": "date-time",
-                          "type": "string",
-                          "x-linode-cli-display": 4
-                        },
-                        "version": {
-                          "description": "Interface version number that increments when the interface updates.",
-                          "example": 1,
-                          "type": "integer",
-                          "x-linode-cli-display": 7
-                        },
-                        "vlan": {
-                          "description": "The value is `null` if this is not a VLAN interface.",
-                          "example": null,
-                          "nullable": true,
-                          "type": "object"
-                        },
-                        "vpc": {
-                          "additionalProperties": false,
-                          "description": "The value is `null` if this is not a VPC interface.",
-                          "example": null,
-                          "nullable": true,
-                          "type": "object"
-                        }
-                      },
-                      "title": "Public interface",
-                      "type": "object",
-                      "x-akamai": {
-                        "file-path": "schemas/linode-interface-public.yaml"
-                      }
-                    },
-                    {
-                      "additionalProperties": false,
-                      "description": "A VLAN interface configuration defines the properties and settings for a specific VLAN interface in the Linode network.",
-                      "properties": {
-                        "created": {
-                          "description": "When the interface was created.",
-                          "example": "2024-01-01T00:01:01",
-                          "format": "date-time",
-                          "type": "string",
-                          "x-linode-cli-display": 3
-                        },
-                        "id": {
-                          "description": "__Read-only__ The unique ID for this interface. For `dry_run` [upgrades](https://techdocs.akamai.com/linode-api/reference/post-upgrade-linode-interfaces), a unique `id` is not generated for the interface and its value is set to 0.",
-                          "example": 1234,
-                          "readOnly": true,
-                          "type": "integer",
-                          "x-linode-cli-display": 1
-                        },
-                        "mac_address": {
-                          "description": "A 48-bit MAC address used to identify the Linode\u2019s interface. The `mac_address` of an interface remains constant and does not change.",
-                          "example": "22:00:AB:CD:EF:01",
-                          "maxLength": 64,
-                          "minLength": 1,
-                          "pattern": "[a-zA-Z0-9-]+",
-                          "type": "string",
-                          "x-linode-cli-display": 2
-                        },
-                        "public": {
-                          "description": "The value is `null` if this isn't a public interface.",
-                          "example": null,
-                          "nullable": true,
-                          "type": "object"
-                        },
-                        "updated": {
-                          "description": "When the interface was last updated.",
-                          "example": "2024-01-01T00:01:01",
-                          "format": "date-time",
-                          "type": "string",
-                          "x-linode-cli-display": 4
-                        },
-                        "version": {
-                          "description": "Interface version number that is incremented when the interface is updated.",
-                          "example": 1,
-                          "type": "integer",
-                          "x-linode-cli-display": 5
-                        },
-                        "vlan": {
-                          "additionalProperties": false,
-                          "description": "VLAN interface type.",
-                          "properties": {
-                            "ipam_address": {
-                              "description": "This VLAN interface's private IPv4 address in classless inter-domain routing (CIDR) notation.",
-                              "example": "10.0.0.1/24",
-                              "format": "ip/netmask",
-                              "nullable": true,
-                              "type": "string",
-                              "x-linode-cli-display": 7
-                            },
-                            "vlan_label": {
-                              "description": "The VLAN's label. VLAN interfaces on the same Linode must have a unique `vlan_label`.",
-                              "example": "my-vlan",
-                              "type": "string",
-                              "x-linode-cli-display": 6
-                            }
-                          },
-                          "type": "object"
-                        },
-                        "vpc": {
-                          "description": "The value is `null` if this isn't a VPC interface.",
-                          "example": null,
-                          "nullable": true,
-                          "type": "object"
-                        }
-                      },
-                      "title": "VLAN interface",
-                      "type": "object",
-                      "x-akamai": {
-                        "file-path": "schemas/linode-interface-vlan.yaml"
-                      }
-                    },
-                    {
-                      "additionalProperties": false,
-                      "description": "A VPC interface configuration defines settings for a specific VPC interface in the Linode network.",
-                      "properties": {
-                        "created": {
-                          "description": "When the interface was created.",
-                          "example": "2025-01-01 00:01:01",
-                          "format": "date-time",
-                          "type": "string",
-                          "x-linode-cli-display": 3
-                        },
-                        "default_route": {
-                          "additionalProperties": false,
-                          "description": "Indicates if the interface serves as a default route.",
-                          "properties": {
-                            "ipv4": {
-                              "default": false,
-                              "description": "Indicates if the interface serves as the IPv4 default route. Only one interface per Linode can have the IPv4 default route.",
-                              "example": true,
-                              "type": "boolean",
-                              "x-linode-cli-display": 5
-                            }
-                          },
-                          "type": "object"
-                        },
-                        "id": {
-                          "description": "__Read-only__ The unique ID for this interface. For `dry_run` [upgrades](https://techdocs.akamai.com/linode-api/reference/post-upgrade-linode-interfaces), a unique `id` is not generated for the interface and its value is set to 0.",
-                          "example": 1234,
-                          "readOnly": true,
-                          "type": "integer",
-                          "x-linode-cli-display": 1
-                        },
-                        "mac_address": {
-                          "description": "A 48-bit MAC address used to identify the Linode\u2019s interface. The `mac_address` of an interface remains constant and does not change.",
-                          "example": "22:00:AB:CD:EF:01",
-                          "maxLength": 64,
-                          "minLength": 1,
-                          "pattern": "[a-zA-Z0-9-]+",
-                          "type": "string",
-                          "x-linode-cli-display": 2
-                        },
-                        "public": {
-                          "additionalProperties": false,
-                          "description": "The value is `null` if this is not a public interface.",
-                          "example": null,
-                          "nullable": true,
-                          "type": "object"
-                        },
-                        "updated": {
-                          "description": "When the interface last updated.",
-                          "example": "2025-01-01 00:01:01",
-                          "format": "date-time",
-                          "type": "string",
-                          "x-linode-cli-display": 4
-                        },
-                        "version": {
-                          "description": "The version number of the interface configuration, incremented each time the interface is updated.",
-                          "example": 1,
-                          "type": "integer",
-                          "x-linode-cli-display": 6
-                        },
-                        "vlan": {
-                          "additionalProperties": false,
-                          "description": "The value is `null` if this is not a VLAN interface.",
-                          "example": null,
-                          "nullable": true,
-                          "type": "object"
-                        },
-                        "vpc": {
-                          "additionalProperties": false,
-                          "description": "VPC interface type.",
-                          "properties": {
-                            "ipv4": {
-                              "additionalProperties": false,
-                              "description": "The interface's IPv4 `addresses` and `ranges` configuration.",
-                              "properties": {
-                                "addresses": {
-                                  "description": "IPv4 address settings for this VPC interface.",
-                                  "items": {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "address": {
-                                        "description": "The VPC subnet IPv4 address.",
-                                        "example": "192.168.22.3",
-                                        "type": "string",
-                                        "x-linode-cli-display": 9
-                                      },
-                                      "nat_1_1_address": {
-                                        "description": "The 1:1 NAT IPv4 address used to associate a public IPv4 address with the interface's VPC subnet IPv4 address.",
-                                        "example": null,
-                                        "nullable": true,
-                                        "type": "string",
-                                        "x-linode-cli-display": 11
-                                      },
-                                      "primary": {
-                                        "description": "Indicates if the IPv4 address is used to set up a source address for routes inside the Linode for the corresponding network interface.",
-                                        "example": true,
-                                        "type": "boolean",
-                                        "x-linode-cli-display": 10
-                                      }
-                                    },
-                                    "type": "object"
-                                  },
-                                  "type": "array"
-                                },
-                                "ranges": {
-                                  "description": "VPC IPv4 ranges.",
-                                  "items": {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "range": {
-                                        "description": "CIDR notation of a range (`1.2.3.4/24`) or prefix only (`/24`).",
-                                        "example": "192.168.22.16/28",
-                                        "type": "string",
-                                        "x-linode-cli-display": 12
-                                      }
-                                    },
-                                    "type": "object"
-                                  },
-                                  "type": "array"
-                                }
+                              "id": {
+                                "description": "__Read-only__ The unique ID for this interface. For `dry_run` [upgrades](https://techdocs.akamai.com/linode-api/reference/post-upgrade-linode-interfaces), a unique `id` is not generated for the interface and its value is set to 0.",
+                                "example": 1234,
+                                "readOnly": true,
+                                "type": "integer",
+                                "x-linode-cli-display": 1
                               },
-                              "type": "object"
+                              "mac_address": {
+                                "description": "A 48-bit MAC address used to identify the Linode\u2019s interface. A public interface's `mac_address` does not change, even if the public interface is deleted and then recreated.",
+                                "example": "22:00:AB:CD:EF:01",
+                                "maxLength": 64,
+                                "minLength": 1,
+                                "pattern": "[a-zA-Z0-9-]+",
+                                "type": "string",
+                                "x-linode-cli-display": 2
+                              },
+                              "public": {
+                                "additionalProperties": false,
+                                "description": "Public interface type.",
+                                "properties": {
+                                  "ipv4": {
+                                    "additionalProperties": false,
+                                    "description": "The interface's public IPv4 `addresses`.",
+                                    "properties": {
+                                      "addresses": {
+                                        "description": "The public IPv4 addresses and primary settings for this public interface.",
+                                        "items": {
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "address": {
+                                              "description": "The public IPv4 address assigned to this interface.",
+                                              "example": "172.232.100.100",
+                                              "type": "string",
+                                              "x-linode-cli-display": 8
+                                            },
+                                            "primary": {
+                                              "description": "Indicates if the public IPv4 address serves as the source address for traffic routing within the Linode and other corresponding network interfaces and services.",
+                                              "example": true,
+                                              "type": "boolean",
+                                              "x-linode-cli-display": 9
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "shared": {
+                                        "description": "The IPv4 address assigned to this Linode interface, which is also shared with another Linode.",
+                                        "items": {
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "address": {
+                                              "description": "Shared IPv4 address.",
+                                              "example": "172.222.33.4",
+                                              "type": "string",
+                                              "x-linode-cli-display": 10
+                                            },
+                                            "linode_id": {
+                                              "description": "The ID of the Linode this address currently belongs to. For IPv4 addresses, by default this is the Linode this address was assigned when created.",
+                                              "example": 12345,
+                                              "type": "string",
+                                              "x-linode-cli-display": 11
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "ipv6": {
+                                    "additionalProperties": false,
+                                    "description": "The interface's public IPv6 configuration.",
+                                    "properties": {
+                                      "ranges": {
+                                        "description": "List of IPv6 ranges assigned to this interface.",
+                                        "items": {
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "range": {
+                                              "description": "IPv6 range in CIDR notation (`2600:0db8::1/64`) or prefix-only (`/64`).",
+                                              "example": "2600:3c09:e001:59::/64",
+                                              "type": "string",
+                                              "x-linode-cli-display": 16
+                                            },
+                                            "route_target": {
+                                              "description": "The public IPv6 address that the `range` is routed to.",
+                                              "example": "2600:3c09::ff:feab:cdef",
+                                              "type": "string",
+                                              "x-linode-cli-display": 17
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "shared": {
+                                        "description": "The IPv6 address assigned to this Linode interface, which is also shared with another Linode.",
+                                        "items": {
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "range": {
+                                              "description": "The IPv6 address range.",
+                                              "example": "2600:3c09:e001:2a::/64",
+                                              "type": "string",
+                                              "x-linode-cli-display": 14
+                                            },
+                                            "route_target": {
+                                              "description": "The public IPv6 address that the `range` is routed to.",
+                                              "example": null,
+                                              "type": "string",
+                                              "x-linode-cli-display": 15
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "slaac": {
+                                        "description": "The public `slaac` and subnet prefix settings for this public interface that is used to communicate over the public internet, and with other services in the same data center.",
+                                        "items": {
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "address": {
+                                              "description": "Public IPv6 addresses assigned to this interface.",
+                                              "example": "2600:3c09::ff:feab:cdef",
+                                              "type": "string",
+                                              "x-linode-cli-display": 12
+                                            },
+                                            "prefix": {
+                                              "description": "The prefix length advertised for SLAAC to use. Only the specific (`/128`) EUI-64 address derived from the interface's MAC address is supported. To ensure the MAC-based EUI-64 address is used, privacy addressing needs to be disabled. Network Helper automatically configures the MAC-derived EUI-64 address. If you disable Network Helper or use an unsupported operating system, follow the specific instructions for your OS.",
+                                              "example": 64,
+                                              "type": "integer",
+                                              "x-linode-cli-display": 13
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "updated": {
+                                "description": "When the interface was last updated.",
+                                "example": "2024-01-01T00:01:01",
+                                "format": "date-time",
+                                "type": "string",
+                                "x-linode-cli-display": 4
+                              },
+                              "version": {
+                                "description": "Interface version number that increments when the interface updates.",
+                                "example": 1,
+                                "type": "integer",
+                                "x-linode-cli-display": 7
+                              },
+                              "vlan": {
+                                "description": "The value is `null` if this is not a VLAN interface.",
+                                "example": null,
+                                "nullable": true,
+                                "type": "object"
+                              },
+                              "vpc": {
+                                "additionalProperties": false,
+                                "description": "The value is `null` if this is not a VPC interface.",
+                                "example": null,
+                                "nullable": true,
+                                "type": "object"
+                              }
                             },
-                            "subnet_id": {
-                              "description": "VPC subnet's unique identifier.",
-                              "example": 1234,
-                              "type": "integer",
-                              "x-linode-cli-display": 8
-                            },
-                            "vpc_id": {
-                              "description": "VPC's unique identifier.",
-                              "example": 1234,
-                              "type": "integer",
-                              "x-linode-cli-display": 7
+                            "title": "Public interface",
+                            "type": "object",
+                            "x-akamai": {
+                              "file-path": "schemas/linode-interface-public.yaml"
                             }
                           },
-                          "type": "object"
-                        }
+                          {
+                            "additionalProperties": false,
+                            "description": "A VLAN interface configuration defines the properties and settings for a specific VLAN interface in the Linode network.",
+                            "properties": {
+                              "created": {
+                                "description": "When the interface was created.",
+                                "example": "2024-01-01T00:01:01",
+                                "format": "date-time",
+                                "type": "string",
+                                "x-linode-cli-display": 3
+                              },
+                              "id": {
+                                "description": "__Read-only__ The unique ID for this interface. For `dry_run` [upgrades](https://techdocs.akamai.com/linode-api/reference/post-upgrade-linode-interfaces), a unique `id` is not generated for the interface and its value is set to 0.",
+                                "example": 1234,
+                                "readOnly": true,
+                                "type": "integer",
+                                "x-linode-cli-display": 1
+                              },
+                              "mac_address": {
+                                "description": "A 48-bit MAC address used to identify the Linode\u2019s interface. The `mac_address` of an interface remains constant and does not change.",
+                                "example": "22:00:AB:CD:EF:01",
+                                "maxLength": 64,
+                                "minLength": 1,
+                                "pattern": "[a-zA-Z0-9-]+",
+                                "type": "string",
+                                "x-linode-cli-display": 2
+                              },
+                              "public": {
+                                "description": "The value is `null` if this isn't a public interface.",
+                                "example": null,
+                                "nullable": true,
+                                "type": "object"
+                              },
+                              "updated": {
+                                "description": "When the interface was last updated.",
+                                "example": "2024-01-01T00:01:01",
+                                "format": "date-time",
+                                "type": "string",
+                                "x-linode-cli-display": 4
+                              },
+                              "version": {
+                                "description": "Interface version number that is incremented when the interface is updated.",
+                                "example": 1,
+                                "type": "integer",
+                                "x-linode-cli-display": 5
+                              },
+                              "vlan": {
+                                "additionalProperties": false,
+                                "description": "VLAN interface type.",
+                                "properties": {
+                                  "ipam_address": {
+                                    "description": "This VLAN interface's private IPv4 address in classless inter-domain routing (CIDR) notation.",
+                                    "example": "10.0.0.1/24",
+                                    "format": "ip/netmask",
+                                    "nullable": true,
+                                    "type": "string",
+                                    "x-linode-cli-display": 7
+                                  },
+                                  "vlan_label": {
+                                    "description": "The VLAN's label. VLAN interfaces on the same Linode must have a unique `vlan_label`.",
+                                    "example": "my-vlan",
+                                    "type": "string",
+                                    "x-linode-cli-display": 6
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "vpc": {
+                                "description": "The value is `null` if this isn't a VPC interface.",
+                                "example": null,
+                                "nullable": true,
+                                "type": "object"
+                              }
+                            },
+                            "title": "VLAN interface",
+                            "type": "object",
+                            "x-akamai": {
+                              "file-path": "schemas/linode-interface-vlan.yaml"
+                            }
+                          },
+                          {
+                            "additionalProperties": false,
+                            "description": "A VPC interface configuration defines settings for a specific VPC interface in the Linode network.",
+                            "properties": {
+                              "created": {
+                                "description": "When the interface was created.",
+                                "example": "2025-01-01 00:01:01",
+                                "format": "date-time",
+                                "type": "string",
+                                "x-linode-cli-display": 3
+                              },
+                              "default_route": {
+                                "additionalProperties": false,
+                                "description": "Indicates if the interface serves as a default route.",
+                                "properties": {
+                                  "ipv4": {
+                                    "default": false,
+                                    "description": "Indicates if the interface serves as the IPv4 default route. Only one interface per Linode can have the IPv4 default route.",
+                                    "example": true,
+                                    "type": "boolean",
+                                    "x-linode-cli-display": 5
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "id": {
+                                "description": "__Read-only__ The unique ID for this interface. For `dry_run` [upgrades](https://techdocs.akamai.com/linode-api/reference/post-upgrade-linode-interfaces), a unique `id` is not generated for the interface and its value is set to 0.",
+                                "example": 1234,
+                                "readOnly": true,
+                                "type": "integer",
+                                "x-linode-cli-display": 1
+                              },
+                              "mac_address": {
+                                "description": "A 48-bit MAC address used to identify the Linode\u2019s interface. The `mac_address` of an interface remains constant and does not change.",
+                                "example": "22:00:AB:CD:EF:01",
+                                "maxLength": 64,
+                                "minLength": 1,
+                                "pattern": "[a-zA-Z0-9-]+",
+                                "type": "string",
+                                "x-linode-cli-display": 2
+                              },
+                              "public": {
+                                "additionalProperties": false,
+                                "description": "The value is `null` if this is not a public interface.",
+                                "example": null,
+                                "nullable": true,
+                                "type": "object"
+                              },
+                              "updated": {
+                                "description": "When the interface last updated.",
+                                "example": "2025-01-01 00:01:01",
+                                "format": "date-time",
+                                "type": "string",
+                                "x-linode-cli-display": 4
+                              },
+                              "version": {
+                                "description": "The version number of the interface configuration, incremented each time the interface is updated.",
+                                "example": 1,
+                                "type": "integer",
+                                "x-linode-cli-display": 6
+                              },
+                              "vlan": {
+                                "additionalProperties": false,
+                                "description": "The value is `null` if this is not a VLAN interface.",
+                                "example": null,
+                                "nullable": true,
+                                "type": "object"
+                              },
+                              "vpc": {
+                                "additionalProperties": false,
+                                "description": "VPC interface type.",
+                                "properties": {
+                                  "ipv4": {
+                                    "additionalProperties": false,
+                                    "description": "The interface's IPv4 `addresses` and `ranges` configuration.",
+                                    "properties": {
+                                      "addresses": {
+                                        "description": "IPv4 address settings for this VPC interface.",
+                                        "items": {
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "address": {
+                                              "description": "The VPC subnet IPv4 address.",
+                                              "example": "192.168.22.3",
+                                              "type": "string",
+                                              "x-linode-cli-display": 9
+                                            },
+                                            "nat_1_1_address": {
+                                              "description": "The 1:1 NAT IPv4 address used to associate a public IPv4 address with the interface's VPC subnet IPv4 address.",
+                                              "example": null,
+                                              "nullable": true,
+                                              "type": "string",
+                                              "x-linode-cli-display": 11
+                                            },
+                                            "primary": {
+                                              "description": "Indicates if the IPv4 address is used to set up a source address for routes inside the Linode for the corresponding network interface.",
+                                              "example": true,
+                                              "type": "boolean",
+                                              "x-linode-cli-display": 10
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "ranges": {
+                                        "description": "VPC IPv4 ranges.",
+                                        "items": {
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "range": {
+                                              "description": "CIDR notation of a range (`1.2.3.4/24`) or prefix only (`/24`).",
+                                              "example": "192.168.22.16/28",
+                                              "type": "string",
+                                              "x-linode-cli-display": 12
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "subnet_id": {
+                                    "description": "VPC subnet's unique identifier.",
+                                    "example": 1234,
+                                    "type": "integer",
+                                    "x-linode-cli-display": 8
+                                  },
+                                  "vpc_id": {
+                                    "description": "VPC's unique identifier.",
+                                    "example": 1234,
+                                    "type": "integer",
+                                    "x-linode-cli-display": 7
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "title": "VPC interface",
+                            "type": "object",
+                            "x-akamai": {
+                              "file-path": "schemas/linode-interface-vpc.yaml"
+                            }
+                          }
+                        ],
+                        "type": "object"
                       },
-                      "title": "VPC interface",
-                      "type": "object",
-                      "x-akamai": {
-                        "file-path": "schemas/linode-interface-vpc.yaml"
-                      }
+                      "type": "array"
                     }
+                  },
+                  "required": [
+                    "interfaces"
                   ],
                   "type": "object",
                   "x-akamai": {
-                    "file-path": "schemas/linode-interface.yaml"
+                    "file-path": "schemas/linode-interfaces.yaml"
                   }
                 },
                 "x-linode-cli-nested-list": "interfaces",
@@ -59619,6 +66118,310 @@
       },
       "x-linode-cli-command": "linodes"
     },
+    "/{apiVersion}/linode/instances/{linodeId}/interfaces/history": {
+      "get": {
+        "description": "__Beta__ Lists the history of network interfaces by version for a Linode. This operation is for Linode interfaces, and not for legacy configuration profile interfaces.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli linodes interface-history-list $linodeId\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    linodes:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "externalDocs": {
+          "description": "See documentation for this operation in Akamai's Linode API",
+          "url": "https://techdocs.akamai.com/linode-api/reference/get-linode-interface-history"
+        },
+        "operationId": "get-linode-interface-history",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": [
+                    {
+                      "created": "2025-08-01T00:01:01",
+                      "interface_data": {
+                        "created": "2024-01-01T00:01:01",
+                        "default_route": {
+                          "ipv4": true,
+                          "ipv6": true
+                        },
+                        "id": 1234,
+                        "mac_address": "22:00:AB:CD:EF:01",
+                        "public": {
+                          "ipv4": {
+                            "addresses": [
+                              {
+                                "address": "172.29.234.138",
+                                "primary": true
+                              }
+                            ],
+                            "shared": [
+                              {
+                                "address": "172.26.212.79",
+                                "linode_id": 12345
+                              }
+                            ]
+                          },
+                          "ipv6": {
+                            "ranges": [
+                              {
+                                "range": "2001:DB8::/64",
+                                "route_target": "2600:3c09::ff:feab:cdef"
+                              },
+                              {
+                                "range": "2001:DB8::/64",
+                                "route_target": "2600:3c09::ff:feab:cdef"
+                              }
+                            ],
+                            "shared": [
+                              {
+                                "range": "2001:DB8::/64",
+                                "route_target": null
+                              }
+                            ],
+                            "slaac": [
+                              {
+                                "address": "2600:3c09::ff:feab:cdef2",
+                                "prefix": 64
+                              }
+                            ]
+                          }
+                        },
+                        "updated": "2024-01-01T00:01:01",
+                        "version": 3,
+                        "vlan": null,
+                        "vpc": null
+                      },
+                      "interface_history_id": 3,
+                      "interface_id": 221,
+                      "linode_id": 22,
+                      "version": 1
+                    }
+                  ],
+                  "page": 1,
+                  "pages": 1,
+                  "results": 1
+                },
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "Returns a paginated list of all available versions for all interfaces (as full objects) on the Linode. A new entry is added to this list each time a change is made to any interface.",
+                        "properties": {
+                          "created": {
+                            "description": "__Filterable__, __Read-only__ When this version was created. Use `created` to determine which settings an interface prevously had.",
+                            "example": "2025-08-01T00:01:01",
+                            "format": "date-time",
+                            "readOnly": true,
+                            "type": "string",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ]
+                            },
+                            "x-linode-cli-display": 6,
+                            "x-linode-filterable": true
+                          },
+                          "interface_data": {
+                            "description": "The JSON body returned in response to a successful `PUT`, `POST`, or `DELETE` operation on the interface.",
+                            "example": {},
+                            "type": "string",
+                            "x-linode-cli-display": 5
+                          },
+                          "interface_history_id": {
+                            "description": "__Filterable__, __Read-only__ The unique ID for this history version.",
+                            "example": 1,
+                            "readOnly": true,
+                            "type": "integer",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ]
+                            },
+                            "x-linode-cli-display": 1,
+                            "x-linode-filterable": true
+                          },
+                          "interface_id": {
+                            "description": "__Filterable__, __Read-only__ The network interface defined in the `version`.",
+                            "example": 221,
+                            "readOnly": true,
+                            "type": "integer",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ]
+                            },
+                            "x-linode-cli-display": 2,
+                            "x-linode-filterable": true
+                          },
+                          "linode_id": {
+                            "description": "__Filterable__, __Read-only__ The Linode the `interface_id` belongs to.",
+                            "example": 22,
+                            "readOnly": true,
+                            "type": "integer",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ]
+                            },
+                            "x-linode-cli-display": 3,
+                            "x-linode-filterable": true
+                          },
+                          "version": {
+                            "description": "__Filterable__, __Read-only__ The network interface's version. The first version from a `POST` is `1`. The version number is incremented when the network interface configuration is changed.",
+                            "example": 1,
+                            "readOnly": true,
+                            "type": "integer",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ]
+                            },
+                            "x-linode-cli-display": 4,
+                            "x-linode-filterable": true
+                          }
+                        },
+                        "type": "object",
+                        "x-akamai": {
+                          "file-path": "schemas/history.yaml"
+                        }
+                      },
+                      "type": "array"
+                    },
+                    "page": {
+                      "description": "__Read-only__ The current [page](https://techdocs.akamai.com/linode-api/reference/pagination).",
+                      "example": 1,
+                      "readOnly": true,
+                      "type": "integer"
+                    },
+                    "pages": {
+                      "description": "__Read-only__ The total number of [pages](https://techdocs.akamai.com/linode-api/reference/pagination).",
+                      "example": 1,
+                      "readOnly": true,
+                      "type": "integer"
+                    },
+                    "results": {
+                      "description": "__Read-only__ The total number of results.",
+                      "example": 1,
+                      "readOnly": true,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "x-akamai": {
+                    "file-path": "schemas/added-get-linode-interfaces-history-200.yaml"
+                  }
+                }
+              }
+            },
+            "description": "Returns a paginated list of network interface versions for a Linode."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "errors": {
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "An object for describing a single error that occurred during the processing of a request.",
+                        "properties": {
+                          "field": {
+                            "description": "The field in the request that caused this error. This may be a path, separated by periods in the case of nested fields. In some cases this may come back as `null` if the error is not specific to any single element of the request.",
+                            "example": "fieldname",
+                            "type": "string"
+                          },
+                          "reason": {
+                            "description": "What happened to cause this error. In most cases, this can be fixed immediately by changing the data you sent in the request, but in some cases you will be instructed to [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) or perform some other action before you can complete the request successfully.",
+                            "example": "fieldname must be a valid value",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-akamai": {
+                          "file-path": "schemas/error-object.yaml"
+                        }
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "See [Errors](https://techdocs.akamai.com/linode-api/reference/errors) for the range of possible error response codes."
+          }
+        },
+        "security": [
+          {
+            "personalAccessToken": []
+          },
+          {
+            "oauth": [
+              "linodes:read_only"
+            ]
+          }
+        ],
+        "summary": "List a Linode's network interface history",
+        "tags": [
+          "Linode interfaces"
+        ],
+        "x-akamai": {
+          "status": "BETA",
+          "tabs": [
+            {
+              "syntax": "linode-cli linodes interface-history-list $linodeId",
+              "title": "CLI",
+              "url": "https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli"
+            },
+            {
+              "syntax": "linodes:read_only",
+              "title": "OAuth scopes",
+              "url": "https://techdocs.akamai.com/linode-api/reference/get-started#oauth"
+            }
+          ]
+        },
+        "x-linode-cli-action": "interface-history-list",
+        "x-linode-grant": "read_only"
+      },
+      "parameters": [
+        {
+          "description": "__Enum__ Call either the `v4` URL, or `v4beta` for operations still in Beta.",
+          "example": "{{apiVersion}}",
+          "in": "path",
+          "name": "apiVersion",
+          "required": true,
+          "schema": {
+            "enum": [
+              "v4",
+              "v4beta"
+            ],
+            "type": "string"
+          },
+          "x-akamai": {
+            "file-path": "parameters/api-version-path.yaml"
+          }
+        },
+        {
+          "description": "The `id` of the Linode.",
+          "example": "{{linodeId}}",
+          "in": "path",
+          "name": "linodeId",
+          "required": true,
+          "schema": {
+            "example": 234,
+            "type": "integer"
+          },
+          "x-akamai": {
+            "file-path": "parameters/linode-id.yaml"
+          }
+        }
+      ],
+      "x-akamai": {
+        "file-path": "paths/linode-interface-history.yaml",
+        "path-info": "/{apiVersion}/linode/instances/{linodeId}/interfaces/history",
+        "status": "BETA"
+      },
+      "x-linode-cli-command": "linodes"
+    },
     "/{apiVersion}/linode/instances/{linodeId}/interfaces/settings": {
       "get": {
         "description": "__Beta__ Lists a Linode's interface settings, including Network Helper and default route settings. This operation is for Linode interfaces, not for legacy configuration profile interfaces.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli linodes interfaces-settings-list $linodeId\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    linodes: read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
@@ -59666,8 +66469,8 @@
                           "items": {
                             "description": "__Read-only__ Eligible IDs, or an empty array if there are none.",
                             "example": [
-                              2,
-                              3
+                              4,
+                              5
                             ],
                             "readOnly": true,
                             "type": "integer"
@@ -59678,7 +66481,7 @@
                         "ipv6_interface_id": {
                           "default": null,
                           "description": "The public interface ID assigned as the IPv6 `default_route`. The [List Linode interface settings](https://techdocs.akamai.com/linode-api/reference/get-linode-interface-settings) operation provides eligible IPv6 interface IDs.",
-                          "example": 1,
+                          "example": 4,
                           "nullable": true,
                           "type": "integer",
                           "x-linode-cli-display": 4
@@ -59819,8 +66622,8 @@
                         "items": {
                           "description": "__Read-only__ Eligible IDs, or an empty array if there are none.",
                           "example": [
-                            2,
-                            3
+                            4,
+                            5
                           ],
                           "readOnly": true,
                           "type": "integer"
@@ -59831,7 +66634,7 @@
                       "ipv6_interface_id": {
                         "default": null,
                         "description": "The public interface ID assigned as the IPv6 `default_route`. The [List Linode interface settings](https://techdocs.akamai.com/linode-api/reference/get-linode-interface-settings) operation provides eligible IPv6 interface IDs.",
-                        "example": 1,
+                        "example": 4,
                         "nullable": true,
                         "type": "integer",
                         "x-linode-cli-display": 4
@@ -59898,8 +66701,8 @@
                           "items": {
                             "description": "__Read-only__ Eligible IDs, or an empty array if there are none.",
                             "example": [
-                              2,
-                              3
+                              4,
+                              5
                             ],
                             "readOnly": true,
                             "type": "integer"
@@ -59910,7 +66713,7 @@
                         "ipv6_interface_id": {
                           "default": null,
                           "description": "The public interface ID assigned as the IPv6 `default_route`. The [List Linode interface settings](https://techdocs.akamai.com/linode-api/reference/get-linode-interface-settings) operation provides eligible IPv6 interface IDs.",
-                          "example": 1,
+                          "example": 4,
                           "nullable": true,
                           "type": "integer",
                           "x-linode-cli-display": 4
@@ -60784,10 +67587,7 @@
                                     "range": {
                                       "default": null,
                                       "description": "IPv6 range in CIDR notation (`2001:0db8::1/64`) or prefix-only (`/64`).\n- The prefix of /64 or /56 block of IPv6 addresses.\n- CIDR notation ranges must be within your assigned ranges.",
-                                      "example": [
-                                        "2001:0db8::1/64",
-                                        "/64"
-                                      ],
+                                      "example": "/64",
                                       "type": "string"
                                     }
                                   },
@@ -65122,6 +71922,18 @@
                         "example": "linode/debian9",
                         "type": "string"
                       },
+                      "maintenance_policy": {
+                        "description": "__Beta__ Defines the maintenance policy for this Linode. Choose from the following policies:\n\n- `linode/migrate`: Migrates the Linode to a new host while it remains fully operational (with some performance degradation). Recommended for maximizing availability.\n- `linode/power_off_on`: Powers off the Linode at the start of the maintenance event and reboots it once the maintenance finishes. Recommended for maximizing performance.\n\nReview [maintenance policy](https://techdocs.akamai.com/cloud-computing/docs/host-maintenance-policy) documentation for more details.",
+                        "enum": [
+                          "linode/migrate",
+                          "linode/power_off_on"
+                        ],
+                        "example": "linode/migrate",
+                        "type": "string",
+                        "x-akamai": {
+                          "status": "BETA"
+                        }
+                      },
                       "metadata": {
                         "additionalProperties": false,
                         "description": "__Write-only__ An object containing user-defined data relevant to the creation of Linodes.",
@@ -65463,6 +72275,18 @@
                       "nullable": true,
                       "readOnly": true,
                       "type": "integer"
+                    },
+                    "maintenance_policy": {
+                      "description": "__Beta__ The maintenance policy configured by the user for this Linode. Review [maintenance policy](https://techdocs.akamai.com/cloud-computing/docs/host-maintenance-policy) documentation for more details.",
+                      "enum": [
+                        "linode/migrate",
+                        "linode/power_off_on"
+                      ],
+                      "example": "linode/migrate",
+                      "type": "string",
+                      "x-akamai": {
+                        "status": "BETA"
+                      }
                     },
                     "placement_group": {
                       "additionalProperties": false,
@@ -80158,6 +86982,192 @@
       },
       "x-linode-cli-command": "longview"
     },
+    "/{apiVersion}/maintenance/policies": {
+      "get": {
+        "description": "__Beta__ List all available maintenance policies that can be applied to your Linodes.\n\n> \ud83d\udcd8\n>\n> This operation is beta and only works when using the beta API. Call the URL with the `apiVersion` path parameter set to `v4beta`.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli maintenance policies-list\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)",
+        "externalDocs": {
+          "description": "See documentation for this operation in Akamai's Linode API",
+          "url": "https://techdocs.akamai.com/linode-api/reference/get-maintenance-policies"
+        },
+        "operationId": "get-maintenance-policies",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "Information about maintenance policies.",
+                        "properties": {
+                          "description": {
+                            "description": "A brief explanation of the maintenance policy's intended behavior.",
+                            "example": "Migrates the Linode to a new host while it remains fully operational. Recommended for maximizing availability.",
+                            "type": "string"
+                          },
+                          "is_default": {
+                            "description": "Indicates whether this policy is the default one applied when creating a Linode.",
+                            "example": true,
+                            "type": "boolean"
+                          },
+                          "label": {
+                            "description": "The display name for the maintenance policy.",
+                            "example": "Migrate",
+                            "type": "string"
+                          },
+                          "notification_period_sec": {
+                            "description": "__Filterable__ Number of seconds before the maintenance event triggers. A value of 0 means no prior notification.",
+                            "example": 10800,
+                            "type": "integer",
+                            "x-akamai": {
+                              "labels": [
+                                "Filterable"
+                              ]
+                            },
+                            "x-linode-filterable": true
+                          },
+                          "slug": {
+                            "description": "Unique identifier for the maintenance policy. System policies are prefixed with `linode/`.",
+                            "example": "linode/migrate",
+                            "type": "string"
+                          },
+                          "type": {
+                            "description": "The type of policy.",
+                            "enum": [
+                              "migrate",
+                              "power_off_on"
+                            ],
+                            "example": "migrate",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-akamai": {
+                          "file-path": "schemas/maintenance-policies.yaml"
+                        }
+                      },
+                      "type": "array"
+                    },
+                    "page": {
+                      "description": "__Read-only__ The current [page](https://techdocs.akamai.com/linode-api/reference/pagination).",
+                      "example": 1,
+                      "readOnly": true,
+                      "type": "integer"
+                    },
+                    "pages": {
+                      "description": "__Read-only__ The total number of [pages](https://techdocs.akamai.com/linode-api/reference/pagination).",
+                      "example": 1,
+                      "readOnly": true,
+                      "type": "integer"
+                    },
+                    "results": {
+                      "description": "__Read-only__ The total number of results.",
+                      "example": 1,
+                      "readOnly": true,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "x-akamai": {
+                    "file-path": "schemas/get-maintenance-policies-200.yaml"
+                  }
+                },
+                "x-example": {
+                  "x-ref": "../examples/get-maintenance-policies-200.json"
+                }
+              }
+            },
+            "description": "Returns a paginated list of maintenance policy objects."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "errors": {
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "An object for describing a single error that occurred during the processing of a request.",
+                        "properties": {
+                          "field": {
+                            "description": "The field in the request that caused this error. This may be a path, separated by periods in the case of nested fields. In some cases this may come back as `null` if the error is not specific to any single element of the request.",
+                            "example": "fieldname",
+                            "type": "string"
+                          },
+                          "reason": {
+                            "description": "What happened to cause this error. In most cases, this can be fixed immediately by changing the data you sent in the request, but in some cases you will be instructed to [Open a support ticket](https://techdocs.akamai.com/linode-api/reference/post-ticket) or perform some other action before you can complete the request successfully.",
+                            "example": "fieldname must be a valid value",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-akamai": {
+                          "file-path": "schemas/error-object.yaml"
+                        }
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "See [Errors](https://techdocs.akamai.com/linode-api/reference/errors) for the range of possible error response codes."
+          }
+        },
+        "security": [
+          {
+            "personalAccessToken": []
+          },
+          {
+            "oauth": []
+          }
+        ],
+        "summary": "List maintenance policies",
+        "tags": [
+          "Maintenance policies"
+        ],
+        "x-akamai": {
+          "status": "BETA",
+          "tabs": [
+            {
+              "syntax": "linode-cli maintenance policies-list",
+              "title": "CLI",
+              "url": "https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli"
+            }
+          ]
+        },
+        "x-linode-cli-action": "policies-list",
+        "x-linode-grant": "read_only"
+      },
+      "parameters": [
+        {
+          "description": "__Enum__ Call the `v4beta` URL for operations still only in beta.",
+          "example": "{{apiVersion}}",
+          "in": "path",
+          "name": "apiVersion",
+          "required": true,
+          "schema": {
+            "enum": [
+              "v4beta"
+            ],
+            "example": "v4beta",
+            "type": "string"
+          },
+          "x-akamai": {
+            "file-path": "parameters/api-version-v4beta-path.yaml"
+          }
+        }
+      ],
+      "x-akamai": {
+        "file-path": "paths/maintenance-policies.yaml",
+        "path-info": "/{apiVersion}/maintenance/policies"
+      },
+      "x-linode-cli-command": "maintenance"
+    },
     "/{apiVersion}/managed/contacts": {
       "post": {
         "description": "Creates a Managed Contact.  A Managed Contact is someone Linode special forces can contact in the course of attempting to resolve an issue with a Managed Service.\n\nThis operation can only be accessed by the unrestricted users of an account.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli managed contact-create \\\n  --name \"John Doe\" \\\n  --email \"john.doe@example.org\" \\\n  --phone.primary \"123-456-7890\"\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
@@ -85850,7 +92860,7 @@
       ],
       "x-akamai": {
         "file-path": "paths/aclp-alert-channels.yaml",
-        "path-info": "/monitor/alert-channels"
+        "path-info": "/{apiVersion}/monitor/alert-channels"
       },
       "x-linode-cli-command": "alerts"
     },
@@ -86405,7 +93415,7 @@
       ],
       "x-akamai": {
         "file-path": "paths/aclp-alert-definitions.yaml",
-        "path-info": "/monitor/alert-definitions"
+        "path-info": "/{apiVersion}/monitor/alert-definitions"
       },
       "x-linode-cli-command": "alerts"
     },
@@ -87006,7 +94016,7 @@
           }
         },
         {
-          "description": "ID of the Dashboard",
+          "description": "Identifies each dashboard.",
           "example": "{{dashboard_id}}",
           "in": "path",
           "name": "dashboard_id",
@@ -87016,7 +94026,7 @@
             "type": "integer"
           },
           "x-akamai": {
-            "file-path": "parameters/dashboard-id.yaml"
+            "file-path": "parameters/aclp-dashboard-id.yaml"
           }
         }
       ],
@@ -88608,7 +95618,7 @@
       ],
       "x-akamai": {
         "file-path": "paths/aclp-service-alert-definitions.yaml",
-        "path-info": "/monitor/services/{service_type}/alert-definitions"
+        "path-info": "/{apiVersion}/monitor/services/{service_type}/alert-definitions"
       },
       "x-linode-cli-command": "alerts"
     },
@@ -90620,6 +97630,10 @@
                     "value": "primary"
                   }
                 ],
+                "group_by": [
+                  "entity_id",
+                  "node_type"
+                ],
                 "metrics": [
                   {
                     "aggregate_function": "avg",
@@ -90687,6 +97701,17 @@
                                 }
                               },
                               "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "group_by": {
+                            "description": "Categorizes response data based on the specified fields:\n\n* `entity_id`. Include this parameter by name to group the response data using the `entity_id` values included in the request.\n\n* `dimension_label`. This represents the desired dimension from a monitoring metric. To get a `dimension_label`, run the [List metrics for a service type](https://techdocs.akamai.com/linode-api/reference/get-monitor-information) operation, review the available `dimensions`, and store the applicable `dimension_label` values.\n\nYou can group these fields using these combinations:\n\n* Group by `entity_id` values and one or more `dimensions_label` values. For example, `[entity_id, node_type]` groups response data based on values set for the `entity_id` parameter and the `node_type` dimension that's available for a `service_type` of `dbaas`.\n\n* Group by only the `entity_id` values. For example, `[entity_id]` exclusively groups response data based on values set for the `entity_id` parameter.\n\n* Group by one or more `dimension_label` values. For example, `[node_type]` groups response data based on the `node_type` dimension that's available for a `service_type` of `dbaas`.\n\nIf you leave this out of a request, data is aggregated across all series.",
+                            "items": {
+                              "example": [
+                                "entity_id",
+                                "node_type"
+                              ],
+                              "type": "string"
                             },
                             "type": "array"
                           },
@@ -90848,6 +97873,17 @@
                                 }
                               },
                               "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "group_by": {
+                            "description": "Categorizes response data based on the specified fields:\n\n* `entity_id`. Include this parameter by name to group the response data using the `entity_id` values included in the request.\n\n* `dimension_label`. This represents the desired dimension from a monitoring metric. To get a `dimension_label`, run the [List metrics for a service type](https://techdocs.akamai.com/linode-api/reference/get-monitor-information) operation, review the available `dimensions`, and store the applicable `dimension_label` values.\n\nYou can group these fields using these combinations:\n\n* Group by `entity_id` values and one or more `dimensions_label` values. For example, `[entity_id, node_type]` groups response data based on values set for the `entity_id` parameter and the `node_type` dimension that's available for a `service_type` of `dbaas`.\n\n* Group by only the `entity_id` values. For example, `[entity_id]` exclusively groups response data based on values set for the `entity_id` parameter.\n\n* Group by one or more `dimension_label` values. For example, `[node_type]` groups response data based on the `node_type` dimension that's available for a `service_type` of `dbaas`.\n\nIf you leave this out of a request, data is aggregated across all series.",
+                            "items": {
+                              "example": [
+                                "entity_id",
+                                "node_type"
+                              ],
+                              "type": "string"
                             },
                             "type": "array"
                           },
@@ -91220,7 +98256,7 @@
       "x-akamai": {
         "auth-type": "JWT",
         "file-path": "paths/aclp-metric-read.yaml",
-        "path-info": "/{apiVersion}/monitor/services/{service-type}/metrics"
+        "path-info": "/{apiVersion}/monitor/services/{service_type}/metrics"
       },
       "x-linode-cli-command": "metric"
     },
@@ -91402,7 +98438,7 @@
       ],
       "x-akamai": {
         "file-path": "paths/aclp-get-token.yaml",
-        "path-info": "/{apiVersion}/monitor/services/{service-type}/token"
+        "path-info": "/{apiVersion}/monitor/services/{service_type}/token"
       },
       "x-linode-cli-command": "monitor"
     },
@@ -91955,7 +98991,7 @@
                     "additionalProperties": false,
                     "description": "Devices to create for this firewall. When a device is created, the firewall is assigned to its associated service. Currently, devices can be created for Linodes using legacy configuration profiles, Linode interfaces, and NodeBalancers. Firewall devices can't be created for individual legacy configuration profile interfaces.\n\nAdditional devices can be assigned after Firewall creation by using the [Create a firewall device](https://techdocs.akamai.com/linode-api/reference/post-firewall-device) operation.",
                     "properties": {
-                      "interfaces": {
+                      "linode_interfaces": {
                         "description": "An array of Linode interface IDs. A firewall device is created for each ID. For Linodes using Linode interfaces, firewalls need to be assigned to Linode interfaces and not the Linode.",
                         "example": [
                           321
@@ -95255,7 +102291,7 @@
     },
     "/{apiVersion}/networking/firewalls/{firewallId}/devices": {
       "post": {
-        "description": "Creates a firewall device, which assigns a firewall to a service (referred to as the device's `entity`) and applies the firewall's rules to the device.\n\n- Currently, devices with `linode`, `interface`, and `nodebalancer` entity types are accepted.\n  - The `linode` type is not allowed for Linodes using Linode interfaces.\n  - The `interface` type is not allowed for legacy config interfaces. For VPC and public legacy config profile interfaces, the firewall is applied through the `linode` device.\n\n- Firewalls only apply to inbound TCP traffic to NodeBalancers.\n\n- A firewall can be assigned to multiple services at a time.\n\n- A service can have one assigned firewall at a time.\n\n- Assigned Linodes must not have any ongoing live migrations.\n\n- A `firewall_device_add` event is generated when the firewall device is added successfully.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli firewalls device-create 123 \\\n  --id 456 \\\n  --type \"linode\"\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    firewall:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Creates a firewall device, which assigns a firewall to a service (referred to as the device's `entity`) and applies the firewall's rules to the device.\n\n- Currently, devices with `linode`, `linode_interfaces`, and `nodebalancer` entity types are accepted.\n  - The `linode` type is not allowed for Linodes using Linode interfaces.\n  - The `linode_interfaces` type is not allowed for legacy config interfaces. For VPC and public legacy config profile interfaces, the firewall is applied through the `linode` device.\n\n- Firewalls only apply to inbound TCP traffic to NodeBalancers.\n\n- A firewall can be assigned to multiple services at a time.\n\n- A service can have one assigned firewall at a time.\n\n- Assigned Linodes must not have any ongoing live migrations.\n\n- A `firewall_device_add` event is generated when the firewall device is added successfully.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli firewalls device-create 123 \\\n  --id 456 \\\n  --type \"linode\"\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    firewall:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/post-firewall-device"
@@ -95268,7 +102304,7 @@
                 "allOf": [
                   {
                     "additionalProperties": false,
-                    "description": "__Read-only__ The compute service or interface this firewall is assigned to.",
+                    "description": "The compute service or interface this firewall is assigned to.",
                     "properties": {
                       "id": {
                         "description": "The entity's ID.",
@@ -95286,7 +102322,7 @@
                         "enum": [
                           "linode",
                           "nodebalancer",
-                          "interface"
+                          "linode_interfaces"
                         ],
                         "example": "linode",
                         "type": "string"
@@ -95299,7 +102335,6 @@
                         "type": "string"
                       }
                     },
-                    "readOnly": true,
                     "type": "object"
                   }
                 ],
@@ -95342,7 +102377,7 @@
                     },
                     "entity": {
                       "additionalProperties": false,
-                      "description": "__Read-only__ The compute service or interface this firewall is assigned to.",
+                      "description": "The compute service or interface this firewall is assigned to.",
                       "properties": {
                         "id": {
                           "description": "The entity's ID.",
@@ -95360,7 +102395,7 @@
                           "enum": [
                             "linode",
                             "nodebalancer",
-                            "interface"
+                            "linode_interfaces"
                           ],
                           "example": "linode",
                           "type": "string"
@@ -95373,7 +102408,6 @@
                           "type": "string"
                         }
                       },
-                      "readOnly": true,
                       "type": "object"
                     },
                     "id": {
@@ -95560,8 +102594,8 @@
                           "entity": {
                             "id": 321,
                             "label": "my-interface",
-                            "type": "interface",
-                            "url": "/v4/linode/instances/123/interfaces/12345"
+                            "type": "linode_interfaces",
+                            "url": "/v4/linode/instances/123/linode_interfaces/12345"
                           },
                           "id": 654,
                           "updated": "2025-01-02 00:01:01"
@@ -95587,7 +102621,7 @@
                           },
                           "entity": {
                             "additionalProperties": false,
-                            "description": "__Read-only__ The compute service or interface this firewall is assigned to.",
+                            "description": "The compute service or interface this firewall is assigned to.",
                             "properties": {
                               "id": {
                                 "description": "The entity's ID.",
@@ -95605,7 +102639,7 @@
                                 "enum": [
                                   "linode",
                                   "nodebalancer",
-                                  "interface"
+                                  "linode_interfaces"
                                 ],
                                 "example": "linode",
                                 "type": "string"
@@ -95618,7 +102652,6 @@
                                 "type": "string"
                               }
                             },
-                            "readOnly": true,
                             "type": "object"
                           },
                           "id": {
@@ -95825,7 +102858,7 @@
                     },
                     "entity": {
                       "additionalProperties": false,
-                      "description": "__Read-only__ The compute service or interface this firewall is assigned to.",
+                      "description": "The compute service or interface this firewall is assigned to.",
                       "properties": {
                         "id": {
                           "description": "The entity's ID.",
@@ -95843,7 +102876,7 @@
                           "enum": [
                             "linode",
                             "nodebalancer",
-                            "interface"
+                            "linode_interfaces"
                           ],
                           "example": "linode",
                           "type": "string"
@@ -95856,7 +102889,6 @@
                           "type": "string"
                         }
                       },
-                      "readOnly": true,
                       "type": "object"
                     },
                     "id": {
@@ -116492,7 +123524,10 @@
                 "properties": {
                   "firewall_ids": {
                     "description": "A complete list of firewall IDs to assign to this Linode or NodeBalancer. This operation replaces any existing assignments. To remove all firewalls, pass an empty list, `[]`.",
-                    "example": 1234,
+                    "example": [
+                      1,
+                      2
+                    ],
                     "items": {
                       "type": "integer"
                     },
@@ -117733,8 +124768,7 @@
                   }
                 },
                 "required": [
-                  "label",
-                  "cluster"
+                  "label"
                 ],
                 "type": "object",
                 "x-akamai": {
@@ -132783,7 +139817,7 @@
     },
     "/{apiVersion}/tags": {
       "post": {
-        "description": "Creates a new tag and lets you optionally add it to specific objects. Tags are labels you can attach to objects in your account. Use them to specify and group attributes of objects that are relevant to you. Currently, you can add a tag to your `linodes`, your `nodebalancers`, the `domains` for your Linodes, and the `volumes` on your Linodes.\n\n> \ud83d\udcd8\n>\n> - This operation can only be accessed by account users with _unrestricted_ access.\n>\n> - If you don't add a tag to a supported object with this operation, you can use that object's update operation to later add the tag you created.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli tags create \\\n  --label 'example tag' \\\n  --linodes 123 \\\n  --linodes 456 \\\n  --volumes 9082 \\\n  --volumes 10003\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Creates a new tag and lets you optionally add it to specific objects. Tags are labels you can attach to objects in your account. Use them to specify and group attributes of objects that are relevant to you. Currently, you can add a tag to your `linodes`, your `nodebalancers`, the `domains` for your Linodes, and the `volumes` on your Linodes.\n\n> \ud83d\udcd8\n>\n> - This operation can only be accessed by account users with _unrestricted_ access. Talk to your local account administrator about access management.\n>\n> - If you don't add a tag to a supported object with this operation, you can use that object's update operation to later add the tag you created.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli tags create \\\n  --label 'example tag' \\\n  --linodes 123 \\\n  --linodes 456 \\\n  --volumes 9082 \\\n  --volumes 10003\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/post-tag"
@@ -132972,7 +140006,7 @@
         "x-linode-grant": "unrestricted only"
       },
       "get": {
-        "description": "Returns a paginated list of tags you've [created](https://techdocs.akamai.com/linode-api/reference/post-tag) on your account.\n> \ud83d\udcd8\n>\n> This operation can only be accessed by account users with _unrestricted_ access.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli tags list\nlinode-cli tags ls\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Returns a paginated list of tags you've [created](https://techdocs.akamai.com/linode-api/reference/post-tag) on your account.\n> \ud83d\udcd8\n>\n> This operation can only be accessed by account users with _unrestricted_ access. Talk to your local account administrator about access management.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli tags list\nlinode-cli tags ls\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-tags"
@@ -133173,7 +140207,7 @@
     },
     "/{apiVersion}/tags/{tagLabel}": {
       "get": {
-        "description": "Returns a paginated list of all objects you've tagged with the specified tag. The response includes a mixed collection of all object types.\n\n> \ud83d\udcd8\n>\n> This operation can only be accessed by account users with _unrestricted_ access.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    account:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Returns a paginated list of all objects you've tagged with the specified tag. The response includes a mixed collection of all object types.\n\n> \ud83d\udcd8\n>\n> This operation can only be accessed by account users with _unrestricted_ access. Talk to your local account administrator about access management.\n\n\n<<LB>>\n\n---\n\n\n- __OAuth scopes__.\n\n    ```\n    account:read_only\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/get-tagged-objects"
@@ -133562,6 +140596,18 @@
                                     "nullable": true,
                                     "readOnly": true,
                                     "type": "integer"
+                                  },
+                                  "maintenance_policy": {
+                                    "description": "__Beta__ The maintenance policy configured by the user for this Linode. Review [maintenance policy](https://techdocs.akamai.com/cloud-computing/docs/host-maintenance-policy) documentation for more details.",
+                                    "enum": [
+                                      "linode/migrate",
+                                      "linode/power_off_on"
+                                    ],
+                                    "example": "linode/migrate",
+                                    "type": "string",
+                                    "x-akamai": {
+                                      "status": "BETA"
+                                    }
                                   },
                                   "placement_group": {
                                     "additionalProperties": false,
@@ -134323,7 +141369,7 @@
         "x-linode-cli-skip": true
       },
       "delete": {
-        "description": "Removes a tag from all objects and deletes it.\n\n> \ud83d\udcd8\n>\n> This operation can only be accessed by account users with _unrestricted_ access.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli tags delete\nlinode-cli tags rm\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
+        "description": "Removes a tag from all objects and deletes it.\n\n> \ud83d\udcd8\n>\n> This operation can only be accessed by account users with _unrestricted_ access. Talk to your local account administrator about access management.\n\n\n<<LB>>\n\n---\n\n\n- __CLI__.\n\n    ```\n    linode-cli tags delete\nlinode-cli tags rm\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli)\n\n- __OAuth scopes__.\n\n    ```\n    account:read_write\n    ```\n\n    [Learn more...](https://techdocs.akamai.com/linode-api/reference/get-started#oauth)",
         "externalDocs": {
           "description": "See documentation for this operation in Akamai's Linode API",
           "url": "https://techdocs.akamai.com/linode-api/reference/delete-tag"
@@ -140768,6 +147814,10 @@
       "name": "Placement groups"
     },
     {
+      "description": "Use the images/sharegroups endpoints to create, update, and delete images share groups.",
+      "name": "Private Image Sharing"
+    },
+    {
       "description": "Use the Profile endpoints to manage your Linode user profile preferences and security settings. This includes creating and maintaining personal access tokens, creating and maintaining SSH keys, confirming and enabling two-factor authentication, and updating user and profile preferences.",
       "name": "Profile"
     },
@@ -140794,6 +147844,10 @@
     {
       "description": "Use the VPCs endpoints to view, create, and manage Virtual Private Cloud (VPC) and VPC Subnet resources.",
       "name": "VPCs"
+    },
+    {
+      "description": "Use the maintenance endpoints to view maintenance policies that are available for your Linodes.",
+      "name": "Maintenance"
     },
     {
       "description": "Use the Monitor endpoints to view Dashboards and Metrics",


### PR DESCRIPTION
## Added

### Maintenance policies
The maintenance policies features is now in beta. As part of this, a new endpoint has been added: List maintenance policies (GET /maintenance/policies).

### QEMU reboot support
New objects have been added to the response for the List notifications and List maintenances operations. They identify when your Linodes need to be rebooted to apply this upgrade. See [Reboot your Linodes for QEMU maintenance](ref:reboot-your-linodes-for-qemu-maintenance) for complete details.

## Changed
- Account:
  - Get account settings (GET /account/settings)
  - Update account settings (PUT /account/settings)
  - List events (GET /account/events)
  - Get an event (GET /account/events/{eventId})
  - List maintenances (GET /account/maintenance)
  - - **List notifications** (GET /account/notifications). In addition to filtering the response on `type`, you can also filter on `entity.type`.
- Linodes:
  - Create a Linode (POST /linode/instances)
  - List Linodes (GET /linode/instances)
  - Get a Linode (GET /linode/instances/{linodeId})
  - Update a Linode (PUT /linode/instances/{linodeId})
  - Clone a Linode(POST /linode/instances/{linodeId}/clone)
- Monitor
  - Get an entity's metrics (POST /monitor/services/{service_type}/metrics)

## Fixed

- Fix the required properties for VPC IPv4 ranges
- Changed linode_interface to linode_interfaces

### Object Storage

Several fixes have been made to the documentation to properly cover how authentication keys are created and maintained. The following operations have been updated:

- **Create an Object Storage key** ([POST /object-storage/keys](ref:post-object-storage-keys))
- **List Object Storage keys** ([GET /object-storage/keys](ref:get-object-storage-keys))
- **Get an Object Storage key** ([GET /object-storage/keys/{keyId}](ref:get-object-storage-keys))
- **Update an Object Storage key** ([PUT /object-storage/key/{keyId}](ref:put-object-storage-key))